### PR TITLE
Add scene board planning UI

### DIFF
--- a/docs/plans/issue-2-scene-board.md
+++ b/docs/plans/issue-2-scene-board.md
@@ -1,0 +1,46 @@
+# Issue #2 Plan: Scene Board UI
+
+## Goal
+
+Build a scene board that lets writers scan chapter scenes visually and move quickly into scene-level editing and review.
+
+## Why
+
+Novel Assistant already supports scene markers and scene-scoped review, but it still lacks a planning surface comparable to novelWriter or Manuskript.
+
+A scene board closes that gap by making structure visible without opening full chapter text.
+
+## Constraints
+
+- Keep backward compatibility with plain chapter files that do not use scene markers.
+- Reuse the current `## Scene N` / `## Scene N: Title` parsing model.
+- Do not break the existing chapter overview and review page workflows.
+- Prefer file-based storage that stays readable in Git.
+
+## Scope For This Issue
+
+1. Define scene planning metadata for:
+   - synopsis
+   - POV
+   - conflict
+   - purpose
+   - quick status markers
+2. Add backend support to load and save that metadata.
+3. Add a scene board page or chapter-level board section with visual scene cards.
+4. Link each scene card to the current editing / review flow.
+5. Add tests for parsing, persistence, and board-facing data.
+
+## Implementation Steps
+
+1. Inspect current chapter and scene loading flow.
+2. Choose a storage shape for scene planning metadata that is simple and Git-friendly.
+3. Extend backend chapter loading so scene board data is available in one request.
+4. Build the scene board UI with clear cards and quick actions.
+5. Add tests and run formatting, `go test ./...`, and `go build ./...`.
+
+## Done When
+
+- Scenes are visible as cards from a board-style UI.
+- Each card shows planning metadata and review status.
+- Users can jump from a scene card into editing or review quickly.
+- Plain chapters still work without errors.

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -25,6 +25,20 @@ type chapterOverview struct {
 	OpenForeshadows int
 	TimelineCount   int
 	Signals         extractor.Signals
+	SceneCards      []sceneBoardCard
+}
+
+type sceneBoardCard struct {
+	Index        int
+	Title        string
+	Preview      string
+	Synopsis     string
+	POV          string
+	Conflict     string
+	Purpose      string
+	Status       string
+	ReviewCount  int
+	RewriteCount int
 }
 
 type candidateCreateRequest struct {
@@ -57,6 +71,8 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 	}
 
 	historyCounts := make(map[string]int)
+	sceneReviews := make(map[string]int)
+	sceneRewrites := make(map[string]int)
 	for _, entry := range s.history.Recent(0) {
 		key := entry.ChapterFile
 		if key == "" && entry.ChapterTitle != "" {
@@ -64,6 +80,14 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		}
 		if key != "" {
 			historyCounts[key]++
+			if scene := strings.TrimSpace(entry.SceneTitle); scene != "" {
+				sceneKey := key + "::" + scene
+				if entry.Kind == "rewrite" {
+					sceneRewrites[sceneKey]++
+				} else {
+					sceneReviews[sceneKey]++
+				}
+			}
 		}
 	}
 
@@ -95,6 +119,35 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		signals := extractor.AnalyzeChapter(text, s.profiles.AllNames())
 		chapterNo := chapterNumberFromName(file.Name)
 		scenes := parseScenes(text)
+		scenePlans, err := s.loadScenePlans(file.Name)
+		if err != nil {
+			return nil, err
+		}
+		sceneCards := make([]sceneBoardCard, 0, len(scenes))
+		for _, scene := range scenes {
+			plan := scenePlans[scene.Title]
+			sceneKey := file.Name + "::" + scene.Title
+			reviewCount := sceneReviews[sceneKey]
+			rewriteCount := sceneRewrites[sceneKey]
+			status := "draft"
+			if rewriteCount > 0 {
+				status = "rewritten"
+			} else if reviewCount > 0 {
+				status = "reviewed"
+			}
+			sceneCards = append(sceneCards, sceneBoardCard{
+				Index:        scene.Index,
+				Title:        scene.Title,
+				Preview:      scenePreview(scene.Content),
+				Synopsis:     plan.Synopsis,
+				POV:          plan.POV,
+				Conflict:     plan.Conflict,
+				Purpose:      plan.Purpose,
+				Status:       status,
+				ReviewCount:  reviewCount,
+				RewriteCount: rewriteCount,
+			})
+		}
 		overviews = append(overviews, chapterOverview{
 			Name:            file.Name,
 			Title:           file.Title,
@@ -106,6 +159,7 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 			OpenForeshadows: foreshadowCounts[chapterNo],
 			TimelineCount:   timelineCounts[chapterNo],
 			Signals:         signals,
+			SceneCards:      sceneCards,
 		})
 	}
 
@@ -113,6 +167,19 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		return overviews[i].Name < overviews[j].Name
 	})
 	return overviews, nil
+}
+
+func scenePreview(content string) string {
+	text := strings.Join(strings.Fields(strings.TrimSpace(content)), " ")
+	if text == "" {
+		return "尚未填寫場景內容。"
+	}
+	const limit = 120
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "…"
 }
 
 func draftTargetPath(dataDir, kind, name string) (string, string, error) {
@@ -160,6 +227,44 @@ func (s *Server) handleAnalyzeChapter(c *gin.Context) {
 	}
 	signals := extractor.AnalyzeChapter(file.Content, s.profiles.AllNames())
 	c.JSON(http.StatusOK, gin.H{"item": signals})
+}
+
+func (s *Server) handleSaveScenePlan(c *gin.Context) {
+	chapterName := c.Param("name")
+	file, err := s.loadChapterFile(chapterName)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var req scenePlanRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	title := strings.TrimSpace(req.SceneTitle)
+	if title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "場景標題不可為空"})
+		return
+	}
+	if sceneByTitle(file.Scenes, title) == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "找不到指定場景"})
+		return
+	}
+
+	if err := s.saveScenePlan(file.Name, scenePlan{
+		Title:    title,
+		Synopsis: req.Synopsis,
+		POV:      req.POV,
+		Conflict: req.Conflict,
+		Purpose:  req.Purpose,
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已儲存場景規劃"})
 }
 
 func (s *Server) handleCreateCandidateDraft(c *gin.Context) {

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -121,7 +122,8 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		scenes := parseScenes(text)
 		scenePlans, err := s.loadScenePlans(file.Name)
 		if err != nil {
-			return nil, err
+			log.Printf("scene plans load %s: %v", file.Name, err)
+			scenePlans = map[string]scenePlan{}
 		}
 		sceneCards := make([]sceneBoardCard, 0, len(scenes))
 		for _, scene := range scenes {

--- a/internal/server/sceneboard.go
+++ b/internal/server/sceneboard.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -61,6 +62,8 @@ func (s *Server) loadScenePlans(chapterName string) (map[string]scenePlan, error
 		if title == "" {
 			continue
 		}
+		// Plans are keyed by scene title, so renaming a scene in markdown can
+		// leave behind orphaned sidecar entries until a future cleanup step prunes them.
 		item.Title = title
 		items[title] = item
 	}
@@ -92,6 +95,9 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 	for _, item := range items {
 		out.Items = append(out.Items, item)
 	}
+	sort.Slice(out.Items, func(i, j int) bool {
+		return out.Items[i].Title < out.Items[j].Title
+	})
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err

--- a/internal/server/sceneboard.go
+++ b/internal/server/sceneboard.go
@@ -38,11 +38,17 @@ func (s *Server) scenePlanPath(chapterName string) (string, error) {
 }
 
 func (s *Server) loadScenePlans(chapterName string) (map[string]scenePlan, error) {
+	s.scenePlansMu.RLock()
+	defer s.scenePlansMu.RUnlock()
+
 	path, err := s.scenePlanPath(chapterName)
 	if err != nil {
 		return nil, err
 	}
+	return loadScenePlansFromPath(path)
+}
 
+func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		return map[string]scenePlan{}, nil
@@ -80,12 +86,15 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 		return fmt.Errorf("場景標題不可為空")
 	}
 
+	s.scenePlansMu.Lock()
+	defer s.scenePlansMu.Unlock()
+
 	path, err := s.scenePlanPath(chapterName)
 	if err != nil {
 		return err
 	}
 
-	items, err := s.loadScenePlans(chapterName)
+	items, err := loadScenePlansFromPath(path)
 	if err != nil {
 		return err
 	}
@@ -106,5 +115,42 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	return writeFileReplace(path, data, 0644)
+}
+
+func writeFileReplace(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	tmp, err := os.CreateTemp(dir, base+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return err
+	}
+
+	// Write to a temp file first so the existing sidecar is never replaced with
+	// a partially written file if the process dies mid-write.
+	if err := os.Rename(tmpPath, path); err == nil {
+		return nil
+	}
+
+	// Windows does not replace existing files on rename, so fall back to a
+	// best-effort replace after the temp file is fully written.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/internal/server/sceneboard.go
+++ b/internal/server/sceneboard.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type scenePlan struct {
+	Title    string `json:"title"`
+	Synopsis string `json:"synopsis,omitempty"`
+	POV      string `json:"pov,omitempty"`
+	Conflict string `json:"conflict,omitempty"`
+	Purpose  string `json:"purpose,omitempty"`
+}
+
+type scenePlanFile struct {
+	Items []scenePlan `json:"items"`
+}
+
+type scenePlanRequest struct {
+	SceneTitle string `json:"scene_title"`
+	Synopsis   string `json:"synopsis"`
+	POV        string `json:"pov"`
+	Conflict   string `json:"conflict"`
+	Purpose    string `json:"purpose"`
+}
+
+func (s *Server) scenePlanPath(chapterName string) (string, error) {
+	normalized, err := normalizeChapterName(chapterName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.chapterDir(), normalized+".scenes.json"), nil
+}
+
+func (s *Server) loadScenePlans(chapterName string) (map[string]scenePlan, error) {
+	path, err := s.scenePlanPath(chapterName)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]scenePlan{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var stored scenePlanFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, err
+	}
+
+	items := make(map[string]scenePlan, len(stored.Items))
+	for _, item := range stored.Items {
+		title := strings.TrimSpace(item.Title)
+		if title == "" {
+			continue
+		}
+		item.Title = title
+		items[title] = item
+	}
+	return items, nil
+}
+
+func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
+	plan.Title = strings.TrimSpace(plan.Title)
+	plan.Synopsis = strings.TrimSpace(plan.Synopsis)
+	plan.POV = strings.TrimSpace(plan.POV)
+	plan.Conflict = strings.TrimSpace(plan.Conflict)
+	plan.Purpose = strings.TrimSpace(plan.Purpose)
+	if plan.Title == "" {
+		return fmt.Errorf("場景標題不可為空")
+	}
+
+	path, err := s.scenePlanPath(chapterName)
+	if err != nil {
+		return err
+	}
+
+	items, err := s.loadScenePlans(chapterName)
+	if err != nil {
+		return err
+	}
+	items[plan.Title] = plan
+
+	out := scenePlanFile{Items: make([]scenePlan, 0, len(items))}
+	for _, item := range items {
+		out.Items = append(out.Items, item)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}

--- a/internal/server/sceneboard_test.go
+++ b/internal/server/sceneboard_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,6 +51,54 @@ Lin Hao opened the door.`); err != nil {
 	}
 	if got.POV != "Lin Hao" || got.Purpose != "Open the investigation thread." {
 		t.Fatalf("unexpected round-trip scene plan: %#v", got)
+	}
+}
+
+func TestSaveScenePlanWritesStableSortedJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(dir + "/reviews.json"),
+		timeline:   tracker.NewTimelineTracker(dir + "/timeline.json"),
+		foreshadow: tracker.NewForeshadowTracker(dir + "/foreshadow.json"),
+	}
+
+	if _, err := s.saveChapterFile("第09章", `## Scene 2: Rain
+Rain.
+
+## Scene 1: Opening
+Open.`); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	if err := s.saveScenePlan("第09章.md", scenePlan{Title: "Scene 2: Rain", Synopsis: "Second"}); err != nil {
+		t.Fatalf("save scene 2: %v", err)
+	}
+	if err := s.saveScenePlan("第09章.md", scenePlan{Title: "Scene 1: Opening", Synopsis: "First"}); err != nil {
+		t.Fatalf("save scene 1: %v", err)
+	}
+
+	path, err := s.scenePlanPath("第09章.md")
+	if err != nil {
+		t.Fatalf("scenePlanPath: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved sidecar: %v", err)
+	}
+
+	var stored scenePlanFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("unmarshal saved sidecar: %v", err)
+	}
+	if len(stored.Items) != 2 {
+		t.Fatalf("expected 2 stored scene plans, got %d", len(stored.Items))
+	}
+	if stored.Items[0].Title != "Scene 1: Opening" || stored.Items[1].Title != "Scene 2: Rain" {
+		t.Fatalf("expected stable sorted titles, got %#v", stored.Items)
 	}
 }
 

--- a/internal/server/sceneboard_test.go
+++ b/internal/server/sceneboard_test.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"novel-assistant/internal/config"
@@ -114,5 +117,77 @@ Zhang Lei stood in the rain.`)
 	}
 	if scene2.Preview == "" {
 		t.Fatal("expected scene 2 preview to be populated")
+	}
+}
+
+func TestBuildChapterOverviewsKeepsPlainChaptersWithoutSceneBoard(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(dir + "/reviews.json"),
+		timeline:   tracker.NewTimelineTracker(dir + "/timeline.json"),
+		foreshadow: tracker.NewForeshadowTracker(dir + "/foreshadow.json"),
+	}
+
+	if _, err := s.saveChapterFile("第02章", "Lin Hao walked alone through the station."); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	overviews, err := s.buildChapterOverviews()
+	if err != nil {
+		t.Fatalf("build chapter overviews: %v", err)
+	}
+	if len(overviews) != 1 {
+		t.Fatalf("expected 1 chapter overview, got %d", len(overviews))
+	}
+	if overviews[0].SceneCount != 0 {
+		t.Fatalf("expected 0 scenes, got %d", overviews[0].SceneCount)
+	}
+	if len(overviews[0].SceneCards) != 0 {
+		t.Fatalf("expected no scene cards, got %d", len(overviews[0].SceneCards))
+	}
+}
+
+func TestBuildChapterOverviewsIgnoresCorruptScenePlanSidecar(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(dir + "/reviews.json"),
+		timeline:   tracker.NewTimelineTracker(dir + "/timeline.json"),
+		foreshadow: tracker.NewForeshadowTracker(dir + "/foreshadow.json"),
+	}
+
+	if _, err := s.saveChapterFile("第03章", `## Scene 1: Opening
+Lin Hao opened the case file.`); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	sidecarPath, err := s.scenePlanPath("第03章.md")
+	if err != nil {
+		t.Fatalf("scenePlanPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(sidecarPath), 0755); err != nil {
+		t.Fatalf("mkdir sidecar dir: %v", err)
+	}
+	if err := os.WriteFile(sidecarPath, []byte("{not valid json"), 0644); err != nil {
+		t.Fatalf("write corrupt sidecar: %v", err)
+	}
+
+	overviews, err := s.buildChapterOverviews()
+	if err != nil {
+		t.Fatalf("expected corrupt sidecar to be ignored, got error: %v", err)
+	}
+	if len(overviews) != 1 || len(overviews[0].SceneCards) != 1 {
+		t.Fatalf("expected one chapter with one scene card, got %#v", overviews)
+	}
+	scene := overviews[0].SceneCards[0]
+	if strings.TrimSpace(scene.Synopsis) != "" || strings.TrimSpace(scene.POV) != "" {
+		t.Fatalf("expected empty fallback scene plan metadata, got %#v", scene)
 	}
 }

--- a/internal/server/sceneboard_test.go
+++ b/internal/server/sceneboard_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"testing"
+
+	"novel-assistant/internal/config"
+	"novel-assistant/internal/profile"
+	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/tracker"
+)
+
+func TestScenePlanRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(dir + "/reviews.json"),
+		timeline:   tracker.NewTimelineTracker(dir + "/timeline.json"),
+		foreshadow: tracker.NewForeshadowTracker(dir + "/foreshadow.json"),
+	}
+
+	if _, err := s.saveChapterFile("第01章", `## Scene 1: Opening
+Lin Hao opened the door.`); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	err := s.saveScenePlan("第01章.md", scenePlan{
+		Title:    "Scene 1: Opening",
+		Synopsis: "Lin Hao enters the room.",
+		POV:      "Lin Hao",
+		Conflict: "He does not know who is waiting inside.",
+		Purpose:  "Open the investigation thread.",
+	})
+	if err != nil {
+		t.Fatalf("save scene plan: %v", err)
+	}
+
+	items, err := s.loadScenePlans("第01章.md")
+	if err != nil {
+		t.Fatalf("load scene plans: %v", err)
+	}
+	got, ok := items["Scene 1: Opening"]
+	if !ok {
+		t.Fatalf("expected scene plan to exist, got %v", items)
+	}
+	if got.POV != "Lin Hao" || got.Purpose != "Open the investigation thread." {
+		t.Fatalf("unexpected round-trip scene plan: %#v", got)
+	}
+}
+
+func TestBuildChapterOverviewsIncludesSceneBoardMetadataAndStatus(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(dir + "/reviews.json"),
+		timeline:   tracker.NewTimelineTracker(dir + "/timeline.json"),
+		foreshadow: tracker.NewForeshadowTracker(dir + "/foreshadow.json"),
+	}
+
+	_, err := s.saveChapterFile("第01章", `序章前言
+
+## Scene 1: Opening
+Lin Hao opened the door.
+
+## Scene 2: Rain
+Zhang Lei stood in the rain.`)
+	if err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	if err := s.saveScenePlan("第01章.md", scenePlan{
+		Title:    "Scene 1: Opening",
+		Synopsis: "Lin Hao enters.",
+		POV:      "Lin Hao",
+		Conflict: "Unknown threat",
+		Purpose:  "Start the chapter",
+	}); err != nil {
+		t.Fatalf("save scene 1 plan: %v", err)
+	}
+
+	s.history.Add(&reviewhistory.Entry{Kind: "review", ChapterFile: "第01章.md", SceneTitle: "Scene 1: Opening"})
+	s.history.Add(&reviewhistory.Entry{Kind: "rewrite", ChapterFile: "第01章.md", SceneTitle: "Scene 2: Rain"})
+
+	overviews, err := s.buildChapterOverviews()
+	if err != nil {
+		t.Fatalf("build chapter overviews: %v", err)
+	}
+	if len(overviews) != 1 {
+		t.Fatalf("expected 1 chapter overview, got %d", len(overviews))
+	}
+	if overviews[0].SceneCount != 2 {
+		t.Fatalf("expected 2 scenes, got %d", overviews[0].SceneCount)
+	}
+	if len(overviews[0].SceneCards) != 2 {
+		t.Fatalf("expected 2 scene cards, got %d", len(overviews[0].SceneCards))
+	}
+
+	scene1 := overviews[0].SceneCards[0]
+	scene2 := overviews[0].SceneCards[1]
+
+	if scene1.Status != "reviewed" {
+		t.Fatalf("expected scene 1 to be reviewed, got %q", scene1.Status)
+	}
+	if scene1.POV != "Lin Hao" || scene1.Synopsis != "Lin Hao enters." {
+		t.Fatalf("expected scene 1 planning metadata, got %#v", scene1)
+	}
+	if scene2.Status != "rewritten" {
+		t.Fatalf("expected scene 2 to be rewritten, got %q", scene2.Status)
+	}
+	if scene2.Preview == "" {
+		t.Fatal("expected scene 2 preview to be populated")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,6 +125,7 @@ func (s *Server) setupRoutes() {
 
 	r.POST("/ingest", s.handleIngest)
 	r.POST("/api/chapters", s.handleSaveChapter)
+	r.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
 	r.POST("/api/backups/create", s.handleCreateBackup)
 	r.POST("/api/backups/restore", s.handleRestoreBackup)
 	r.POST("/api/candidates/create", s.handleCreateCandidateDraft)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
@@ -32,6 +33,7 @@ type Server struct {
 	relationships *tracker.RelationshipTracker
 	timeline      *tracker.TimelineTracker
 	foreshadow    *tracker.ForeshadowTracker
+	scenePlansMu  sync.RWMutex
 }
 
 func New(cfg *config.Config) (*Server, error) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -379,6 +379,99 @@ tr:hover td { background: #1e1a30; }
   gap: 14px;
 }
 
+.scene-board-section {
+  display: grid;
+  gap: 14px;
+  padding-top: 6px;
+}
+
+.scene-board-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.scene-card {
+  background: linear-gradient(180deg, #171124 0%, #120d1d 100%);
+  border: 1px solid #3b2d57;
+  border-radius: 14px;
+  padding: 16px;
+  display: grid;
+  gap: 14px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+}
+
+.scene-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.scene-card-header h3 {
+  margin-bottom: 0;
+}
+
+.scene-kicker {
+  color: #94a3b8;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+
+.scene-preview {
+  color: #cbd5e1;
+  line-height: 1.7;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid #2d2540;
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.scene-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.scene-status-draft {
+  background: rgba(148, 163, 184, 0.14);
+  color: #cbd5e1;
+}
+
+.scene-status-reviewed {
+  background: rgba(56, 189, 248, 0.14);
+  color: #7dd3fc;
+}
+
+.scene-status-rewritten {
+  background: rgba(52, 211, 153, 0.14);
+  color: #86efac;
+}
+
+.scene-meta-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.scene-plan-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.scene-card-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .chapter-metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -135,7 +135,7 @@
               </div>
 
               <div class="scene-card-actions">
-                <button class="btn btn-ghost btn-sm" type="button" onclick="saveScenePlan({{printf "%q" $.Name}}, {{printf "%q" .Title}})">儲存規劃</button>
+                <button class="btn btn-ghost btn-sm" type="button" data-chapter="{{$.Name}}" data-scene="{{.Title}}" onclick="saveScenePlanFromAttr(this)">儲存規劃</button>
                 <a class="btn btn-ghost btn-sm" href="/check?chapter={{$.Name | urlquery}}&scene={{.Title | urlquery}}">審查這個 scene</a>
               </div>
             </div>
@@ -196,6 +196,11 @@ function sceneFieldValue(chapterName, sceneTitle, field) {
   const selector = `.scene-plan-input[data-chapter="${CSS.escape(chapterName)}"][data-scene="${CSS.escape(sceneTitle)}"][data-field="${field}"]`;
   const el = document.querySelector(selector);
   return el ? el.value : '';
+}
+
+function saveScenePlanFromAttr(button) {
+  if (!button) return;
+  saveScenePlan(button.dataset.chapter || '', button.dataset.scene || '');
 }
 
 async function saveScenePlan(chapterName, sceneTitle) {

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -81,6 +81,68 @@
             {{end}}
           </div>
         </div>
+
+        {{if .SceneCards}}
+        <div class="scene-board-section">
+          <div class="history-title-row" style="margin-bottom:0">
+            <div>
+              <h3 style="margin-bottom:6px">Scene Board</h3>
+              <div class="helper-text">快速掃描每個場景的 synopsis、POV、衝突與用途，也能直接跳到指定 scene 審查。</div>
+            </div>
+          </div>
+
+          <div class="scene-board-grid">
+            {{range .SceneCards}}
+            <div class="scene-card" data-scene-status="{{.Status}}">
+              <div class="scene-card-header">
+                <div>
+                  <div class="scene-kicker">Scene {{.Index}}</div>
+                  <h3>{{.Title}}</h3>
+                </div>
+                <span class="scene-status-badge scene-status-{{.Status}}">{{.Status}}</span>
+              </div>
+
+              <div class="scene-preview">{{.Preview}}</div>
+
+              <div class="scene-meta-row">
+                <div class="rag-item">
+                  <span>Reviews</span>
+                  <strong>{{.ReviewCount}}</strong>
+                </div>
+                <div class="rag-item">
+                  <span>Rewrites</span>
+                  <strong>{{.RewriteCount}}</strong>
+                </div>
+              </div>
+
+              <div class="scene-plan-grid">
+                <div class="form-group">
+                  <label>Synopsis</label>
+                  <textarea class="compact-textarea scene-plan-input" data-field="synopsis" data-chapter="{{$.Name}}" data-scene="{{.Title}}" placeholder="一句話描述這個 scene 在做什麼。">{{.Synopsis}}</textarea>
+                </div>
+                <div class="form-group">
+                  <label>POV</label>
+                  <input class="scene-plan-input" data-field="pov" data-chapter="{{$.Name}}" data-scene="{{.Title}}" type="text" value="{{.POV}}" placeholder="例：林昊 / 第三人稱有限">
+                </div>
+                <div class="form-group">
+                  <label>Conflict</label>
+                  <input class="scene-plan-input" data-field="conflict" data-chapter="{{$.Name}}" data-scene="{{.Title}}" type="text" value="{{.Conflict}}" placeholder="這個 scene 的主要衝突">
+                </div>
+                <div class="form-group">
+                  <label>Purpose</label>
+                  <input class="scene-plan-input" data-field="purpose" data-chapter="{{$.Name}}" data-scene="{{.Title}}" type="text" value="{{.Purpose}}" placeholder="推進情節 / 建立張力 / 曝露線索">
+                </div>
+              </div>
+
+              <div class="scene-card-actions">
+                <button class="btn btn-ghost btn-sm" type="button" onclick="saveScenePlan({{printf "%q" $.Name}}, {{printf "%q" .Title}})">儲存規劃</button>
+                <a class="btn btn-ghost btn-sm" href="/check?chapter={{$.Name | urlquery}}&scene={{.Title | urlquery}}">審查這個 scene</a>
+              </div>
+            </div>
+            {{end}}
+          </div>
+        </div>
+        {{end}}
       </div>
       {{end}}
     </div>
@@ -127,6 +189,33 @@ async function exportChapterBundle(name) {
     URL.revokeObjectURL(url);
   } catch (e) {
     alert('匯出失敗：' + e.message);
+  }
+}
+
+function sceneFieldValue(chapterName, sceneTitle, field) {
+  const selector = `.scene-plan-input[data-chapter="${CSS.escape(chapterName)}"][data-scene="${CSS.escape(sceneTitle)}"][data-field="${field}"]`;
+  const el = document.querySelector(selector);
+  return el ? el.value : '';
+}
+
+async function saveScenePlan(chapterName, sceneTitle) {
+  try {
+    const resp = await fetch('/api/chapters/' + encodeURIComponent(chapterName) + '/scenes/plan', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        scene_title: sceneTitle,
+        synopsis: sceneFieldValue(chapterName, sceneTitle, 'synopsis'),
+        pov: sceneFieldValue(chapterName, sceneTitle, 'pov'),
+        conflict: sceneFieldValue(chapterName, sceneTitle, 'conflict'),
+        purpose: sceneFieldValue(chapterName, sceneTitle, 'purpose')
+      })
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '儲存場景規劃失敗');
+    alert(data.message + '：' + sceneTitle);
+  } catch (e) {
+    alert('儲存場景規劃失敗：' + e.message);
   }
 }
 </script>

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -390,6 +390,16 @@ function loadSelectedScene() {
   }
 }
 
+function selectSceneByTitle(title) {
+  const trimmed = (title || '').trim();
+  const sel = document.getElementById('scene-select');
+  if (!trimmed || !sel) return;
+  const exists = loadedScenes.some(s => s.title === trimmed);
+  if (!exists) return;
+  sel.value = trimmed;
+  loadSelectedScene();
+}
+
 async function loadChapterByName(name) {
   const select = document.getElementById('chapter-file-select');
   if (select) {
@@ -475,9 +485,13 @@ async function hydrateFromHistory() {
   const params = new URLSearchParams(window.location.search);
   const historyId = params.get('history_id');
   const chapterName = params.get('chapter');
+  const sceneTitle = params.get('scene');
 
   if (chapterName) {
     await loadChapterByName(chapterName);
+    if (sceneTitle) {
+      selectSceneByTitle(sceneTitle);
+    }
   }
   if (!historyId) return;
 


### PR DESCRIPTION
## Summary

- closes #2
- add a scene board section to Chapter Overview for scene-level planning
- store scene planning metadata in per-chapter sidecar files
- add quick deep-links from scene cards to scene-scoped review
- harden sidecar handling based on pre-PR review findings

## What Changed

- introduced scene planning metadata fields: synopsis, POV, conflict, and purpose
- added backend sidecar storage for scene plans under each chapter
- extended chapter overview assembly to expose scene cards with derived statuses
- added scene board UI cards with quick save and review actions
- added safe deep-link handling for `?chapter=` + `?scene=` on the review page
- made corrupt sidecar files fall back gracefully instead of breaking the whole page
- made sidecar JSON output stable by sorting scene entries before save
- replaced inline string interpolation in the save button with `data-*` based lookup

## Verification

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual smoke test for changed UI flow, if applicable
- [x] Docs updated if behavior changed

## Review Focus

- data safety for scene plan sidecar files
- backward compatibility for plain chapter files without scene markers
- scene board save flow and chapter overview rendering
- deep-link behavior from scene board to the review page

## Notes

- this PR keeps plain chapter files working by only rendering scene board cards when parsed scene markers exist
- scene plans are currently keyed by scene title; renaming a scene can leave behind orphaned sidecar entries as a known limitation for future cleanup work
- pre-PR review fixes include corrupt-sidecar fallback, deterministic JSON ordering, safer button binding, and added regression tests