### PR TITLE
Add drag-and-drop ordering for chapters and scenes

### DIFF
--- a/docs/plans/issue-3-reordering.md
+++ b/docs/plans/issue-3-reordering.md
@@ -1,0 +1,53 @@
+# Issue #3 Plan: Drag-and-Drop Reordering
+
+## Goal
+
+Add persistent drag-and-drop reordering for chapters and scenes, and make downstream export follow the saved order.
+
+## Why
+
+Structural iteration is a core fiction workflow.
+
+Reordering should not require manual file renaming or manual scene text shuffling.
+
+## Dependency Note
+
+This issue depends partly on Issue #2:
+
+- chapter reordering can be implemented directly from `master`
+- scene reordering inside a visual board depends on the scene board UI from Issue #2
+
+Because of that, the safest implementation path is either:
+
+1. merge Issue #2 first, then build Issue #3 on top of `master`
+2. temporarily stack Issue #3 on the Issue #2 branch / PR
+
+## Proposed Storage
+
+- chapter ordering: a project-level JSON file that stores ordered chapter filenames
+- scene ordering: a per-chapter sidecar JSON file that stores ordered scene titles
+
+This keeps the Markdown files readable while allowing UI-driven structure changes.
+
+## Scope
+
+1. Add persistent chapter order metadata.
+2. Add persistent scene order metadata.
+3. Make chapter overview respect saved chapter order.
+4. Make scene board respect saved scene order.
+5. Make export follow saved order.
+6. Add regression tests for reload persistence and export order.
+
+## Open Decision
+
+Should Issue #3:
+
+- wait for Issue #2 to merge, then build on `master`
+- or stack directly on top of the Issue #2 branch now
+
+## Done When
+
+- chapter reorder survives reload
+- scene reorder survives reload
+- export uses saved order instead of filename order
+- plain chapters and unordered projects still work

--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -119,10 +118,11 @@ func (s *Server) listChapterFiles() ([]chapterFile, error) {
 		})
 	}
 
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Name < files[j].Name
-	})
-	return files, nil
+	order, err := s.loadChapterOrder()
+	if err != nil {
+		return nil, err
+	}
+	return orderedChapterFiles(files, order), nil
 }
 
 func (s *Server) loadChapterFile(name string) (chapterFile, error) {

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -30,6 +30,7 @@ type chapterOverview struct {
 }
 
 type sceneBoardCard struct {
+	Position     int
 	Index        int
 	Title        string
 	Preview      string
@@ -125,8 +126,12 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 			log.Printf("scene plans load %s: %v", file.Name, err)
 			scenePlans = map[string]scenePlan{}
 		}
+		sceneOrder, err := s.loadScenePlanOrder(file.Name)
+		if err != nil {
+			log.Printf("scene plan order load %s: %v", file.Name, err)
+		}
 		sceneCards := make([]sceneBoardCard, 0, len(scenes))
-		for _, scene := range scenes {
+		for idx, scene := range orderedScenes(scenes, sceneOrder) {
 			plan := scenePlans[scene.Title]
 			sceneKey := file.Name + "::" + scene.Title
 			reviewCount := sceneReviews[sceneKey]
@@ -138,6 +143,7 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 				status = "reviewed"
 			}
 			sceneCards = append(sceneCards, sceneBoardCard{
+				Position:     idx + 1,
 				Index:        scene.Index,
 				Title:        scene.Title,
 				Preview:      scenePreview(scene.Content),

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -171,9 +170,6 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		})
 	}
 
-	sort.Slice(overviews, func(i, j int) bool {
-		return overviews[i].Name < overviews[j].Name
-	})
 	return overviews, nil
 }
 

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -291,3 +291,47 @@ func (s *Server) handleExportChapterBundle(c *gin.Context) {
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, strings.TrimSuffix(req.Name, filepath.Ext(req.Name))+"_bundle.zip"))
 	c.Data(http.StatusOK, "application/zip", buf.Bytes())
 }
+
+func (s *Server) buildManuscriptMarkdown() (string, error) {
+	files, err := s.listChapterFiles()
+	if err != nil {
+		return "", err
+	}
+	if len(files) == 0 {
+		return "", fmt.Errorf("目前沒有章節可匯出")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# 小說手稿匯出\n\n")
+
+	for _, item := range files {
+		file, err := s.loadChapterFile(item.Name)
+		if err != nil {
+			return "", err
+		}
+		sceneOrder, err := s.loadScenePlanOrder(item.Name)
+		if err != nil {
+			return "", err
+		}
+		content := rebuildChapterWithSceneOrder(file.Content, file.Scenes, sceneOrder)
+		sb.WriteString("## ")
+		sb.WriteString(file.Title)
+		sb.WriteString("\n\n")
+		sb.WriteString(strings.TrimSpace(content))
+		sb.WriteString("\n\n")
+	}
+
+	return strings.TrimSpace(sb.String()) + "\n", nil
+}
+
+func (s *Server) handleExportManuscript(c *gin.Context) {
+	report, err := s.buildManuscriptMarkdown()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Header("Content-Type", "text/markdown; charset=utf-8")
+	c.Header("Content-Disposition", `attachment; filename="novel_manuscript.md"`)
+	c.Data(http.StatusOK, "text/markdown; charset=utf-8", []byte(report))
+}

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -107,3 +107,54 @@ func TestZipHelperWritesReadableFile(t *testing.T) {
 		t.Fatalf("unexpected zip contents: %q", data)
 	}
 }
+
+func TestBuildManuscriptMarkdownUsesSavedChapterAndSceneOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
+		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
+		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
+	}
+
+	if _, err := s.saveChapterFile("第02章", "第二章內容"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", `前言
+
+## Scene 1: Opening
+Open.
+
+## Scene 2: Rain
+Rain.`); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if err := s.saveChapterOrder([]string{"第02章.md", "第01章.md"}); err != nil {
+		t.Fatalf("save chapter order: %v", err)
+	}
+	if err := s.saveScenePlanOrder("第01章.md", []string{"Scene 2: Rain", "Scene 1: Opening"}); err != nil {
+		t.Fatalf("save scene order: %v", err)
+	}
+
+	manuscript, err := s.buildManuscriptMarkdown()
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+
+	chapter2Pos := strings.Index(manuscript, "## 第02章")
+	chapter1Pos := strings.Index(manuscript, "## 第01章")
+	if chapter2Pos == -1 || chapter1Pos == -1 || chapter2Pos > chapter1Pos {
+		t.Fatalf("expected chapter order to follow saved order, got %q", manuscript)
+	}
+	rainPos := strings.Index(manuscript, "## Scene 2: Rain")
+	openPos := strings.Index(manuscript, "## Scene 1: Opening")
+	if rainPos == -1 || openPos == -1 || rainPos > openPos {
+		t.Fatalf("expected scene order to follow saved order, got %q", manuscript)
+	}
+	if strings.Contains(manuscript, "第二章內容\n\n\n\n## 第01章") {
+		t.Fatalf("expected manuscript chapters to be separated by two newlines, got %q", manuscript)
+	}
+}

--- a/internal/server/ordering.go
+++ b/internal/server/ordering.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type chapterOrderFile struct {
+	Order []string `json:"order"`
+}
+
+type orderRequest struct {
+	Order []string `json:"order"`
+}
+
+func (s *Server) chapterOrderPath() string {
+	return filepath.Join(s.cfg.DataDir, "chapter_order.json")
+}
+
+func (s *Server) loadChapterOrder() ([]string, error) {
+	s.chapterOrderMu.RLock()
+	defer s.chapterOrderMu.RUnlock()
+	return loadChapterOrderFromPath(s.chapterOrderPath())
+}
+
+func loadChapterOrderFromPath(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var stored chapterOrderFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(stored.Order))
+	seen := make(map[string]struct{}, len(stored.Order))
+	for _, name := range stored.Order {
+		normalized, err := normalizeChapterName(name)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func (s *Server) saveChapterOrder(order []string) error {
+	s.chapterOrderMu.Lock()
+	defer s.chapterOrderMu.Unlock()
+
+	normalized := make([]string, 0, len(order))
+	seen := make(map[string]struct{}, len(order))
+	for _, name := range order {
+		clean, err := normalizeChapterName(name)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		normalized = append(normalized, clean)
+	}
+
+	data, err := json.MarshalIndent(chapterOrderFile{Order: normalized}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.chapterOrderPath()), 0755); err != nil {
+		return err
+	}
+	return writeFileReplace(s.chapterOrderPath(), data, 0644)
+}
+
+func orderedChapterFiles(files []chapterFile, order []string) []chapterFile {
+	if len(files) == 0 {
+		return nil
+	}
+	if len(order) == 0 {
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].Name < files[j].Name
+		})
+		return files
+	}
+
+	index := make(map[string]int, len(order))
+	for i, name := range order {
+		index[name] = i
+	}
+	sort.SliceStable(files, func(i, j int) bool {
+		pi, okI := index[files[i].Name]
+		pj, okJ := index[files[j].Name]
+		switch {
+		case okI && okJ:
+			return pi < pj
+		case okI:
+			return true
+		case okJ:
+			return false
+		default:
+			return files[i].Name < files[j].Name
+		}
+	})
+	return files
+}
+
+func orderedScenes(scenes []Scene, order []string) []Scene {
+	if len(scenes) == 0 || len(order) == 0 {
+		return scenes
+	}
+
+	copied := make([]Scene, len(scenes))
+	copy(copied, scenes)
+
+	index := make(map[string]int, len(order))
+	for i, title := range order {
+		index[strings.TrimSpace(title)] = i
+	}
+	sort.SliceStable(copied, func(i, j int) bool {
+		pi, okI := index[copied[i].Title]
+		pj, okJ := index[copied[j].Title]
+		switch {
+		case okI && okJ:
+			return pi < pj
+		case okI:
+			return true
+		case okJ:
+			return false
+		default:
+			return copied[i].Index < copied[j].Index
+		}
+	})
+	return copied
+}
+
+func chapterPreamble(content string) string {
+	firstMarker := sceneHeaderRe.FindStringIndex(content)
+	if firstMarker == nil || firstMarker[0] <= 0 {
+		return ""
+	}
+	return strings.TrimRight(content[:firstMarker[0]], "\r\n\t ")
+}
+
+func rebuildChapterWithSceneOrder(content string, scenes []Scene, order []string) string {
+	if len(scenes) == 0 {
+		return strings.TrimSpace(content)
+	}
+
+	parts := make([]string, 0, len(scenes)+1)
+	if preamble := chapterPreamble(content); preamble != "" {
+		parts = append(parts, preamble)
+	}
+	for _, scene := range orderedScenes(scenes, order) {
+		parts = append(parts, "## "+scene.Title+"\n"+scene.Content)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (s *Server) handleSaveChapterOrder(c *gin.Context) {
+	var req orderRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := s.saveChapterOrder(req.Order); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已儲存章節排序"})
+}
+
+func (s *Server) handleSaveSceneOrder(c *gin.Context) {
+	chapterName := c.Param("name")
+	file, err := s.loadChapterFile(chapterName)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var req orderRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	allowed := make(map[string]struct{}, len(file.Scenes))
+	for _, scene := range file.Scenes {
+		allowed[scene.Title] = struct{}{}
+	}
+	for _, title := range req.Order {
+		if _, ok := allowed[strings.TrimSpace(title)]; !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("找不到場景：%s", title)})
+			return
+		}
+	}
+	if err := s.saveScenePlanOrder(file.Name, req.Order); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已儲存場景排序"})
+}

--- a/internal/server/ordering_test.go
+++ b/internal/server/ordering_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"testing"
+
+	"novel-assistant/internal/config"
+)
+
+func TestOrderedChapterFilesRespectsSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	files := []chapterFile{
+		{Name: "第02章.md"},
+		{Name: "第01章.md"},
+		{Name: "第03章.md"},
+	}
+	order := []string{"第03章.md", "第01章.md"}
+	got := orderedChapterFiles(files, order)
+	if got[0].Name != "第03章.md" || got[1].Name != "第01章.md" || got[2].Name != "第02章.md" {
+		t.Fatalf("unexpected ordered chapter files: %#v", got)
+	}
+}
+
+func TestOrderedScenesRespectsSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	scenes := []Scene{
+		{Index: 1, Title: "Scene 1: Opening"},
+		{Index: 2, Title: "Scene 2: Rain"},
+		{Index: 3, Title: "Scene 3: Rooftop"},
+	}
+	got := orderedScenes(scenes, []string{"Scene 3: Rooftop", "Scene 1: Opening"})
+	if got[0].Title != "Scene 3: Rooftop" || got[1].Title != "Scene 1: Opening" || got[2].Title != "Scene 2: Rain" {
+		t.Fatalf("unexpected ordered scenes: %#v", got)
+	}
+}
+
+func TestRebuildChapterWithSceneOrderPreservesPreamble(t *testing.T) {
+	t.Parallel()
+
+	content := `前言
+
+## Scene 1: Opening
+Open.
+
+## Scene 2: Rain
+Rain.`
+	scenes := parseScenes(content)
+	got := rebuildChapterWithSceneOrder(content, scenes, []string{"Scene 2: Rain", "Scene 1: Opening"})
+	want := "前言\n\n## Scene 2: Rain\nRain.\n\n## Scene 1: Opening\nOpen."
+	if got != want {
+		t.Fatalf("unexpected rebuilt chapter:\n%s", got)
+	}
+}
+
+func TestListChapterFilesUsesSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{cfg: &config.Config{DataDir: dir}}
+	if _, err := s.saveChapterFile("第02章", "b"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", "a"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if err := s.saveChapterOrder([]string{"第02章.md", "第01章.md"}); err != nil {
+		t.Fatalf("save chapter order: %v", err)
+	}
+
+	files, err := s.listChapterFiles()
+	if err != nil {
+		t.Fatalf("list chapter files: %v", err)
+	}
+	if len(files) != 2 || files[0].Name != "第02章.md" || files[1].Name != "第01章.md" {
+		t.Fatalf("unexpected chapter file order: %#v", files)
+	}
+}

--- a/internal/server/ordering_test.go
+++ b/internal/server/ordering_test.go
@@ -1,9 +1,13 @@
 package server
 
 import (
+	"path/filepath"
 	"testing"
 
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/profile"
+	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/tracker"
 )
 
 func TestOrderedChapterFilesRespectsSavedOrder(t *testing.T) {
@@ -75,4 +79,42 @@ func TestListChapterFilesUsesSavedOrder(t *testing.T) {
 	if len(files) != 2 || files[0].Name != "第02章.md" || files[1].Name != "第01章.md" {
 		t.Fatalf("unexpected chapter file order: %#v", files)
 	}
+}
+
+func TestBuildChapterOverviewsPreservesSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
+		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
+		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
+	}
+	if _, err := s.saveChapterFile("第02章", "b"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", "a"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if err := s.saveChapterOrder([]string{"第02章.md", "第01章.md"}); err != nil {
+		t.Fatalf("save chapter order: %v", err)
+	}
+
+	overviews, err := s.buildChapterOverviews()
+	if err != nil {
+		t.Fatalf("buildChapterOverviews: %v", err)
+	}
+	if len(overviews) != 2 || overviews[0].Name != "第02章.md" || overviews[1].Name != "第01章.md" {
+		t.Fatalf("buildChapterOverviews did not preserve saved order: %v", overviewNames(overviews))
+	}
+}
+
+func overviewNames(overviews []chapterOverview) []string {
+	names := make([]string, len(overviews))
+	for i, o := range overviews {
+		names[i] = o.Name
+	}
+	return names
 }

--- a/internal/server/sceneboard.go
+++ b/internal/server/sceneboard.go
@@ -18,6 +18,7 @@ type scenePlan struct {
 }
 
 type scenePlanFile struct {
+	Order []string    `json:"order,omitempty"`
 	Items []scenePlan `json:"items"`
 }
 
@@ -48,17 +49,24 @@ func (s *Server) loadScenePlans(chapterName string) (map[string]scenePlan, error
 	return loadScenePlansFromPath(path)
 }
 
-func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return map[string]scenePlan{}, nil
-	}
+func (s *Server) loadScenePlanOrder(chapterName string) ([]string, error) {
+	s.scenePlansMu.RLock()
+	defer s.scenePlansMu.RUnlock()
+
+	path, err := s.scenePlanPath(chapterName)
 	if err != nil {
 		return nil, err
 	}
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return sanitizeSceneOrder(stored.Order), nil
+}
 
-	var stored scenePlanFile
-	if err := json.Unmarshal(data, &stored); err != nil {
+func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
 		return nil, err
 	}
 
@@ -74,6 +82,39 @@ func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
 		items[title] = item
 	}
 	return items, nil
+}
+
+func loadScenePlanFile(path string) (scenePlanFile, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return scenePlanFile{}, nil
+	}
+	if err != nil {
+		return scenePlanFile{}, err
+	}
+
+	var stored scenePlanFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return scenePlanFile{}, err
+	}
+	return stored, nil
+}
+
+func sanitizeSceneOrder(order []string) []string {
+	out := make([]string, 0, len(order))
+	seen := make(map[string]struct{}, len(order))
+	for _, title := range order {
+		clean := strings.TrimSpace(title)
+		if clean == "" {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	return out
 }
 
 func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
@@ -94,13 +135,25 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 		return err
 	}
 
-	items, err := loadScenePlansFromPath(path)
+	stored, err := loadScenePlanFile(path)
 	if err != nil {
 		return err
 	}
+	items := make(map[string]scenePlan, len(stored.Items))
+	for _, item := range stored.Items {
+		title := strings.TrimSpace(item.Title)
+		if title == "" {
+			continue
+		}
+		item.Title = title
+		items[title] = item
+	}
 	items[plan.Title] = plan
 
-	out := scenePlanFile{Items: make([]scenePlan, 0, len(items))}
+	out := scenePlanFile{
+		Order: sanitizeSceneOrder(stored.Order),
+		Items: make([]scenePlan, 0, len(items)),
+	}
 	for _, item := range items {
 		out.Items = append(out.Items, item)
 	}
@@ -112,6 +165,32 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 		return err
 	}
 	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileReplace(path, data, 0644)
+}
+
+func (s *Server) saveScenePlanOrder(chapterName string, order []string) error {
+	s.scenePlansMu.Lock()
+	defer s.scenePlansMu.Unlock()
+
+	path, err := s.scenePlanPath(chapterName)
+	if err != nil {
+		return err
+	}
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
+		return err
+	}
+	stored.Order = sanitizeSceneOrder(order)
+	sort.Slice(stored.Items, func(i, j int) bool {
+		return stored.Items[i].Title < stored.Items[j].Title
+	})
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(stored, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,19 +21,20 @@ import (
 )
 
 type Server struct {
-	cfg           *config.Config
-	router        *gin.Engine
-	profiles      *profile.Manager
-	store         *vectorstore.Store
-	project       *projectsettings.Store
-	embedder      *embedder.OllamaEmbedder
-	checker       *checker.Checker
-	rules         *reviewrules.Store
-	history       *reviewhistory.Store
-	relationships *tracker.RelationshipTracker
-	timeline      *tracker.TimelineTracker
-	foreshadow    *tracker.ForeshadowTracker
-	scenePlansMu  sync.RWMutex
+	cfg            *config.Config
+	router         *gin.Engine
+	profiles       *profile.Manager
+	store          *vectorstore.Store
+	project        *projectsettings.Store
+	embedder       *embedder.OllamaEmbedder
+	checker        *checker.Checker
+	rules          *reviewrules.Store
+	history        *reviewhistory.Store
+	relationships  *tracker.RelationshipTracker
+	timeline       *tracker.TimelineTracker
+	foreshadow     *tracker.ForeshadowTracker
+	chapterOrderMu sync.RWMutex
+	scenePlansMu   sync.RWMutex
 }
 
 func New(cfg *config.Config) (*Server, error) {
@@ -127,11 +128,14 @@ func (s *Server) setupRoutes() {
 
 	r.POST("/ingest", s.handleIngest)
 	r.POST("/api/chapters", s.handleSaveChapter)
+	r.POST("/api/chapters/order", s.handleSaveChapterOrder)
 	r.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
+	r.POST("/api/chapters/:name/scenes/order", s.handleSaveSceneOrder)
 	r.POST("/api/backups/create", s.handleCreateBackup)
 	r.POST("/api/backups/restore", s.handleRestoreBackup)
 	r.POST("/api/candidates/create", s.handleCreateCandidateDraft)
 	r.POST("/api/chapter-report/export", s.handleExportChapterBundle)
+	r.POST("/api/manuscript/export", s.handleExportManuscript)
 	r.POST("/api/history/delete", s.handleDeleteHistoryEntry)
 	r.POST("/api/history/export", s.handleExportHistory)
 	r.POST("/api/settings", s.handleSaveSettings)

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -379,6 +379,15 @@ tr:hover td { background: #1e1a30; }
   gap: 14px;
 }
 
+.chapter-overview-card[draggable="true"] {
+  cursor: grab;
+}
+
+.chapter-overview-card.dragging {
+  opacity: 0.72;
+  border-color: #7dd3fc;
+}
+
 .scene-board-section {
   display: grid;
   gap: 14px;
@@ -391,7 +400,7 @@ tr:hover td { background: #1e1a30; }
   gap: 16px;
 }
 
-.scene-card {
+.scene-card[draggable="true"] {
   background: linear-gradient(180deg, #171124 0%, #120d1d 100%);
   border: 1px solid #3b2d57;
   border-radius: 14px;
@@ -399,6 +408,12 @@ tr:hover td { background: #1e1a30; }
   display: grid;
   gap: 14px;
   box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+  cursor: grab;
+}
+
+.scene-card.dragging {
+  opacity: 0.72;
+  border-color: #86efac;
 }
 
 .scene-card-header {

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -14,12 +14,15 @@
     <div class="page-header">
       <h1>章節總覽</h1>
       <p>快速查看每一章的字數、最後更新、出場角色、審查次數與未回收伏筆，也能直接建立候選設定草稿。</p>
+      <div class="history-actions">
+        <button class="btn btn-ghost" type="button" onclick="exportManuscript()">匯出手稿</button>
+      </div>
     </div>
 
     {{if .Chapters}}
-    <div class="chapter-overview-list">
+    <div class="chapter-overview-list" id="chapter-overview-list">
       {{range .Chapters}}
-      <div class="card chapter-overview-card">
+      <div class="card chapter-overview-card" data-chapter="{{.Name}}" draggable="true">
         <div class="history-title-row">
           <div>
             <h2 style="margin-bottom:6px">{{.Title}}</h2>
@@ -91,12 +94,12 @@
             </div>
           </div>
 
-          <div class="scene-board-grid">
+          <div class="scene-board-grid" data-chapter="{{$.Name}}">
             {{range .SceneCards}}
-            <div class="scene-card" data-scene-status="{{.Status}}">
+            <div class="scene-card" data-scene-status="{{.Status}}" data-scene="{{.Title}}" draggable="true">
               <div class="scene-card-header">
                 <div>
-                  <div class="scene-kicker">Scene {{.Index}}</div>
+                  <div class="scene-kicker">Board {{.Position}} ・ {{.Title}}</div>
                   <h3>{{.Title}}</h3>
                 </div>
                 <span class="scene-status-badge scene-status-{{.Status}}">{{.Status}}</span>
@@ -192,6 +195,27 @@ async function exportChapterBundle(name) {
   }
 }
 
+async function exportManuscript() {
+  try {
+    const resp = await fetch('/api/manuscript/export', { method: 'POST' });
+    if (!resp.ok) {
+      const data = await resp.json();
+      throw new Error(data.error || '匯出手稿失敗');
+    }
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'novel_manuscript.md';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    alert('匯出手稿失敗：' + e.message);
+  }
+}
+
 function sceneFieldValue(chapterName, sceneTitle, field) {
   const selector = `.scene-plan-input[data-chapter="${CSS.escape(chapterName)}"][data-scene="${CSS.escape(sceneTitle)}"][data-field="${field}"]`;
   const el = document.querySelector(selector);
@@ -223,6 +247,139 @@ async function saveScenePlan(chapterName, sceneTitle) {
     alert('儲存場景規劃失敗：' + e.message);
   }
 }
+
+let draggedChapterCard = null;
+let draggedSceneCard = null;
+
+function setupChapterReordering() {
+  const list = document.getElementById('chapter-overview-list');
+  if (!list) return;
+
+  list.querySelectorAll('.chapter-overview-card[draggable="true"]').forEach((card) => {
+    card.addEventListener('dragstart', () => {
+      draggedChapterCard = card;
+      card.classList.add('dragging');
+    });
+    card.addEventListener('dragend', () => {
+      card.classList.remove('dragging');
+      draggedChapterCard = null;
+    });
+    card.addEventListener('dragover', (event) => {
+      event.preventDefault();
+    });
+    card.addEventListener('drop', async (event) => {
+      event.preventDefault();
+      if (!draggedChapterCard || draggedChapterCard === card) return;
+      const previousSibling = draggedChapterCard.previousElementSibling;
+      const nextSibling = draggedChapterCard.nextElementSibling;
+      const cards = Array.from(list.querySelectorAll('.chapter-overview-card'));
+      const targetIndex = cards.indexOf(card);
+      const draggedIndex = cards.indexOf(draggedChapterCard);
+      if (draggedIndex < targetIndex) {
+        card.after(draggedChapterCard);
+      } else {
+        card.before(draggedChapterCard);
+      }
+      try {
+        await persistChapterOrder();
+      } catch (e) {
+        if (nextSibling && nextSibling.parentElement === list) {
+          nextSibling.before(draggedChapterCard);
+        } else if (previousSibling && previousSibling.parentElement === list) {
+          previousSibling.after(draggedChapterCard);
+        } else {
+          list.prepend(draggedChapterCard);
+        }
+        alert(e.message || '儲存章節排序失敗');
+      }
+    });
+  });
+}
+
+async function persistChapterOrder() {
+  const order = Array.from(document.querySelectorAll('.chapter-overview-card')).map((card) => card.dataset.chapter).filter(Boolean);
+  const resp = await fetch('/api/chapters/order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ order })
+  });
+  const data = await resp.json();
+  if (!resp.ok) throw new Error(data.error || '儲存章節排序失敗');
+}
+
+function setupSceneReordering() {
+  document.querySelectorAll('.scene-board-grid').forEach((grid) => {
+    const cards = grid.querySelectorAll('.scene-card[draggable="true"]');
+    cards.forEach((card) => {
+      card.addEventListener('dragstart', () => {
+        draggedSceneCard = card;
+        card.classList.add('dragging');
+      });
+      card.addEventListener('dragend', () => {
+        card.classList.remove('dragging');
+        draggedSceneCard = null;
+      });
+      card.addEventListener('dragover', (event) => {
+        event.preventDefault();
+      });
+      card.addEventListener('drop', async (event) => {
+        event.preventDefault();
+        if (!draggedSceneCard || draggedSceneCard === card) return;
+        if (draggedSceneCard.closest('.scene-board-grid') !== grid) return;
+        const previousSibling = draggedSceneCard.previousElementSibling;
+        const nextSibling = draggedSceneCard.nextElementSibling;
+        const siblings = Array.from(grid.querySelectorAll('.scene-card'));
+        const targetIndex = siblings.indexOf(card);
+        const draggedIndex = siblings.indexOf(draggedSceneCard);
+        if (draggedIndex < targetIndex) {
+          card.after(draggedSceneCard);
+        } else {
+          card.before(draggedSceneCard);
+        }
+        refreshSceneBoardLabels(grid);
+        try {
+          await persistSceneOrder(grid);
+        } catch (e) {
+          if (nextSibling && nextSibling.parentElement === grid) {
+            nextSibling.before(draggedSceneCard);
+          } else if (previousSibling && previousSibling.parentElement === grid) {
+            previousSibling.after(draggedSceneCard);
+          } else {
+            grid.prepend(draggedSceneCard);
+          }
+          refreshSceneBoardLabels(grid);
+          alert(e.message || '儲存場景排序失敗');
+        }
+      });
+    });
+    refreshSceneBoardLabels(grid);
+  });
+}
+
+function refreshSceneBoardLabels(grid) {
+  Array.from(grid.querySelectorAll('.scene-card')).forEach((card, index) => {
+    const kicker = card.querySelector('.scene-kicker');
+    const sceneTitle = card.dataset.scene || '';
+    if (kicker) kicker.textContent = `Board ${index + 1} ・ ${sceneTitle}`;
+  });
+}
+
+async function persistSceneOrder(grid) {
+  const chapterName = grid.dataset.chapter || '';
+  const order = Array.from(grid.querySelectorAll('.scene-card')).map((card) => card.dataset.scene).filter(Boolean);
+  const resp = await fetch('/api/chapters/' + encodeURIComponent(chapterName) + '/scenes/order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ order })
+  });
+  const data = await resp.json();
+  if (!resp.ok) throw new Error(data.error || '儲存場景排序失敗');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupChapterReordering();
+  setupSceneReordering();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- closes #3
- add persistent drag-and-drop ordering for chapters and scenes
- make manuscript export follow the saved ordering metadata

## What Changed

- introduced project-level chapter ordering storage in `chapter_order.json`
- extended scene sidecar files to store scene order alongside planning metadata
- made chapter listing respect saved chapter order instead of filename order only
- made scene board cards respect saved scene order instead of original markdown order only
- added chapter drag-and-drop reordering in Chapter Overview
- added scene drag-and-drop reordering inside each scene board
- added rollback-on-error behavior if ordering persistence fails after a drag action
- added a new manuscript export endpoint that emits chapters and scenes in saved order
- added tests for chapter ordering, scene ordering, chapter rebuild ordering, and manuscript export order

## Verification

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual smoke test for changed UI flow, if applicable
- [x] Docs updated if behavior changed

## Review Focus

- persistence and recovery behavior for chapter/scene ordering metadata
- correctness of chapter and scene order after reload
- manuscript export order vs saved order
- drag-and-drop UI behavior and rollback-on-error handling

## Notes

- chapter ordering is stored separately from chapter filenames, so reordering does not require renaming files
- scene ordering is stored in the existing per-chapter sidecar file to keep manuscript structure Git-friendly
- this PR keeps plain chapter files working; if no scene markers exist, chapter ordering still applies and scene ordering is effectively skipped