### PR TITLE
[codex] Add retrieval control panel for story RAG

### DIFF
--- a/internal/reviewrules/store.go
+++ b/internal/reviewrules/store.go
@@ -8,10 +8,13 @@ import (
 )
 
 type Settings struct {
-	DefaultChecks []string `json:"default_checks"`
-	DefaultStyles []string `json:"default_styles"`
-	ReviewBias    string   `json:"review_bias"`
-	RewriteBias   string   `json:"rewrite_bias"`
+	DefaultChecks      []string `json:"default_checks"`
+	DefaultStyles      []string `json:"default_styles"`
+	ReviewBias         string   `json:"review_bias"`
+	RewriteBias        string   `json:"rewrite_bias"`
+	RetrievalSources   []string `json:"retrieval_sources"`
+	RetrievalTopK      int      `json:"retrieval_top_k"`
+	RetrievalThreshold float64  `json:"retrieval_threshold"`
 }
 
 type Store struct {
@@ -22,9 +25,12 @@ type Store struct {
 
 func Defaults() Settings {
 	return Settings{
-		DefaultChecks: []string{"behavior"},
-		ReviewBias:    "balanced",
-		RewriteBias:   "faithful",
+		DefaultChecks:      []string{"behavior"},
+		ReviewBias:         "balanced",
+		RewriteBias:        "faithful",
+		RetrievalSources:   []string{"character", "world", "style"},
+		RetrievalTopK:      4,
+		RetrievalThreshold: 0,
 	}
 }
 
@@ -95,12 +101,36 @@ func normalize(item Settings) Settings {
 	default:
 		item.RewriteBias = def.RewriteBias
 	}
+
+	allowed := map[string]struct{}{
+		"character": {},
+		"world":     {},
+		"style":     {},
+	}
+	filtered := make([]string, 0, len(item.RetrievalSources))
+	for _, source := range uniqueNonEmpty(item.RetrievalSources) {
+		if _, ok := allowed[source]; ok {
+			filtered = append(filtered, source)
+		}
+	}
+	if len(filtered) == 0 {
+		item.RetrievalSources = append([]string(nil), def.RetrievalSources...)
+	} else {
+		item.RetrievalSources = filtered
+	}
+	if item.RetrievalTopK < 1 || item.RetrievalTopK > 20 {
+		item.RetrievalTopK = def.RetrievalTopK
+	}
+	if item.RetrievalThreshold < 0 || item.RetrievalThreshold > 1 {
+		item.RetrievalThreshold = def.RetrievalThreshold
+	}
 	return item
 }
 
 func clone(item Settings) Settings {
 	item.DefaultChecks = append([]string(nil), item.DefaultChecks...)
 	item.DefaultStyles = append([]string(nil), item.DefaultStyles...)
+	item.RetrievalSources = append([]string(nil), item.RetrievalSources...)
 	return item
 }
 

--- a/internal/reviewrules/store_test.go
+++ b/internal/reviewrules/store_test.go
@@ -1,6 +1,9 @@
 package reviewrules
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestNormalizeAppliesDefaults(t *testing.T) {
 	t.Parallel()
@@ -25,5 +28,54 @@ func TestNormalizeDeduplicatesDefaults(t *testing.T) {
 	}
 	if len(item.DefaultStyles) != 1 {
 		t.Fatalf("expected deduped styles, got %#v", item.DefaultStyles)
+	}
+}
+
+func TestLoadMissingFileUsesDefaults(t *testing.T) {
+	t.Parallel()
+
+	store := New(filepath.Join(t.TempDir(), "review_rules.json"))
+	if err := store.Load(); err != nil {
+		t.Fatalf("load missing settings file: %v", err)
+	}
+
+	got := store.Get()
+	if got.RetrievalTopK != 4 || got.RetrievalThreshold != 0 {
+		t.Fatalf("expected retrieval defaults, got %#v", got)
+	}
+	if len(got.RetrievalSources) != 3 {
+		t.Fatalf("expected default retrieval sources, got %#v", got.RetrievalSources)
+	}
+}
+
+func TestNormalizeRetrievalSettings(t *testing.T) {
+	t.Parallel()
+
+	item := normalize(Settings{
+		RetrievalSources:   []string{"character", "unknown", "character"},
+		RetrievalTopK:      99,
+		RetrievalThreshold: -0.5,
+	})
+
+	if len(item.RetrievalSources) != 1 || item.RetrievalSources[0] != "character" {
+		t.Fatalf("expected filtered retrieval sources, got %#v", item.RetrievalSources)
+	}
+	if item.RetrievalTopK != Defaults().RetrievalTopK {
+		t.Fatalf("expected retrieval top-k fallback, got %d", item.RetrievalTopK)
+	}
+	if item.RetrievalThreshold != 0 {
+		t.Fatalf("expected retrieval threshold fallback, got %v", item.RetrievalThreshold)
+	}
+}
+
+func TestNormalizeRetrievalSourcesFallbackToDefaults(t *testing.T) {
+	t.Parallel()
+
+	item := normalize(Settings{
+		RetrievalSources: []string{"unknown"},
+	})
+
+	if len(item.RetrievalSources) != len(Defaults().RetrievalSources) {
+		t.Fatalf("expected default retrieval sources, got %#v", item.RetrievalSources)
 	}
 }

--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -119,10 +118,11 @@ func (s *Server) listChapterFiles() ([]chapterFile, error) {
 		})
 	}
 
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].Name < files[j].Name
-	})
-	return files, nil
+	order, err := s.loadChapterOrder()
+	if err != nil {
+		return nil, err
+	}
+	return orderedChapterFiles(files, order), nil
 }
 
 func (s *Server) loadChapterFile(name string) (chapterFile, error) {

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,6 +29,7 @@ type chapterOverview struct {
 }
 
 type sceneBoardCard struct {
+	Position     int
 	Index        int
 	Title        string
 	Preview      string
@@ -125,8 +125,12 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 			log.Printf("scene plans load %s: %v", file.Name, err)
 			scenePlans = map[string]scenePlan{}
 		}
+		sceneOrder, err := s.loadScenePlanOrder(file.Name)
+		if err != nil {
+			log.Printf("scene plan order load %s: %v", file.Name, err)
+		}
 		sceneCards := make([]sceneBoardCard, 0, len(scenes))
-		for _, scene := range scenes {
+		for idx, scene := range orderedScenes(scenes, sceneOrder) {
 			plan := scenePlans[scene.Title]
 			sceneKey := file.Name + "::" + scene.Title
 			reviewCount := sceneReviews[sceneKey]
@@ -138,6 +142,7 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 				status = "reviewed"
 			}
 			sceneCards = append(sceneCards, sceneBoardCard{
+				Position:     idx + 1,
 				Index:        scene.Index,
 				Title:        scene.Title,
 				Preview:      scenePreview(scene.Content),
@@ -165,9 +170,6 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 		})
 	}
 
-	sort.Slice(overviews, func(i, j int) bool {
-		return overviews[i].Name < overviews[j].Name
-	})
 	return overviews, nil
 }
 

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -194,6 +194,32 @@ Zhang Lei stood in the rain.`
 	}
 }
 
+func TestGetSettingsReturnsRetrievalDefaults(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, "http://127.0.0.1:0")
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performRequest(t, app.URL, "GET", "/api/settings", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get settings failed: %s", string(resp.Body))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		t.Fatalf("decode settings response: %v", err)
+	}
+	if got := payload["retrieval_top_k"]; got != float64(4) {
+		t.Fatalf("expected retrieval_top_k=4, got %#v", got)
+	}
+	sources, ok := payload["retrieval_sources"].([]any)
+	if !ok || len(sources) != 3 {
+		t.Fatalf("expected retrieval_sources in response, got %#v", payload["retrieval_sources"])
+	}
+}
+
 func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 	t.Helper()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -201,7 +201,7 @@ func (s *Server) resolveStyles(req checkRequest) ([]*profile.StyleGuide, error) 
 	return styles, nil
 }
 
-func (s *Server) buildReferenceContext(ctx context.Context, chapter string) ([]vectorProfile, error) {
+func (s *Server) buildReferenceContext(ctx context.Context, chapter string, opts retrievalOptions) ([]vectorProfile, error) {
 	if s.store.Len() == 0 {
 		return nil, nil
 	}
@@ -211,7 +211,21 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter string) ([]v
 		return nil, err
 	}
 
-	docs := s.store.QueryScored(queryVec, 4, "")
+	rules := s.rules.Get()
+	topK := opts.TopK
+	if topK < 1 {
+		topK = rules.RetrievalTopK
+	}
+	sources := opts.Sources
+	if len(sources) == 0 {
+		sources = rules.RetrievalSources
+	}
+	threshold := opts.Threshold
+	if threshold < 0 || threshold > 1 {
+		threshold = rules.RetrievalThreshold
+	}
+
+	docs := s.store.QueryFilteredScored(queryVec, topK, sources, threshold)
 	results := make([]vectorProfile, 0, len(docs))
 	for _, doc := range docs {
 		name := strings.TrimPrefix(doc.ID, "char_")
@@ -373,14 +387,17 @@ func (s *Server) handleCheckPage(c *gin.Context) {
 	}
 	rules := s.rules.Get()
 	c.HTML(http.StatusOK, "check.html", gin.H{
-		"Title":         "一致性審查",
-		"Characters":    s.profiles.Characters,
-		"Styles":        s.profiles.Styles,
-		"Chapters":      chapters,
-		"DefaultChecks": rules.DefaultChecks,
-		"DefaultStyles": rules.DefaultStyles,
-		"ReviewBias":    rules.ReviewBias,
-		"RewriteBias":   rules.RewriteBias,
+		"Title":              "一致性審查",
+		"Characters":         s.profiles.Characters,
+		"Styles":             s.profiles.Styles,
+		"Chapters":           chapters,
+		"DefaultChecks":      rules.DefaultChecks,
+		"DefaultStyles":      rules.DefaultStyles,
+		"ReviewBias":         rules.ReviewBias,
+		"RewriteBias":        rules.RewriteBias,
+		"RetrievalSources":   rules.RetrievalSources,
+		"RetrievalTopK":      rules.RetrievalTopK,
+		"RetrievalThreshold": rules.RetrievalThreshold,
 	})
 }
 
@@ -425,13 +442,20 @@ func (s *Server) handleIngest(c *gin.Context) {
 // ─── check stream ─────────────────────────────────────────────────────────────
 
 type checkRequest struct {
-	Chapter      string   `json:"chapter"`
-	Characters   []string `json:"characters"`
-	Checks       []string `json:"checks"` // ["behavior","dialogue","style","world"]
-	Styles       []string `json:"styles"` // style guide names to apply; empty = all styles
-	ChapterFile  string   `json:"chapter_file"`
-	ChapterTitle string   `json:"chapter_title"`
-	SceneTitle   string   `json:"scene_title,omitempty"` // empty = full chapter
+	Chapter      string           `json:"chapter"`
+	Characters   []string         `json:"characters"`
+	Checks       []string         `json:"checks"` // ["behavior","dialogue","style","world"]
+	Styles       []string         `json:"styles"` // style guide names to apply; empty = all styles
+	Retrieval    retrievalOptions `json:"retrieval"`
+	ChapterFile  string           `json:"chapter_file"`
+	ChapterTitle string           `json:"chapter_title"`
+	SceneTitle   string           `json:"scene_title,omitempty"` // empty = full chapter
+}
+
+type retrievalOptions struct {
+	Sources   []string `json:"sources"`
+	TopK      int      `json:"top_k"`
+	Threshold float64  `json:"threshold"`
 }
 
 func (s *Server) handleCheckStream(c *gin.Context) {
@@ -467,7 +491,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			return
 		}
 
-		references, err := s.buildReferenceContext(ctx, req.Chapter)
+		references, err := s.buildReferenceContext(ctx, req.Chapter, req.Retrieval)
 		if err != nil {
 			text := fmt.Sprintf("\n> RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 			transcript.WriteString(text)
@@ -627,13 +651,14 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 }
 
 type rewriteRequest struct {
-	Chapter      string   `json:"chapter"`
-	Mode         string   `json:"mode"`
-	Characters   []string `json:"characters"`
-	Styles       []string `json:"styles"`
-	ChapterFile  string   `json:"chapter_file"`
-	ChapterTitle string   `json:"chapter_title"`
-	SceneTitle   string   `json:"scene_title,omitempty"` // empty = full chapter
+	Chapter      string           `json:"chapter"`
+	Mode         string           `json:"mode"`
+	Characters   []string         `json:"characters"`
+	Styles       []string         `json:"styles"`
+	Retrieval    retrievalOptions `json:"retrieval"`
+	ChapterFile  string           `json:"chapter_file"`
+	ChapterTitle string           `json:"chapter_title"`
+	SceneTitle   string           `json:"scene_title,omitempty"` // empty = full chapter
 }
 
 func rewriteInstruction(mode string) (string, error) {
@@ -682,7 +707,7 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer close(msgChan)
 		defer cancel()
 
-		references, refErr := s.buildReferenceContext(ctx, req.Chapter)
+		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.Retrieval)
 		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		if refErr != nil {
 			text := fmt.Sprintf("\n> RAG 參考載入失敗，改用基礎模式繼續：%s\n", refErr.Error())

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"novel-assistant/internal/profile"
+	"novel-assistant/internal/vectorstore"
 	"testing"
 )
 
@@ -95,5 +97,21 @@ func TestRewriteInstructionRejectsUnknownMode(t *testing.T) {
 
 	if _, err := rewriteInstruction("unknown"); err == nil {
 		t.Fatal("expected error for unknown rewrite mode")
+	}
+}
+
+func TestBuildReferenceContextReturnsNilWhenStoreIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		store: &vectorstore.Store{},
+	}
+
+	refs, err := s.buildReferenceContext(context.Background(), "chapter", retrievalOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error with empty store: %v", err)
+	}
+	if refs != nil {
+		t.Fatalf("expected nil refs for empty store, got %#v", refs)
 	}
 }

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -291,3 +291,47 @@ func (s *Server) handleExportChapterBundle(c *gin.Context) {
 	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, strings.TrimSuffix(req.Name, filepath.Ext(req.Name))+"_bundle.zip"))
 	c.Data(http.StatusOK, "application/zip", buf.Bytes())
 }
+
+func (s *Server) buildManuscriptMarkdown() (string, error) {
+	files, err := s.listChapterFiles()
+	if err != nil {
+		return "", err
+	}
+	if len(files) == 0 {
+		return "", fmt.Errorf("目前沒有章節可匯出")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("# 小說手稿匯出\n\n")
+
+	for _, item := range files {
+		file, err := s.loadChapterFile(item.Name)
+		if err != nil {
+			return "", err
+		}
+		sceneOrder, err := s.loadScenePlanOrder(item.Name)
+		if err != nil {
+			return "", err
+		}
+		content := rebuildChapterWithSceneOrder(file.Content, file.Scenes, sceneOrder)
+		sb.WriteString("## ")
+		sb.WriteString(file.Title)
+		sb.WriteString("\n\n")
+		sb.WriteString(strings.TrimSpace(content))
+		sb.WriteString("\n\n")
+	}
+
+	return strings.TrimSpace(sb.String()) + "\n", nil
+}
+
+func (s *Server) handleExportManuscript(c *gin.Context) {
+	report, err := s.buildManuscriptMarkdown()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Header("Content-Type", "text/markdown; charset=utf-8")
+	c.Header("Content-Disposition", `attachment; filename="novel_manuscript.md"`)
+	c.Data(http.StatusOK, "text/markdown; charset=utf-8", []byte(report))
+}

--- a/internal/server/ordering.go
+++ b/internal/server/ordering.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type chapterOrderFile struct {
+	Order []string `json:"order"`
+}
+
+type orderRequest struct {
+	Order []string `json:"order"`
+}
+
+func (s *Server) chapterOrderPath() string {
+	return filepath.Join(s.cfg.DataDir, "chapter_order.json")
+}
+
+func (s *Server) loadChapterOrder() ([]string, error) {
+	s.chapterOrderMu.RLock()
+	defer s.chapterOrderMu.RUnlock()
+	return loadChapterOrderFromPath(s.chapterOrderPath())
+}
+
+func loadChapterOrderFromPath(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var stored chapterOrderFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return nil, err
+	}
+
+	out := make([]string, 0, len(stored.Order))
+	seen := make(map[string]struct{}, len(stored.Order))
+	for _, name := range stored.Order {
+		normalized, err := normalizeChapterName(name)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func (s *Server) saveChapterOrder(order []string) error {
+	s.chapterOrderMu.Lock()
+	defer s.chapterOrderMu.Unlock()
+
+	normalized := make([]string, 0, len(order))
+	seen := make(map[string]struct{}, len(order))
+	for _, name := range order {
+		clean, err := normalizeChapterName(name)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		normalized = append(normalized, clean)
+	}
+
+	data, err := json.MarshalIndent(chapterOrderFile{Order: normalized}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.chapterOrderPath()), 0755); err != nil {
+		return err
+	}
+	return writeFileReplace(s.chapterOrderPath(), data, 0644)
+}
+
+func orderedChapterFiles(files []chapterFile, order []string) []chapterFile {
+	if len(files) == 0 {
+		return nil
+	}
+	if len(order) == 0 {
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].Name < files[j].Name
+		})
+		return files
+	}
+
+	index := make(map[string]int, len(order))
+	for i, name := range order {
+		index[name] = i
+	}
+	sort.SliceStable(files, func(i, j int) bool {
+		pi, okI := index[files[i].Name]
+		pj, okJ := index[files[j].Name]
+		switch {
+		case okI && okJ:
+			return pi < pj
+		case okI:
+			return true
+		case okJ:
+			return false
+		default:
+			return files[i].Name < files[j].Name
+		}
+	})
+	return files
+}
+
+func orderedScenes(scenes []Scene, order []string) []Scene {
+	if len(scenes) == 0 || len(order) == 0 {
+		return scenes
+	}
+
+	copied := make([]Scene, len(scenes))
+	copy(copied, scenes)
+
+	index := make(map[string]int, len(order))
+	for i, title := range order {
+		index[strings.TrimSpace(title)] = i
+	}
+	sort.SliceStable(copied, func(i, j int) bool {
+		pi, okI := index[copied[i].Title]
+		pj, okJ := index[copied[j].Title]
+		switch {
+		case okI && okJ:
+			return pi < pj
+		case okI:
+			return true
+		case okJ:
+			return false
+		default:
+			return copied[i].Index < copied[j].Index
+		}
+	})
+	return copied
+}
+
+func chapterPreamble(content string) string {
+	firstMarker := sceneHeaderRe.FindStringIndex(content)
+	if firstMarker == nil || firstMarker[0] <= 0 {
+		return ""
+	}
+	return strings.TrimRight(content[:firstMarker[0]], "\r\n\t ")
+}
+
+func rebuildChapterWithSceneOrder(content string, scenes []Scene, order []string) string {
+	if len(scenes) == 0 {
+		return strings.TrimSpace(content)
+	}
+
+	parts := make([]string, 0, len(scenes)+1)
+	if preamble := chapterPreamble(content); preamble != "" {
+		parts = append(parts, preamble)
+	}
+	for _, scene := range orderedScenes(scenes, order) {
+		parts = append(parts, "## "+scene.Title+"\n"+scene.Content)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func (s *Server) handleSaveChapterOrder(c *gin.Context) {
+	var req orderRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := s.saveChapterOrder(req.Order); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已儲存章節排序"})
+}
+
+func (s *Server) handleSaveSceneOrder(c *gin.Context) {
+	chapterName := c.Param("name")
+	file, err := s.loadChapterFile(chapterName)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	var req orderRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	allowed := make(map[string]struct{}, len(file.Scenes))
+	for _, scene := range file.Scenes {
+		allowed[scene.Title] = struct{}{}
+	}
+	for _, title := range req.Order {
+		if _, ok := allowed[strings.TrimSpace(title)]; !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("找不到場景：%s", title)})
+			return
+		}
+	}
+	if err := s.saveScenePlanOrder(file.Name, req.Order); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "已儲存場景排序"})
+}

--- a/internal/server/ordering_test.go
+++ b/internal/server/ordering_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"path/filepath"
+	"testing"
+
+	"novel-assistant/internal/config"
+	"novel-assistant/internal/profile"
+	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/tracker"
+)
+
+func TestOrderedChapterFilesRespectsSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	files := []chapterFile{
+		{Name: "第02章.md"},
+		{Name: "第01章.md"},
+		{Name: "第03章.md"},
+	}
+	order := []string{"第03章.md", "第01章.md"}
+	got := orderedChapterFiles(files, order)
+	if got[0].Name != "第03章.md" || got[1].Name != "第01章.md" || got[2].Name != "第02章.md" {
+		t.Fatalf("unexpected ordered chapter files: %#v", got)
+	}
+}
+
+func TestOrderedScenesRespectsSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	scenes := []Scene{
+		{Index: 1, Title: "Scene 1: Opening"},
+		{Index: 2, Title: "Scene 2: Rain"},
+		{Index: 3, Title: "Scene 3: Rooftop"},
+	}
+	got := orderedScenes(scenes, []string{"Scene 3: Rooftop", "Scene 1: Opening"})
+	if got[0].Title != "Scene 3: Rooftop" || got[1].Title != "Scene 1: Opening" || got[2].Title != "Scene 2: Rain" {
+		t.Fatalf("unexpected ordered scenes: %#v", got)
+	}
+}
+
+func TestRebuildChapterWithSceneOrderPreservesPreamble(t *testing.T) {
+	t.Parallel()
+
+	content := `前言
+
+## Scene 1: Opening
+Open.
+
+## Scene 2: Rain
+Rain.`
+	scenes := parseScenes(content)
+	got := rebuildChapterWithSceneOrder(content, scenes, []string{"Scene 2: Rain", "Scene 1: Opening"})
+	want := "前言\n\n## Scene 2: Rain\nRain.\n\n## Scene 1: Opening\nOpen."
+	if got != want {
+		t.Fatalf("unexpected rebuilt chapter:\n%s", got)
+	}
+}
+
+func TestListChapterFilesUsesSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{cfg: &config.Config{DataDir: dir}}
+	if _, err := s.saveChapterFile("第02章", "b"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", "a"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if err := s.saveChapterOrder([]string{"第02章.md", "第01章.md"}); err != nil {
+		t.Fatalf("save chapter order: %v", err)
+	}
+
+	files, err := s.listChapterFiles()
+	if err != nil {
+		t.Fatalf("list chapter files: %v", err)
+	}
+	if len(files) != 2 || files[0].Name != "第02章.md" || files[1].Name != "第01章.md" {
+		t.Fatalf("unexpected chapter file order: %#v", files)
+	}
+}
+
+func TestBuildChapterOverviewsPreservesSavedOrder(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
+		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
+		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
+	}
+	if _, err := s.saveChapterFile("第02章", "b"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", "a"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if err := s.saveChapterOrder([]string{"第02章.md", "第01章.md"}); err != nil {
+		t.Fatalf("save chapter order: %v", err)
+	}
+
+	overviews, err := s.buildChapterOverviews()
+	if err != nil {
+		t.Fatalf("buildChapterOverviews: %v", err)
+	}
+	if len(overviews) != 2 || overviews[0].Name != "第02章.md" || overviews[1].Name != "第01章.md" {
+		t.Fatalf("buildChapterOverviews did not preserve saved order: %v", overviewNames(overviews))
+	}
+}
+
+func overviewNames(overviews []chapterOverview) []string {
+	names := make([]string, len(overviews))
+	for i, o := range overviews {
+		names[i] = o.Name
+	}
+	return names
+}

--- a/internal/server/sceneboard.go
+++ b/internal/server/sceneboard.go
@@ -18,6 +18,7 @@ type scenePlan struct {
 }
 
 type scenePlanFile struct {
+	Order []string    `json:"order,omitempty"`
 	Items []scenePlan `json:"items"`
 }
 
@@ -48,17 +49,24 @@ func (s *Server) loadScenePlans(chapterName string) (map[string]scenePlan, error
 	return loadScenePlansFromPath(path)
 }
 
-func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return map[string]scenePlan{}, nil
-	}
+func (s *Server) loadScenePlanOrder(chapterName string) ([]string, error) {
+	s.scenePlansMu.RLock()
+	defer s.scenePlansMu.RUnlock()
+
+	path, err := s.scenePlanPath(chapterName)
 	if err != nil {
 		return nil, err
 	}
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return sanitizeSceneOrder(stored.Order), nil
+}
 
-	var stored scenePlanFile
-	if err := json.Unmarshal(data, &stored); err != nil {
+func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
 		return nil, err
 	}
 
@@ -74,6 +82,39 @@ func loadScenePlansFromPath(path string) (map[string]scenePlan, error) {
 		items[title] = item
 	}
 	return items, nil
+}
+
+func loadScenePlanFile(path string) (scenePlanFile, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return scenePlanFile{}, nil
+	}
+	if err != nil {
+		return scenePlanFile{}, err
+	}
+
+	var stored scenePlanFile
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return scenePlanFile{}, err
+	}
+	return stored, nil
+}
+
+func sanitizeSceneOrder(order []string) []string {
+	out := make([]string, 0, len(order))
+	seen := make(map[string]struct{}, len(order))
+	for _, title := range order {
+		clean := strings.TrimSpace(title)
+		if clean == "" {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		out = append(out, clean)
+	}
+	return out
 }
 
 func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
@@ -94,13 +135,25 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 		return err
 	}
 
-	items, err := loadScenePlansFromPath(path)
+	stored, err := loadScenePlanFile(path)
 	if err != nil {
 		return err
 	}
+	items := make(map[string]scenePlan, len(stored.Items))
+	for _, item := range stored.Items {
+		title := strings.TrimSpace(item.Title)
+		if title == "" {
+			continue
+		}
+		item.Title = title
+		items[title] = item
+	}
 	items[plan.Title] = plan
 
-	out := scenePlanFile{Items: make([]scenePlan, 0, len(items))}
+	out := scenePlanFile{
+		Order: sanitizeSceneOrder(stored.Order),
+		Items: make([]scenePlan, 0, len(items)),
+	}
 	for _, item := range items {
 		out.Items = append(out.Items, item)
 	}
@@ -112,6 +165,32 @@ func (s *Server) saveScenePlan(chapterName string, plan scenePlan) error {
 		return err
 	}
 	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileReplace(path, data, 0644)
+}
+
+func (s *Server) saveScenePlanOrder(chapterName string, order []string) error {
+	s.scenePlansMu.Lock()
+	defer s.scenePlansMu.Unlock()
+
+	path, err := s.scenePlanPath(chapterName)
+	if err != nil {
+		return err
+	}
+	stored, err := loadScenePlanFile(path)
+	if err != nil {
+		return err
+	}
+	stored.Order = sanitizeSceneOrder(order)
+	sort.Slice(stored.Items, func(i, j int) bool {
+		return stored.Items[i].Title < stored.Items[j].Title
+	})
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(stored, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,19 +21,20 @@ import (
 )
 
 type Server struct {
-	cfg           *config.Config
-	router        *gin.Engine
-	profiles      *profile.Manager
-	store         *vectorstore.Store
-	project       *projectsettings.Store
-	embedder      *embedder.OllamaEmbedder
-	checker       *checker.Checker
-	rules         *reviewrules.Store
-	history       *reviewhistory.Store
-	relationships *tracker.RelationshipTracker
-	timeline      *tracker.TimelineTracker
-	foreshadow    *tracker.ForeshadowTracker
-	scenePlansMu  sync.RWMutex
+	cfg            *config.Config
+	router         *gin.Engine
+	profiles       *profile.Manager
+	store          *vectorstore.Store
+	project        *projectsettings.Store
+	embedder       *embedder.OllamaEmbedder
+	checker        *checker.Checker
+	rules          *reviewrules.Store
+	history        *reviewhistory.Store
+	relationships  *tracker.RelationshipTracker
+	timeline       *tracker.TimelineTracker
+	foreshadow     *tracker.ForeshadowTracker
+	chapterOrderMu sync.RWMutex
+	scenePlansMu   sync.RWMutex
 }
 
 func New(cfg *config.Config) (*Server, error) {
@@ -97,6 +98,14 @@ func New(cfg *config.Config) (*Server, error) {
 			}
 			return template.JS(data)
 		},
+		"sourceEnabled": func(sources []string, name string) bool {
+			for _, source := range sources {
+				if source == name {
+					return true
+				}
+			}
+			return false
+		},
 	})
 	s.router.LoadHTMLGlob("web/templates/*.html")
 	s.router.Static("/static", "web/static")
@@ -124,14 +133,18 @@ func (s *Server) setupRoutes() {
 	r.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
 	r.GET("/api/chapters", s.handleListChapters)
 	r.GET("/api/chapters/:name", s.handleGetChapter)
+	r.GET("/api/settings", s.handleGetSettings)
 
 	r.POST("/ingest", s.handleIngest)
 	r.POST("/api/chapters", s.handleSaveChapter)
+	r.POST("/api/chapters/order", s.handleSaveChapterOrder)
 	r.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
+	r.POST("/api/chapters/:name/scenes/order", s.handleSaveSceneOrder)
 	r.POST("/api/backups/create", s.handleCreateBackup)
 	r.POST("/api/backups/restore", s.handleRestoreBackup)
 	r.POST("/api/candidates/create", s.handleCreateCandidateDraft)
 	r.POST("/api/chapter-report/export", s.handleExportChapterBundle)
+	r.POST("/api/manuscript/export", s.handleExportManuscript)
 	r.POST("/api/history/delete", s.handleDeleteHistoryEntry)
 	r.POST("/api/history/export", s.handleExportHistory)
 	r.POST("/api/settings", s.handleSaveSettings)

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -12,14 +12,17 @@ import (
 )
 
 type settingsSaveRequest struct {
-	DefaultChecks []string `json:"default_checks"`
-	DefaultStyles []string `json:"default_styles"`
-	ReviewBias    string   `json:"review_bias"`
-	RewriteBias   string   `json:"rewrite_bias"`
-	OllamaURL     string   `json:"ollama_url"`
-	LLMModel      string   `json:"llm_model"`
-	EmbedModel    string   `json:"embed_model"`
-	Port          string   `json:"port"`
+	DefaultChecks      []string `json:"default_checks"`
+	DefaultStyles      []string `json:"default_styles"`
+	ReviewBias         string   `json:"review_bias"`
+	RewriteBias        string   `json:"rewrite_bias"`
+	RetrievalSources   []string `json:"retrieval_sources"`
+	RetrievalTopK      int      `json:"retrieval_top_k"`
+	RetrievalThreshold float64  `json:"retrieval_threshold"`
+	OllamaURL          string   `json:"ollama_url"`
+	LLMModel           string   `json:"llm_model"`
+	EmbedModel         string   `json:"embed_model"`
+	Port               string   `json:"port"`
 }
 
 func (s *Server) handleSettingsPage(c *gin.Context) {
@@ -37,6 +40,24 @@ func (s *Server) handleSettingsPage(c *gin.Context) {
 	})
 }
 
+func (s *Server) handleGetSettings(c *gin.Context) {
+	rules := s.rules.Get()
+	project := s.project.Get()
+	c.JSON(http.StatusOK, gin.H{
+		"default_checks":      rules.DefaultChecks,
+		"default_styles":      rules.DefaultStyles,
+		"review_bias":         rules.ReviewBias,
+		"rewrite_bias":        rules.RewriteBias,
+		"retrieval_sources":   rules.RetrievalSources,
+		"retrieval_top_k":     rules.RetrievalTopK,
+		"retrieval_threshold": rules.RetrievalThreshold,
+		"ollama_url":          project.OllamaURL,
+		"llm_model":           project.LLMModel,
+		"embed_model":         project.EmbedModel,
+		"port":                project.Port,
+	})
+}
+
 func (s *Server) handleSaveSettings(c *gin.Context) {
 	var req settingsSaveRequest
 	if err := c.BindJSON(&req); err != nil {
@@ -45,10 +66,13 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 	}
 
 	s.rules.Update(reviewrules.Settings{
-		DefaultChecks: req.DefaultChecks,
-		DefaultStyles: req.DefaultStyles,
-		ReviewBias:    req.ReviewBias,
-		RewriteBias:   req.RewriteBias,
+		DefaultChecks:      req.DefaultChecks,
+		DefaultStyles:      req.DefaultStyles,
+		ReviewBias:         req.ReviewBias,
+		RewriteBias:        req.RewriteBias,
+		RetrievalSources:   req.RetrievalSources,
+		RetrievalTopK:      req.RetrievalTopK,
+		RetrievalThreshold: req.RetrievalThreshold,
 	})
 	if err := s.rules.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "規則設定保存失敗"})

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -112,6 +112,44 @@ func (s *Store) QueryScored(queryVec []float64, topK int, docType string) []Scor
 	return out
 }
 
+func (s *Store) QueryFilteredScored(queryVec []float64, topK int, types []string, threshold float64) []ScoredDocument {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	typeSet := make(map[string]struct{}, len(types))
+	for _, item := range types {
+		typeSet[item] = struct{}{}
+	}
+
+	type scored struct {
+		doc   Document
+		score float64
+	}
+	var results []scored
+	for _, d := range s.docs {
+		if len(typeSet) > 0 {
+			if _, ok := typeSet[d.Type]; !ok {
+				continue
+			}
+		}
+		score := cosine(queryVec, d.Embedding)
+		if threshold > 0 && score < threshold {
+			continue
+		}
+		results = append(results, scored{doc: d, score: score})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].score > results[j].score })
+
+	out := make([]ScoredDocument, 0, topK)
+	for i := 0; i < topK && i < len(results); i++ {
+		out = append(out, ScoredDocument{
+			Document: results[i].doc,
+			Score:    results[i].score,
+		})
+	}
+	return out
+}
+
 func cosine(a, b []float64) float64 {
 	if len(a) != len(b) {
 		return 0

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -1,0 +1,56 @@
+package vectorstore
+
+import "testing"
+
+func TestQueryFilteredScoredSupportsThresholdAndTypeFilters(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{
+		docs: []Document{
+			{ID: "char_1", Type: "character", Embedding: []float64{1, 0}},
+			{ID: "world_1", Type: "world", Embedding: []float64{0.8, 0.2}},
+			{ID: "style_1", Type: "style", Embedding: []float64{0, 1}},
+		},
+	}
+	query := []float64{1, 0}
+
+	all := store.QueryFilteredScored(query, 10, nil, 0)
+	if len(all) != 3 {
+		t.Fatalf("expected all documents with threshold 0, got %d", len(all))
+	}
+
+	charactersOnly := store.QueryFilteredScored(query, 10, []string{"character"}, 0)
+	if len(charactersOnly) != 1 || charactersOnly[0].Type != "character" {
+		t.Fatalf("expected only character docs, got %#v", charactersOnly)
+	}
+
+	highThreshold := store.QueryFilteredScored(query, 10, nil, 0.9)
+	if len(highThreshold) != 2 {
+		t.Fatalf("expected threshold to filter low-similarity docs, got %d", len(highThreshold))
+	}
+	for _, item := range highThreshold {
+		if item.Score < 0.9 {
+			t.Fatalf("expected score >= 0.9, got %f", item.Score)
+		}
+	}
+}
+
+func TestQueryFilteredScoredRespectsTopK(t *testing.T) {
+	t.Parallel()
+
+	store := &Store{
+		docs: []Document{
+			{ID: "a", Type: "character", Embedding: []float64{1, 0}},
+			{ID: "b", Type: "world", Embedding: []float64{0.9, 0.1}},
+			{ID: "c", Type: "style", Embedding: []float64{0.8, 0.2}},
+		},
+	}
+
+	results := store.QueryFilteredScored([]float64{1, 0}, 2, nil, 0)
+	if len(results) != 2 {
+		t.Fatalf("expected top-k cap of 2, got %d", len(results))
+	}
+	if results[0].Score < results[1].Score {
+		t.Fatalf("expected scores sorted descending, got %#v", results)
+	}
+}

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -44,6 +44,44 @@
         </div>
 
         <div class="card">
+          <h2>RAG 擷取設定</h2>
+          <p class="helper-text">控制哪些知識來源會被納入本次審查的參考上下文。</p>
+
+          <div id="retrieval-summary" class="helper-text" style="margin-bottom:12px;font-weight:600"></div>
+
+          <div class="form-group">
+            <label>啟用來源</label>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" name="retrieval-source" value="character" {{if sourceEnabled .RetrievalSources "character"}}checked{{end}}>
+                角色設定
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="retrieval-source" value="world" {{if sourceEnabled .RetrievalSources "world"}}checked{{end}}>
+                世界觀
+              </label>
+              <label class="checkbox-label">
+                <input type="checkbox" name="retrieval-source" value="style" {{if sourceEnabled .RetrievalSources "style"}}checked{{end}}>
+                寫作風格
+              </label>
+            </div>
+          </div>
+
+          <div class="grid-2">
+            <div class="form-group">
+              <label>Top-K（最多取幾筆）</label>
+              <input type="number" id="retrieval-topk" min="1" max="20" value="{{.RetrievalTopK}}">
+            </div>
+            <div class="form-group">
+              <label>相似度門檻 <span id="threshold-display">{{printf "%.2f" .RetrievalThreshold}}</span></label>
+              <input type="range" id="retrieval-threshold" min="0" max="1" step="0.01" value="{{.RetrievalThreshold}}" oninput="document.getElementById('threshold-display').textContent=parseFloat(this.value).toFixed(2);updateRetrievalSummary()">
+            </div>
+          </div>
+
+          <button class="btn btn-ghost" type="button" onclick="saveRetrievalDefaults()">設為預設</button>
+        </div>
+
+        <div class="card">
           <h2>審查設定</h2>
           <p class="helper-text">目前規則設定：審查偏好 {{.ReviewBias}} ・ 修稿偏好 {{.RewriteBias}}。可到「規則設定」頁調整。</p>
 
@@ -259,9 +297,14 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[name="styles"]').forEach((el) => {
     el.checked = presetStyles.includes(el.value);
   });
+  document.querySelectorAll('[name="retrieval-source"]').forEach((el) => {
+    el.addEventListener('change', updateRetrievalSummary);
+  });
+  document.getElementById('retrieval-topk').addEventListener('input', updateRetrievalSummary);
   if (styleCheck) {
     document.getElementById('style-selector').style.display = styleCheck.checked ? 'block' : 'none';
   }
+  updateRetrievalSummary();
   hydrateFromHistory();
 });
 
@@ -549,6 +592,51 @@ function selectedCharacters() {
   return Array.from(document.querySelectorAll('[name="characters"]:checked')).map(el => el.value);
 }
 
+function getRetrievalOptions() {
+  return {
+    sources: Array.from(document.querySelectorAll('[name="retrieval-source"]:checked')).map(el => el.value),
+    top_k: Math.max(1, Number(document.getElementById('retrieval-topk').value) || 4),
+    threshold: Number(document.getElementById('retrieval-threshold').value) || 0,
+  };
+}
+
+function updateRetrievalSummary() {
+  const opts = getRetrievalOptions();
+  const labels = { character: '角色', world: '世界觀', style: '風格' };
+  const srcStr = opts.sources.length ? opts.sources.map(s => labels[s] || s).join('、') : '（無）';
+  document.getElementById('retrieval-summary').textContent =
+    '來源：' + srcStr + '　Top-K：' + opts.top_k + '　門檻：' + opts.threshold.toFixed(2);
+}
+
+async function saveRetrievalDefaults() {
+  const opts = getRetrievalOptions();
+  try {
+    const current = await fetch('/api/settings')
+      .then(async (r) => {
+        if (!r.ok) {
+          const data = await r.json().catch(() => ({}));
+          throw new Error(data.error || '讀取現有設定失敗');
+        }
+        return r.json();
+      });
+    const body = Object.assign({}, current, {
+      retrieval_sources: opts.sources,
+      retrieval_top_k: opts.top_k,
+      retrieval_threshold: opts.threshold,
+    });
+    const resp = await fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '儲存失敗');
+    alert('已設定為預設擷取設定');
+  } catch (e) {
+    alert('儲存失敗：' + e.message);
+  }
+}
+
 function populateWritebackDefaults() {
   const summary = resultSummary();
   if (!document.getElementById('timeline-description').value.trim()) {
@@ -592,6 +680,7 @@ async function runCheck() {
         characters,
         checks,
         styles,
+        retrieval: getRetrievalOptions(),
         chapter_file: currentChapterFile,
         chapter_title: chapterTitleFromName(currentChapterFile || document.getElementById('chapter-file-name').value.trim()),
         scene_title: currentSceneTitle
@@ -665,6 +754,7 @@ async function runRewrite(mode) {
         mode,
         characters: selectedCharacters(),
         styles: Array.from(document.querySelectorAll('[name="styles"]:checked')).map(el => el.value),
+        retrieval: getRetrievalOptions(),
         chapter_file: currentChapterFile,
         chapter_title: chapterTitleFromName(currentChapterFile || document.getElementById('chapter-file-name').value.trim()),
         scene_title: currentSceneTitle

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -118,6 +118,9 @@ const presetChecks = {{ jsonJS .DefaultChecks }};
 const presetStyles = {{ jsonJS .DefaultStyles }};
 const reviewBias = {{ jsonJS .Settings.ReviewBias }};
 const rewriteBias = {{ jsonJS .Settings.RewriteBias }};
+const retrievalSources = {{ jsonJS .Settings.RetrievalSources }};
+const retrievalTopK = {{ jsonJS .Settings.RetrievalTopK }};
+const retrievalThreshold = {{ jsonJS .Settings.RetrievalThreshold }};
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[name="default-checks"]').forEach((el) => {
@@ -135,8 +138,8 @@ async function saveSettings() {
   status.textContent = '保存中...';
   status.style.color = '#94a3b8';
 
-      try {
-        const resp = await fetch('/api/settings', {
+  try {
+    const resp = await fetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -144,6 +147,9 @@ async function saveSettings() {
         default_styles: Array.from(document.querySelectorAll('[name="default-styles"]:checked')).map(el => el.value),
         review_bias: document.getElementById('review-bias').value,
         rewrite_bias: document.getElementById('rewrite-bias').value,
+        retrieval_sources: retrievalSources,
+        retrieval_top_k: retrievalTopK,
+        retrieval_threshold: retrievalThreshold,
         ollama_url: document.getElementById('ollama-url').value.trim(),
         llm_model: document.getElementById('llm-model').value.trim(),
         embed_model: document.getElementById('embed-model').value.trim(),


### PR DESCRIPTION
## Summary

Add a retrieval control panel to the review UI so authors can choose which story knowledge sources are active and tune RAG settings per run.

## What Changed

- added persisted retrieval defaults in `review_rules.json` for source toggles, `top-k`, and similarity threshold
- added filtered vector-store querying with multi-source support and thresholding
- wired retrieval options through review and rewrite requests
- added `GET /api/settings` plus settings persistence for retrieval defaults
- added a retrieval panel to `/check` with a live summary and a "set as default" action
- added tests for retrieval settings normalization, filtered retrieval, and settings exposure

## Compatibility Fixes

While implementing issue 4, I also restored chapter/scene ordering and manuscript export wiring that would otherwise regress when this branch merges:

- restored ordering/manuscript routes in `server.go`
- restored chapter and scene ordering helpers plus tests
- restored manuscript export handling
- hardened the retrieval-default save flow so a failed settings fetch does not overwrite unrelated settings

## Why

Issue 4 requires authors to control which local canon is used during review and rewrite, and to see those retrieval settings before starting a run.

## Validation

- `go test ./...`
- `go build ./...`
