### PR TITLE
Add task-specific retrieval presets for review and rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is inspired by Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- Rewrite diff view for history entries
+- Project settings for Ollama URL, models, and default review behavior
+- Chapter bundle export with review, rewrite, timeline, foreshadow, and relationship context
+- Data backup and restore from the settings page
+- Dockerfile, docker-compose support, and `.env.example`
+- API-level e2e coverage for chapter save, review, rewrite, writeback, and history export
+
+### Changed
+
+- Chapter review and rewrite history now retains input content for later diff comparison
+- Config loading now supports environment variables and local `.env`
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,9 @@ The format is inspired by Keep a Changelog.
 
 ### Added
 
-- Rewrite diff view for history entries
-- Project settings for Ollama URL, models, and default review behavior
-- Chapter bundle export with review, rewrite, timeline, foreshadow, and relationship context
-- Data backup and restore from the settings page
-- Dockerfile, docker-compose support, and `.env.example`
-- API-level e2e coverage for chapter save, review, rewrite, writeback, and history export
-
-### Changed
-
-- Chapter review and rewrite history now retains input content for later diff comparison
-- Config loading now supports environment variables and local `.env`
+- Task-specific retrieval presets for behavior, dialogue, world, and rewrite workflows
+- Per-task retrieval overrides from the review page; overrides are only sent when the user modifies the preset
+- Preset editor in the settings page for all four task types
 
 ## [0.1.0] - 2026-04-18
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Novel Assistant combines both directions:
 - Character behavior review with streaming output
 - Dialogue style review per character
 - Writing style review with reusable `data/style/*.md` profiles
+- Rewrite modes with history-aware diff view
+- Chapter overview with review counts, tracker signals, and candidate extraction
+- Project settings page for Ollama URL, models, defaults, and backups
 - Relationship, timeline, and foreshadow trackers
 - Local vector indexing for story context retrieval
 - Markdown export for review reports
+- Chapter bundle export with review, rewrite, timeline, foreshadow, and relationship context
+- Local backup / restore for `data/`
 - Local-first design using Ollama and file-based project assets
 
 ## Review Flow
@@ -58,14 +63,14 @@ What is already solid:
 
 - Local review workflow
 - File-based story asset loading
-- Basic tests and CI
+- Unit tests, API-level e2e coverage, and CI
 - Tracker pages and export flow
 
 What is still evolving:
 
-- Richer citation display for retrieved context
-- Scene and chapter file management
-- More complete release process and packaging
+- More advanced manuscript editing ergonomics
+- Richer publishing assets and screenshots
+- Additional import / export formats
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for planned work.
 
@@ -92,6 +97,35 @@ go run ./cmd
 
 Open `http://localhost:8080`.
 
+### Environment Configuration
+
+Copy `.env.example` to `.env` and adjust values if needed:
+
+```bash
+cp .env.example .env
+```
+
+Supported variables:
+
+- `OLLAMA_URL`
+- `LLM_MODEL`
+- `EMBED_MODEL`
+- `DATA_DIR`
+- `PORT`
+
+### Docker Compose
+
+```bash
+docker compose up --build
+```
+
+This starts:
+
+- `app`: the Go web server
+- `ollama`: a local Ollama container
+
+The compose file expects a local `.env` file and mounts `./data` for persistence.
+
 ### Common Development Commands
 
 PowerShell:
@@ -109,6 +143,7 @@ Story assets live in the repository as simple files:
 
 ```text
 data/
+├── backups/         # local snapshots created from the settings page
 ├── characters/      # character profiles in Markdown
 ├── worldbuilding/   # world notes in Markdown
 ├── style/           # writing style guides in Markdown
@@ -158,9 +193,16 @@ Built-in examples:
 
 1. Maintain character, worldbuilding, and style files under `data/`
 2. Click `重新索引` to rebuild the local knowledge base
-3. Paste a single chapter or scene into the review page
-4. Select behavior, dialogue, and optional writing-style review scopes
-5. Export the review or update relationship, timeline, and foreshadow trackers
+3. Use `Chapter Overview` to inspect chapter counts, unresolved signals, and draft candidates
+4. Review or rewrite a single chapter from the review page
+5. Inspect rewrite diffs and history before saving a new chapter version
+6. Export a full chapter bundle or update relationship, timeline, and foreshadow trackers
+
+## New Workflow Pages
+
+- `Chapter Overview`: chapter counts, tracker summaries, candidate extraction, and chapter bundle export
+- `History`: grouped review / rewrite history with export, delete, diff view, and send-back-to-editor flow
+- `Settings`: Ollama and model settings, default review rules, `.env`-friendly project values, and backup / restore
 
 ## Architecture
 
@@ -183,12 +225,16 @@ Example files for onboarding and demos live in [examples/README.md](examples/REA
 
 - VSCode shows red errors but `go test` and `go build` pass:
   Open the `novel-assistant` folder directly in VSCode, not the outer `gopl.io` workspace.
+- Docker starts but review requests fail:
+  Make sure the Ollama container is healthy and the configured models have been pulled.
 - `寫作風格` has no selectable items:
   Add `.md` files under `data/style/` and reindex.
 - Review requests fail immediately:
   Verify Ollama is running locally and the configured models exist.
 - Writing style review returns a validation error:
   Make sure the selected style file exists, is not empty, and includes a `# 風格：...` heading.
+- Restored backup looks stale:
+  Restore the backup, then click `重新索引` to rebuild vector state from restored assets.
 
 ## Privacy Notes
 
@@ -203,6 +249,7 @@ Contributions are welcome.
 Start here:
 
 - [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [SECURITY.md](SECURITY.md)
 
@@ -210,11 +257,19 @@ Start here:
 
 See [CHANGELOG.md](CHANGELOG.md).
 
+## Planning Docs
+
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+- [docs/BACKLOG.md](docs/BACKLOG.md)
+- [docs/GITHUB_ISSUES.md](docs/GITHUB_ISSUES.md)
+- [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
+
 ## Release Notes
 
 Current release notes:
 
 - [v0.1.0](docs/releases/v0.1.0.md)
+- [v0.2.0 draft](docs/releases/v0.2.0.md)
 
 ## License
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -26,9 +26,14 @@ Novel Assistant 想把兩者結合：
 - 角色行為一致性審查
 - 角色對白風格審查
 - 可重複使用的 `data/style/*.md` 寫作風格審查
+- 修稿模式與歷史 diff 差異比較
+- 章節總覽、審查次數、候選訊號與草稿建立
+- 專案設定頁，可管理 Ollama、模型、預設審查與備份
 - 關係圖、時間軸、伏筆追蹤
 - 本地向量索引與 RAG 上下文提示
 - Markdown 審查報告匯出
+- 單章完整報告匯出，整合審查 / 修稿 / 時間軸 / 伏筆 / 關係
+- `data/` 備份與還原
 - 本地優先，搭配 Ollama 與檔案式故事資產
 
 ## 審查流程
@@ -58,14 +63,14 @@ flowchart TD
 
 - 本地審查主流程
 - 檔案式故事資產載入
-- 基本測試與 CI
+- 單元測試、API 級 e2e 測試與 CI
 - 追蹤頁面與匯出流程
 
 持續演進中的部分：
 
-- 更清楚的引用來源顯示
-- 場景與章節檔案管理
-- 更完整的版本發佈與封裝流程
+- 更進階的編輯體驗
+- 更完整的展示素材與專案首頁視覺
+- 更多匯入 / 匯出格式
 
 後續規劃可參考 [docs/ROADMAP.md](docs/ROADMAP.md)。
 
@@ -92,6 +97,35 @@ go run ./cmd
 
 啟動後開啟 `http://localhost:8080`。
 
+### 環境變數設定
+
+可將 `.env.example` 複製成 `.env` 後再啟動：
+
+```bash
+cp .env.example .env
+```
+
+支援的變數有：
+
+- `OLLAMA_URL`
+- `LLM_MODEL`
+- `EMBED_MODEL`
+- `DATA_DIR`
+- `PORT`
+
+### Docker Compose
+
+```bash
+docker compose up --build
+```
+
+這會啟動：
+
+- `app`：Go 網頁伺服器
+- `ollama`：本地 Ollama 容器
+
+`docker-compose.yml` 會讀取本地 `.env`，並將 `./data` 掛載成持久化資料目錄。
+
 ### 常用開發指令
 
 PowerShell：
@@ -109,6 +143,7 @@ PowerShell：
 
 ```text
 data/
+├── backups/         # 從設定頁建立的本地快照
 ├── characters/      # 角色設定 Markdown
 ├── worldbuilding/   # 世界觀 Markdown
 ├── style/           # 寫作風格 Markdown
@@ -158,9 +193,16 @@ data/
 
 1. 在 `data/` 下維護角色、世界觀與風格設定
 2. 點擊 `重新索引` 建立本地知識庫
-3. 在審查頁貼上一段單一章節或單一場景
-4. 依需求勾選行為、對白與寫作風格審查
-5. 匯出結果，或把變化補記到關係圖、時間軸與伏筆追蹤
+3. 在 `章節總覽` 查看字數、審查次數、候選角色 / 設定訊號
+4. 在審查頁檢查或修稿單一章節
+5. 在 `審查歷史` 看 diff、回填編輯器，決定是否另存新版本
+6. 匯出單章完整報告，或把變化補記到關係圖、時間軸與伏筆追蹤
+
+## 主要工作頁
+
+- `章節總覽`：查看章節狀態、候選訊號、完整報告匯出
+- `審查歷史`：分章節查看審查 / 修稿紀錄，支援 diff、刪除、匯出、回填
+- `規則設定`：集中管理 Ollama、模型、預設審查項目、風格、備份與還原
 
 ## 架構說明
 
@@ -183,12 +225,16 @@ data/
 
 - VSCode 顯示紅字，但 `go test` 和 `go build` 都正常：
   請直接用 VSCode 開 `novel-assistant` 資料夾，不要開外層 `gopl.io` workspace。
+- Docker 可以啟動，但審查送出失敗：
+  請確認 Ollama 容器已正常啟動，且所需模型已先 pull。
 - `寫作風格` 沒有可選項目：
   請確認 `data/style/` 內已有 `.md` 檔案，並重新索引。
 - 審查一送出就失敗：
   請確認 Ollama 已在本地執行，且需要的模型已安裝。
 - 寫作風格審查出現驗證錯誤：
   請確認所選風格檔存在、內容不為空，且包含 `# 風格：...` 標題。
+- 還原備份後結果看起來不對：
+  還原完成後請再點一次 `重新索引`，讓向量索引與資料快照重新同步。
 
 ## 隱私說明
 
@@ -203,6 +249,7 @@ data/
 入口文件：
 
 - [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
 - [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 - [SECURITY.md](SECURITY.md)
 
@@ -210,11 +257,19 @@ data/
 
 請見 [CHANGELOG.md](CHANGELOG.md)。
 
+## 規劃文件
+
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+- [docs/BACKLOG.md](docs/BACKLOG.md)
+- [docs/GITHUB_ISSUES.md](docs/GITHUB_ISSUES.md)
+- [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md)
+
 ## Release Notes
 
 目前版本說明：
 
 - [v0.1.0](docs/releases/v0.1.0.md)
+- [v0.2.0 草稿](docs/releases/v0.2.0.zh-TW.md)
 
 ## 授權
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,22 +1,99 @@
 # Roadmap
 
-## Near Term
+This roadmap reflects the current product direction after chapter workflow, review history, rewrite diff, project settings, Docker support, and local backup / restore were added.
 
-- Show richer citations for local RAG context
-- Improve error states and empty-state UX across review pages
-- Add tests for tracker persistence and ingest behavior
-- Add release notes and tagged versions
+## Current Focus
 
-## Next Stage
+Novel Assistant is now strongest as a local-first fiction review workstation.
 
-- Scene or chapter file management inside `data/chapters/`
-- Review history linked to exports and tracker updates
-- Style packs and reusable project templates
-- Better worldbuilding retrieval filters
+The next step is not adding more isolated features, but deepening three product layers:
 
-## Longer Term
+- manuscript structure and writing flow
+- controllable story-specific RAG behavior
+- safer long-term project management
 
-- Project import and export workflows
-- Multi-project workspace support
-- Optional plugin-style review modules
-- Packaging for easier local installation
+## Priority 1: Writing Structure
+
+Goal: move from chapter review to full manuscript organization.
+
+- Add `Chapter -> Scene` hierarchy instead of chapter-only files
+- Build a scene board with synopsis, POV, conflict, and purpose fields
+- Support drag-and-drop reordering for chapters and scenes
+- Show per-scene status such as reviewed, rewritten, unresolved, or needs worldbuilding
+- Let exports assemble a full manuscript from selected scenes
+
+Why this matters:
+
+- `novelWriter` and `Manuskript` both feel powerful because they help authors shape structure, not just inspect text
+- this is the clearest gap between Novel Assistant and mature fiction-writing tools
+
+## Priority 2: Story-RAG Control
+
+Goal: make retrieval more predictable, tunable, and trustworthy.
+
+- Add per-source toggles for character, worldbuilding, style, and chapter context
+- Add retrieval controls such as `top-k` and minimum similarity threshold
+- Add task-specific retrieval presets for behavior review, dialogue review, rewrite, and world conflict checks
+- Show expected-but-missed context when a likely source was not retrieved
+- Add source weighting or priority so critical canon files are harder to ignore
+
+Why this matters:
+
+- `AnythingLLM` style workspace behavior and clear citations make systems feel dependable
+- controllable retrieval is one of the most important differences between a clever demo and a serious writing tool
+
+## Priority 3: Manuscript Build and Delivery
+
+Goal: export writing projects in formats closer to real author workflows.
+
+- Build full-manuscript export across chapters and scenes
+- Export to multiple targets such as `Markdown`, `HTML`, `DOCX`, and `PDF`
+- Offer optional appendices for review notes, rewrite summaries, and tracker state
+- Support chapter bundles filtered by draft state or scene tags
+- Add shareable review packets for editors or beta readers
+
+Why this matters:
+
+- mature writing tools do not stop at editing; they help produce the manuscript you actually send out
+
+## Priority 4: Multi-Project Safety
+
+Goal: make the app safe for heavier long-term usage.
+
+- Add project / workspace isolation instead of a single `data/` root
+- Add per-project settings and independent vector stores
+- Add project import / export and migration helpers
+- Add safer restore flows with preview before overwrite
+- Add automatic snapshot rotation and restore history
+
+Why this matters:
+
+- once writers trust a tool with months of story work, project safety becomes as important as model quality
+
+## Priority 5: Mature App Surface
+
+Goal: reduce friction for adoption and maintenance.
+
+- Add authenticated mode or optional local access protection
+- Add richer screenshots and onboarding docs
+- Add package / installer paths beyond `go run` and Docker
+- Add metrics or debug views for index size, retrieval quality, and model latency
+- Add compatibility notes for Windows, macOS, Linux, and containerized setups
+
+## Suggested Build Order
+
+If development continues in sequence, this is the recommended order:
+
+1. Scene hierarchy and scene board
+2. Retrieval controls and source weighting
+3. Full manuscript export
+4. Multi-project workspace support
+5. Optional local auth and stronger operations tooling
+
+## References
+
+The roadmap direction is especially informed by the strengths of:
+
+- `novelWriter` for chapters, scenes, structure, and manuscript build
+- `Manuskript` for outlines, index cards, and story organization
+- `AnythingLLM` for workspace and retrieval ergonomics

--- a/internal/reviewrules/store.go
+++ b/internal/reviewrules/store.go
@@ -8,13 +8,20 @@ import (
 )
 
 type Settings struct {
-	DefaultChecks      []string `json:"default_checks"`
-	DefaultStyles      []string `json:"default_styles"`
-	ReviewBias         string   `json:"review_bias"`
-	RewriteBias        string   `json:"rewrite_bias"`
-	RetrievalSources   []string `json:"retrieval_sources"`
-	RetrievalTopK      int      `json:"retrieval_top_k"`
-	RetrievalThreshold float64  `json:"retrieval_threshold"`
+	DefaultChecks      []string                   `json:"default_checks"`
+	DefaultStyles      []string                   `json:"default_styles"`
+	ReviewBias         string                     `json:"review_bias"`
+	RewriteBias        string                     `json:"rewrite_bias"`
+	RetrievalSources   []string                   `json:"retrieval_sources"`
+	RetrievalTopK      int                        `json:"retrieval_top_k"`
+	RetrievalThreshold float64                    `json:"retrieval_threshold"`
+	Presets            map[string]RetrievalPreset `json:"presets,omitempty"`
+}
+
+type RetrievalPreset struct {
+	Sources   []string `json:"sources"`
+	TopK      int      `json:"top_k"`
+	Threshold float64  `json:"threshold"`
 }
 
 type Store struct {
@@ -31,6 +38,12 @@ func Defaults() Settings {
 		RetrievalSources:   []string{"character", "world", "style"},
 		RetrievalTopK:      4,
 		RetrievalThreshold: 0,
+		Presets: map[string]RetrievalPreset{
+			"behavior": {Sources: []string{"character", "world"}, TopK: 4, Threshold: 0},
+			"dialogue": {Sources: []string{"character"}, TopK: 3, Threshold: 0},
+			"world":    {Sources: []string{"world"}, TopK: 4, Threshold: 0},
+			"rewrite":  {Sources: []string{"character", "world", "style"}, TopK: 5, Threshold: 0},
+		},
 	}
 }
 
@@ -124,6 +137,37 @@ func normalize(item Settings) Settings {
 	if item.RetrievalThreshold < 0 || item.RetrievalThreshold > 1 {
 		item.RetrievalThreshold = def.RetrievalThreshold
 	}
+
+	validPresetKeys := map[string]struct{}{
+		"behavior": {},
+		"dialogue": {},
+		"world":    {},
+		"rewrite":  {},
+	}
+	if item.Presets == nil {
+		item.Presets = make(map[string]RetrievalPreset)
+	}
+	for key, preset := range item.Presets {
+		if _, ok := validPresetKeys[key]; !ok {
+			delete(item.Presets, key)
+			continue
+		}
+		preset.Sources = normalizePresetSources(preset.Sources, def.RetrievalSources, allowed)
+		if preset.TopK < 1 || preset.TopK > 20 {
+			preset.TopK = def.RetrievalTopK
+		}
+		if preset.Threshold < 0 || preset.Threshold > 1 {
+			preset.Threshold = def.RetrievalThreshold
+		}
+		item.Presets[key] = preset
+	}
+	for key, preset := range def.Presets {
+		if _, ok := item.Presets[key]; ok {
+			continue
+		}
+		preset.Sources = append([]string(nil), preset.Sources...)
+		item.Presets[key] = preset
+	}
 	return item
 }
 
@@ -131,7 +175,44 @@ func clone(item Settings) Settings {
 	item.DefaultChecks = append([]string(nil), item.DefaultChecks...)
 	item.DefaultStyles = append([]string(nil), item.DefaultStyles...)
 	item.RetrievalSources = append([]string(nil), item.RetrievalSources...)
+	if item.Presets != nil {
+		cloned := make(map[string]RetrievalPreset, len(item.Presets))
+		for key, preset := range item.Presets {
+			preset.Sources = append([]string(nil), preset.Sources...)
+			cloned[key] = preset
+		}
+		item.Presets = cloned
+	}
 	return item
+}
+
+// PresetFor returns the retrieval preset for a task, falling back to global settings.
+func (s *Store) PresetFor(task string) RetrievalPreset {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if preset, ok := s.item.Presets[task]; ok {
+		preset.Sources = append([]string(nil), preset.Sources...)
+		return preset
+	}
+	return RetrievalPreset{
+		Sources:   append([]string(nil), s.item.RetrievalSources...),
+		TopK:      s.item.RetrievalTopK,
+		Threshold: s.item.RetrievalThreshold,
+	}
+}
+
+func normalizePresetSources(sources, fallback []string, allowed map[string]struct{}) []string {
+	filtered := make([]string, 0, len(sources))
+	for _, source := range uniqueNonEmpty(sources) {
+		if _, ok := allowed[source]; ok {
+			filtered = append(filtered, source)
+		}
+	}
+	if len(filtered) == 0 {
+		return append([]string(nil), fallback...)
+	}
+	return filtered
 }
 
 func uniqueNonEmpty(items []string) []string {

--- a/internal/reviewrules/store_test.go
+++ b/internal/reviewrules/store_test.go
@@ -2,6 +2,7 @@ package reviewrules
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -77,5 +78,45 @@ func TestNormalizeRetrievalSourcesFallbackToDefaults(t *testing.T) {
 
 	if len(item.RetrievalSources) != len(Defaults().RetrievalSources) {
 		t.Fatalf("expected default retrieval sources, got %#v", item.RetrievalSources)
+	}
+}
+
+func TestPresetFor(t *testing.T) {
+	t.Parallel()
+
+	store := New(filepath.Join(t.TempDir(), "review_rules.json"))
+
+	preset := store.PresetFor("behavior")
+	if !slices.Contains(preset.Sources, "character") {
+		t.Fatal("behavior preset should include character")
+	}
+	if slices.Contains(preset.Sources, "style") {
+		t.Fatal("behavior preset should not include style")
+	}
+
+	fallback := store.PresetFor("unknown")
+	if fallback.TopK != Defaults().RetrievalTopK {
+		t.Fatal("unknown task should fallback to global default")
+	}
+}
+
+func TestNormalizePresets(t *testing.T) {
+	t.Parallel()
+
+	item := normalize(Settings{
+		Presets: map[string]RetrievalPreset{
+			"behavior": {Sources: []string{"character", "invalid_source"}, TopK: 0, Threshold: -1},
+		},
+	})
+
+	preset := item.Presets["behavior"]
+	if slices.Contains(preset.Sources, "invalid_source") {
+		t.Fatal("invalid source should be filtered")
+	}
+	if preset.TopK < 1 {
+		t.Fatal("TopK should be normalized to default")
+	}
+	if len(item.Presets) != len(Defaults().Presets) {
+		t.Fatalf("expected missing presets to be backfilled, got %#v", item.Presets)
 	}
 }

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -218,6 +218,17 @@ func TestGetSettingsReturnsRetrievalDefaults(t *testing.T) {
 	if !ok || len(sources) != 3 {
 		t.Fatalf("expected retrieval_sources in response, got %#v", payload["retrieval_sources"])
 	}
+	presets, ok := payload["presets"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected presets in response, got %#v", payload["presets"])
+	}
+	dialogue, ok := presets["dialogue"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected dialogue preset, got %#v", presets["dialogue"])
+	}
+	if got := dialogue["top_k"]; got != float64(3) {
+		t.Fatalf("expected dialogue top_k=3, got %#v", got)
+	}
 }
 
 func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -477,14 +477,15 @@ func (s *Server) handleIngest(c *gin.Context) {
 // ─── check stream ─────────────────────────────────────────────────────────────
 
 type checkRequest struct {
-	Chapter      string           `json:"chapter"`
-	Characters   []string         `json:"characters"`
-	Checks       []string         `json:"checks"` // ["behavior","dialogue","style","world"]
-	Styles       []string         `json:"styles"` // style guide names to apply; empty = all styles
-	Retrieval    retrievalOptions `json:"retrieval"`
-	ChapterFile  string           `json:"chapter_file"`
-	ChapterTitle string           `json:"chapter_title"`
-	SceneTitle   string           `json:"scene_title,omitempty"` // empty = full chapter
+	Chapter            string                      `json:"chapter"`
+	Characters         []string                    `json:"characters"`
+	Checks             []string                    `json:"checks"` // ["behavior","dialogue","style","world"]
+	Styles             []string                    `json:"styles"` // style guide names to apply; empty = all styles
+	Retrieval          retrievalOptions            `json:"retrieval"`
+	RetrievalOverrides map[string]retrievalOptions `json:"retrieval_overrides,omitempty"`
+	ChapterFile        string                      `json:"chapter_file"`
+	ChapterTitle       string                      `json:"chapter_title"`
+	SceneTitle         string                      `json:"scene_title,omitempty"` // empty = full chapter
 }
 
 type retrievalOptions struct {
@@ -492,6 +493,13 @@ type retrievalOptions struct {
 	TopK         int      `json:"top_k"`
 	Threshold    float64  `json:"threshold"`
 	ThresholdSet bool     `json:"threshold_set,omitempty"`
+}
+
+func (r checkRequest) retrievalOverrideFor(task string) retrievalOptions {
+	if override, ok := r.RetrievalOverrides[task]; ok {
+		return override
+	}
+	return r.Retrieval
 }
 
 func (s *Server) handleCheckStream(c *gin.Context) {
@@ -533,7 +541,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		var err error
 
 		if len(req.Checks) == 0 || contains(req.Checks, "behavior") {
-			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("behavior"), req.Retrieval))
+			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior")))
 			if err != nil {
 				text := fmt.Sprintf("\n> 行為審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)
@@ -541,7 +549,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			}
 		}
 		if contains(req.Checks, "dialogue") {
-			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("dialogue"), req.Retrieval))
+			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue")))
 			if err != nil {
 				text := fmt.Sprintf("\n> 對白審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)
@@ -549,7 +557,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			}
 		}
 		if contains(req.Checks, "world") {
-			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("world"), req.Retrieval))
+			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world")))
 			if err != nil {
 				text := fmt.Sprintf("\n> 世界觀審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -10,6 +10,7 @@ import (
 	"novel-assistant/internal/exporter"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"strconv"
 	"strings"
@@ -126,6 +127,24 @@ func excerptText(content string) string {
 	return compacted[:120] + "..."
 }
 
+func mergeRetrieval(preset reviewrules.RetrievalPreset, override retrievalOptions) retrievalOptions {
+	result := retrievalOptions{
+		Sources:   append([]string(nil), preset.Sources...),
+		TopK:      preset.TopK,
+		Threshold: preset.Threshold,
+	}
+	if len(override.Sources) > 0 {
+		result.Sources = append([]string(nil), override.Sources...)
+	}
+	if override.TopK >= 1 {
+		result.TopK = override.TopK
+	}
+	if override.ThresholdSet {
+		result.Threshold = override.Threshold
+	}
+	return result
+}
+
 func summarizeReferences(items []vectorProfile) []referenceSummary {
 	summaries := make([]referenceSummary, 0, len(items))
 	for _, item := range items {
@@ -157,6 +176,22 @@ func filterReferencesByType(items []vectorProfile, refType string) []vectorProfi
 		}
 	}
 	return filtered
+}
+
+func mergeReferenceLists(groups ...[]vectorProfile) []vectorProfile {
+	seen := make(map[string]struct{})
+	merged := make([]vectorProfile, 0)
+	for _, group := range groups {
+		for _, item := range group {
+			key := item.Type + "\x00" + item.Name
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, item)
+		}
+	}
+	return merged
 }
 
 func joinWorldProfiles(refs []vectorProfile, worlds []*profile.WorldSetting) string {
@@ -453,9 +488,10 @@ type checkRequest struct {
 }
 
 type retrievalOptions struct {
-	Sources   []string `json:"sources"`
-	TopK      int      `json:"top_k"`
-	Threshold float64  `json:"threshold"`
+	Sources      []string `json:"sources"`
+	TopK         int      `json:"top_k"`
+	Threshold    float64  `json:"threshold"`
+	ThresholdSet bool     `json:"threshold_set,omitempty"`
 }
 
 func (s *Server) handleCheckStream(c *gin.Context) {
@@ -491,13 +527,38 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			return
 		}
 
-		references, err := s.buildReferenceContext(ctx, req.Chapter, req.Retrieval)
-		if err != nil {
-			text := fmt.Sprintf("\n> RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
-			transcript.WriteString(text)
-			msgChan <- streamEvent{Event: "chunk", Text: text}
-			msgChan <- streamEvent{Event: "sources", Sources: nil}
-		} else if len(references) > 0 {
+		var behaviorRefs []vectorProfile
+		var dialogueRefs []vectorProfile
+		var worldRefs []vectorProfile
+		var err error
+
+		if len(req.Checks) == 0 || contains(req.Checks, "behavior") {
+			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("behavior"), req.Retrieval))
+			if err != nil {
+				text := fmt.Sprintf("\n> 行為審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			}
+		}
+		if contains(req.Checks, "dialogue") {
+			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("dialogue"), req.Retrieval))
+			if err != nil {
+				text := fmt.Sprintf("\n> 對白審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			}
+		}
+		if contains(req.Checks, "world") {
+			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("world"), req.Retrieval))
+			if err != nil {
+				text := fmt.Sprintf("\n> 世界觀審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			}
+		}
+
+		references := mergeReferenceLists(behaviorRefs, dialogueRefs, worldRefs)
+		if len(references) > 0 {
 			msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
 			transcript.WriteString("### 本地參考上下文\n\n")
 			msgChan <- streamEvent{Event: "chunk", Text: "### 本地參考上下文\n\n"}
@@ -512,8 +573,9 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			msgChan <- streamEvent{Event: "sources", Sources: nil}
 		}
 
-		referenceText := joinProfiles(references)
-		worldText := joinWorldProfiles(filterReferencesByType(references, "world"), s.profiles.Worlds)
+		behaviorRefText := joinProfiles(behaviorRefs)
+		dialogueRefText := joinProfiles(dialogueRefs)
+		worldText := joinWorldProfiles(filterReferencesByType(worldRefs, "world"), s.profiles.Worlds)
 		if contains(req.Checks, "world") {
 			if strings.TrimSpace(worldText) == "" {
 				text := "\n> 尚無世界觀設定可供審查，請先新增 worldbuilding 檔案或重新索引。\n"
@@ -544,8 +606,8 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 				msgChan <- streamEvent{Event: "chunk", Text: "### 行為一致性審查\n\n"}
 				profileText := char.RawContent
 				profileText += "\n\n【審查偏好】\n" + reviewBias
-				if referenceText != "" {
-					profileText += "\n\n【補充參考資料】\n" + referenceText
+				if behaviorRefText != "" {
+					profileText += "\n\n【補充參考資料】\n" + behaviorRefText
 				}
 				if err := s.checker.CheckBehaviorStream(ctx, profileText, req.Chapter, cw); err != nil {
 					if ctx.Err() == nil {
@@ -565,6 +627,9 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 					dialogueStyle += "；"
 				}
 				dialogueStyle += reviewBias
+				if dialogueRefText != "" {
+					dialogueStyle += "\n\n【補充參考資料】\n" + dialogueRefText
+				}
 				if err := s.checker.CheckDialogueStream(ctx, char.Name, char.Personality, dialogueStyle, req.Chapter, cw); err != nil {
 					if ctx.Err() == nil {
 						text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
@@ -707,7 +772,7 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer close(msgChan)
 		defer cancel()
 
-		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.Retrieval)
+		references, refErr := s.buildReferenceContext(ctx, req.Chapter, mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval))
 		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		if refErr != nil {
 			text := fmt.Sprintf("\n> RAG 參考載入失敗，改用基礎模式繼續：%s\n", refErr.Error())

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -162,3 +162,33 @@ func TestMergeRetrievalAllowsThresholdOverrideToZero(t *testing.T) {
 		t.Fatalf("expected threshold override to zero, got %#v", got)
 	}
 }
+
+func TestCheckRequestRetrievalOverrideForTask(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Retrieval: retrievalOptions{
+			Sources:   []string{"character"},
+			TopK:      4,
+			Threshold: 0.1,
+		},
+		RetrievalOverrides: map[string]retrievalOptions{
+			"world": {
+				Sources:      []string{"world"},
+				TopK:         2,
+				Threshold:    0,
+				ThresholdSet: true,
+			},
+		},
+	}
+
+	world := req.retrievalOverrideFor("world")
+	if len(world.Sources) != 1 || world.Sources[0] != "world" || world.TopK != 2 || !world.ThresholdSet {
+		t.Fatalf("expected task-specific override, got %#v", world)
+	}
+
+	behavior := req.retrievalOverrideFor("behavior")
+	if len(behavior.Sources) != 1 || behavior.Sources[0] != "character" || behavior.TopK != 4 {
+		t.Fatalf("expected fallback to shared retrieval, got %#v", behavior)
+	}
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"novel-assistant/internal/profile"
+	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/vectorstore"
 	"testing"
 )
@@ -113,5 +114,51 @@ func TestBuildReferenceContextReturnsNilWhenStoreIsEmpty(t *testing.T) {
 	}
 	if refs != nil {
 		t.Fatalf("expected nil refs for empty store, got %#v", refs)
+	}
+}
+
+func TestMergeRetrievalUsesPresetUntilOverrideProvided(t *testing.T) {
+	t.Parallel()
+
+	preset := reviewrules.RetrievalPreset{
+		Sources:   []string{"character", "world"},
+		TopK:      4,
+		Threshold: 0.25,
+	}
+
+	got := mergeRetrieval(preset, retrievalOptions{})
+	if len(got.Sources) != 2 || got.TopK != 4 || got.Threshold != 0.25 {
+		t.Fatalf("expected preset values to survive zero-value override, got %#v", got)
+	}
+
+	got = mergeRetrieval(preset, retrievalOptions{
+		Sources:      []string{"style"},
+		TopK:         2,
+		Threshold:    0.8,
+		ThresholdSet: true,
+	})
+	if len(got.Sources) != 1 || got.Sources[0] != "style" {
+		t.Fatalf("expected sources override, got %#v", got.Sources)
+	}
+	if got.TopK != 2 || got.Threshold != 0.8 {
+		t.Fatalf("expected numeric overrides, got %#v", got)
+	}
+}
+
+func TestMergeRetrievalAllowsThresholdOverrideToZero(t *testing.T) {
+	t.Parallel()
+
+	preset := reviewrules.RetrievalPreset{
+		Sources:   []string{"world"},
+		TopK:      4,
+		Threshold: 0.6,
+	}
+
+	got := mergeRetrieval(preset, retrievalOptions{
+		Threshold:    0,
+		ThresholdSet: true,
+	})
+	if got.Threshold != 0 {
+		t.Fatalf("expected threshold override to zero, got %#v", got)
 	}
 }

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -12,17 +12,18 @@ import (
 )
 
 type settingsSaveRequest struct {
-	DefaultChecks      []string `json:"default_checks"`
-	DefaultStyles      []string `json:"default_styles"`
-	ReviewBias         string   `json:"review_bias"`
-	RewriteBias        string   `json:"rewrite_bias"`
-	RetrievalSources   []string `json:"retrieval_sources"`
-	RetrievalTopK      int      `json:"retrieval_top_k"`
-	RetrievalThreshold float64  `json:"retrieval_threshold"`
-	OllamaURL          string   `json:"ollama_url"`
-	LLMModel           string   `json:"llm_model"`
-	EmbedModel         string   `json:"embed_model"`
-	Port               string   `json:"port"`
+	DefaultChecks      []string                               `json:"default_checks"`
+	DefaultStyles      []string                               `json:"default_styles"`
+	ReviewBias         string                                 `json:"review_bias"`
+	RewriteBias        string                                 `json:"rewrite_bias"`
+	RetrievalSources   []string                               `json:"retrieval_sources"`
+	RetrievalTopK      int                                    `json:"retrieval_top_k"`
+	RetrievalThreshold float64                                `json:"retrieval_threshold"`
+	Presets            map[string]reviewrules.RetrievalPreset `json:"presets,omitempty"`
+	OllamaURL          string                                 `json:"ollama_url"`
+	LLMModel           string                                 `json:"llm_model"`
+	EmbedModel         string                                 `json:"embed_model"`
+	Port               string                                 `json:"port"`
 }
 
 func (s *Server) handleSettingsPage(c *gin.Context) {
@@ -51,6 +52,7 @@ func (s *Server) handleGetSettings(c *gin.Context) {
 		"retrieval_sources":   rules.RetrievalSources,
 		"retrieval_top_k":     rules.RetrievalTopK,
 		"retrieval_threshold": rules.RetrievalThreshold,
+		"presets":             rules.Presets,
 		"ollama_url":          project.OllamaURL,
 		"llm_model":           project.LLMModel,
 		"embed_model":         project.EmbedModel,
@@ -73,6 +75,7 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		RetrievalSources:   req.RetrievalSources,
 		RetrievalTopK:      req.RetrievalTopK,
 		RetrievalThreshold: req.RetrievalThreshold,
+		Presets:            req.Presets,
 	})
 	if err := s.rules.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "規則設定保存失敗"})

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -695,6 +695,18 @@ function getRetrievalOptions() {
   };
 }
 
+function buildCheckRetrievalOverrides(checks) {
+  if (!retrievalDirty) {
+    return {};
+  }
+  if (!checks.includes(activeRetrievalTask)) {
+    return {};
+  }
+  return {
+    [activeRetrievalTask]: getRetrievalOptions(),
+  };
+}
+
 function getCurrentRetrievalInputs() {
   return {
     sources: Array.from(document.querySelectorAll('[name="retrieval-source"]:checked')).map(el => el.value),
@@ -749,6 +761,7 @@ async function runCheck() {
   const characters = selectedCharacters();
   const checks = Array.from(document.querySelectorAll('[name="checks"]:checked')).map(el => el.value);
   const styles = Array.from(document.querySelectorAll('[name="styles"]:checked')).map(el => el.value);
+  const retrievalOverrides = buildCheckRetrievalOverrides(checks);
   const resultBox = document.getElementById('result-box');
   const submitBtn = document.getElementById('submit-btn');
   document.getElementById('rewrite-box').textContent = '尚未執行修稿模式。';
@@ -769,7 +782,7 @@ async function runCheck() {
         characters,
         checks,
         styles,
-        retrieval: getRetrievalOptions(),
+        retrieval_overrides: retrievalOverrides,
         chapter_file: currentChapterFile,
         chapter_title: chapterTitleFromName(currentChapterFile || document.getElementById('chapter-file-name').value.trim()),
         scene_title: currentSceneTitle

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -45,7 +45,23 @@
 
         <div class="card">
           <h2>RAG 擷取設定</h2>
-          <p class="helper-text">控制哪些知識來源會被納入本次審查的參考上下文。</p>
+          <p class="helper-text">依任務 preset 載入預設值；只有在你手動修改後，才會把 override 送到後端。</p>
+
+          <div class="grid-2">
+            <div class="form-group">
+              <label for="retrieval-task">目前調整的任務 preset</label>
+              <select id="retrieval-task">
+                <option value="behavior">行為一致性</option>
+                <option value="dialogue">對白風格</option>
+                <option value="world">世界觀衝突</option>
+                <option value="rewrite">修稿</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label>&nbsp;</label>
+              <button class="btn btn-ghost" type="button" onclick="resetRetrievalToPreset()">重設為 preset 預設值</button>
+            </div>
+          </div>
 
           <div id="retrieval-summary" class="helper-text" style="margin-bottom:12px;font-weight:600"></div>
 
@@ -77,8 +93,6 @@
               <input type="range" id="retrieval-threshold" min="0" max="1" step="0.01" value="{{.RetrievalThreshold}}" oninput="document.getElementById('threshold-display').textContent=parseFloat(this.value).toFixed(2);updateRetrievalSummary()">
             </div>
           </div>
-
-          <button class="btn btn-ghost" type="button" onclick="saveRetrievalDefaults()">設為預設</button>
         </div>
 
         <div class="card">
@@ -283,6 +297,15 @@ let loadedScenes = [];
 let loadedHistoryEntry = null;
 const presetChecks = {{ jsonJS .DefaultChecks }};
 const presetStyles = {{ jsonJS .DefaultStyles }};
+const initialRetrieval = {
+  sources: {{ jsonJS .RetrievalSources }},
+  top_k: {{ jsonJS .RetrievalTopK }},
+  threshold: {{ jsonJS .RetrievalThreshold }},
+};
+let retrievalPresets = {};
+let activeRetrievalTask = 'behavior';
+let currentPresetSnapshot = cloneRetrieval(initialRetrieval);
+let retrievalDirty = false;
 
 document.addEventListener('DOMContentLoaded', () => {
   const styleCheck = document.getElementById('check-style');
@@ -293,20 +316,84 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   document.querySelectorAll('[name="checks"]').forEach((el) => {
     el.checked = presetChecks.includes(el.value);
+    el.addEventListener('change', syncRetrievalTaskFromChecks);
   });
   document.querySelectorAll('[name="styles"]').forEach((el) => {
     el.checked = presetStyles.includes(el.value);
   });
   document.querySelectorAll('[name="retrieval-source"]').forEach((el) => {
-    el.addEventListener('change', updateRetrievalSummary);
+    el.addEventListener('change', handleRetrievalInputChange);
   });
-  document.getElementById('retrieval-topk').addEventListener('input', updateRetrievalSummary);
+  document.getElementById('retrieval-topk').addEventListener('input', handleRetrievalInputChange);
+  document.getElementById('retrieval-threshold').addEventListener('input', handleRetrievalInputChange);
+  document.getElementById('retrieval-task').addEventListener('change', (event) => {
+    setActiveRetrievalTask(event.target.value);
+  });
   if (styleCheck) {
     document.getElementById('style-selector').style.display = styleCheck.checked ? 'block' : 'none';
   }
-  updateRetrievalSummary();
+  loadRetrievalPresets();
   hydrateFromHistory();
 });
+
+function cloneRetrieval(opts) {
+  return {
+    sources: Array.isArray(opts?.sources) ? [...opts.sources] : [],
+    top_k: Number(opts?.top_k) || 0,
+    threshold: Number(opts?.threshold) || 0,
+  };
+}
+
+function retrievalEqual(left, right) {
+  const leftSources = [...(left?.sources || [])].sort();
+  const rightSources = [...(right?.sources || [])].sort();
+  return JSON.stringify(leftSources) === JSON.stringify(rightSources)
+    && Number(left?.top_k || 0) === Number(right?.top_k || 0)
+    && Number(left?.threshold || 0) === Number(right?.threshold || 0);
+}
+
+function normalizeTaskPreset(task) {
+  return cloneRetrieval(retrievalPresets[task] || initialRetrieval);
+}
+
+function fillRetrievalInputs(opts) {
+  const wanted = new Set(opts.sources || []);
+  document.querySelectorAll('[name="retrieval-source"]').forEach((el) => {
+    el.checked = wanted.has(el.value);
+  });
+  document.getElementById('retrieval-topk').value = Number(opts.top_k) || initialRetrieval.top_k;
+  document.getElementById('retrieval-threshold').value = Number(opts.threshold) || 0;
+  document.getElementById('threshold-display').textContent = Number(opts.threshold || 0).toFixed(2);
+}
+
+async function loadRetrievalPresets() {
+  try {
+    const resp = await fetch('/api/settings');
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '載入 retrieval presets 失敗');
+    retrievalPresets = data.presets || {};
+  } catch (e) {
+    retrievalPresets = {};
+    console.error(e);
+  } finally {
+    syncRetrievalTaskFromChecks();
+  }
+}
+
+function setActiveRetrievalTask(task) {
+  activeRetrievalTask = task || 'behavior';
+  document.getElementById('retrieval-task').value = activeRetrievalTask;
+  currentPresetSnapshot = normalizeTaskPreset(activeRetrievalTask);
+  retrievalDirty = false;
+  fillRetrievalInputs(currentPresetSnapshot);
+  updateRetrievalSummary();
+}
+
+function syncRetrievalTaskFromChecks() {
+  const checked = Array.from(document.querySelectorAll('[name="checks"]:checked')).map((el) => el.value);
+  const next = checked.find((value) => ['behavior', 'dialogue', 'world'].includes(value)) || activeRetrievalTask || 'behavior';
+  setActiveRetrievalTask(next);
+}
 
 function chapterTitleFromName(name) {
   return (name || '').replace(/\.md$/i, '');
@@ -593,48 +680,50 @@ function selectedCharacters() {
 }
 
 function getRetrievalOptions() {
+  if (!retrievalDirty) {
+    return {
+      sources: [],
+      top_k: 0,
+      threshold: 0,
+      threshold_set: false,
+    };
+  }
+  const current = getCurrentRetrievalInputs();
+  return {
+    ...current,
+    threshold_set: Number(current.threshold) !== Number(currentPresetSnapshot.threshold),
+  };
+}
+
+function getCurrentRetrievalInputs() {
   return {
     sources: Array.from(document.querySelectorAll('[name="retrieval-source"]:checked')).map(el => el.value),
-    top_k: Math.max(1, Number(document.getElementById('retrieval-topk').value) || 4),
+    top_k: Math.max(1, Number(document.getElementById('retrieval-topk').value) || initialRetrieval.top_k),
     threshold: Number(document.getElementById('retrieval-threshold').value) || 0,
   };
 }
 
-function updateRetrievalSummary() {
-  const opts = getRetrievalOptions();
-  const labels = { character: '角色', world: '世界觀', style: '風格' };
-  const srcStr = opts.sources.length ? opts.sources.map(s => labels[s] || s).join('、') : '（無）';
-  document.getElementById('retrieval-summary').textContent =
-    '來源：' + srcStr + '　Top-K：' + opts.top_k + '　門檻：' + opts.threshold.toFixed(2);
+function handleRetrievalInputChange() {
+  document.getElementById('threshold-display').textContent =
+    Number(document.getElementById('retrieval-threshold').value || 0).toFixed(2);
+  retrievalDirty = !retrievalEqual(getCurrentRetrievalInputs(), currentPresetSnapshot);
+  updateRetrievalSummary();
 }
 
-async function saveRetrievalDefaults() {
-  const opts = getRetrievalOptions();
-  try {
-    const current = await fetch('/api/settings')
-      .then(async (r) => {
-        if (!r.ok) {
-          const data = await r.json().catch(() => ({}));
-          throw new Error(data.error || '讀取現有設定失敗');
-        }
-        return r.json();
-      });
-    const body = Object.assign({}, current, {
-      retrieval_sources: opts.sources,
-      retrieval_top_k: opts.top_k,
-      retrieval_threshold: opts.threshold,
-    });
-    const resp = await fetch('/api/settings', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body)
-    });
-    const data = await resp.json();
-    if (!resp.ok) throw new Error(data.error || '儲存失敗');
-    alert('已設定為預設擷取設定');
-  } catch (e) {
-    alert('儲存失敗：' + e.message);
-  }
+function resetRetrievalToPreset() {
+  currentPresetSnapshot = normalizeTaskPreset(activeRetrievalTask);
+  retrievalDirty = false;
+  fillRetrievalInputs(currentPresetSnapshot);
+  updateRetrievalSummary();
+}
+
+function updateRetrievalSummary() {
+  const opts = getCurrentRetrievalInputs();
+  const labels = { character: '角色', world: '世界觀', style: '風格' };
+  const srcStr = opts.sources.length ? opts.sources.map(s => labels[s] || s).join('、') : '（無）';
+  const modeText = retrievalDirty ? '已覆蓋 preset' : '沿用 preset';
+  document.getElementById('retrieval-summary').textContent =
+    '任務：' + activeRetrievalTask + '　' + modeText + '　來源：' + srcStr + '　Top-K：' + opts.top_k + '　門檻：' + opts.threshold.toFixed(2);
 }
 
 function populateWritebackDefaults() {
@@ -741,6 +830,16 @@ async function runCheck() {
 async function runRewrite(mode) {
   const chapter = document.getElementById('chapter').value.trim();
   if (!chapter) { alert('請先輸入章節內容'); return; }
+  const pendingRetrieval = getCurrentRetrievalInputs();
+  const hadDirtyRetrieval = retrievalDirty;
+  if (activeRetrievalTask !== 'rewrite') {
+    setActiveRetrievalTask('rewrite');
+    if (hadDirtyRetrieval) {
+      fillRetrievalInputs(pendingRetrieval);
+      retrievalDirty = !retrievalEqual(pendingRetrieval, currentPresetSnapshot);
+      updateRetrievalSummary();
+    }
+  }
 
   const rewriteBox = document.getElementById('rewrite-box');
   rewriteBox.textContent = '修稿中...\n';

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -108,6 +108,35 @@
     </div>
 
     <div class="card">
+      <h2>全域 Retrieval 設定</h2>
+      <p class="helper-text">作為各任務 preset 的後備值；當 preset 欄位無效或缺漏時，會回退到這裡。</p>
+      <div class="form-group">
+        <label>啟用來源</label>
+        <div class="checkbox-group">
+          <label class="checkbox-label"><input type="checkbox" name="global-retrieval-source" value="character">角色設定</label>
+          <label class="checkbox-label"><input type="checkbox" name="global-retrieval-source" value="world">世界觀</label>
+          <label class="checkbox-label"><input type="checkbox" name="global-retrieval-source" value="style">寫作風格</label>
+        </div>
+      </div>
+      <div class="grid-2">
+        <div class="form-group">
+          <label for="global-retrieval-topk">Top-K（最多取幾筆）</label>
+          <input type="number" id="global-retrieval-topk" min="1" max="20">
+        </div>
+        <div class="form-group">
+          <label for="global-retrieval-threshold">相似度門檻 <span id="global-threshold-display">0.00</span></label>
+          <input type="range" id="global-retrieval-threshold" min="0" max="1" step="0.01">
+        </div>
+      </div>
+    </div>
+
+    <section class="card" id="retrieval-presets-section">
+      <h2>各任務 Retrieval Preset</h2>
+      <p class="helper-text">每種審查類型的預設 retrieval 策略；可各自指定來源、Top-K 與相似度門檻。</p>
+      <div id="retrieval-preset-list"></div>
+    </section>
+
+    <div class="card">
       <button class="btn" type="button" onclick="saveSettings()">儲存規則設定</button>
       <div id="settings-status" class="helper-text">調整後會立即套用到後續的審查與修稿流程。</div>
     </div>
@@ -121,6 +150,13 @@ const rewriteBias = {{ jsonJS .Settings.RewriteBias }};
 const retrievalSources = {{ jsonJS .Settings.RetrievalSources }};
 const retrievalTopK = {{ jsonJS .Settings.RetrievalTopK }};
 const retrievalThreshold = {{ jsonJS .Settings.RetrievalThreshold }};
+const retrievalPresets = {{ jsonJS .Settings.Presets }} || {};
+const presetTasks = [
+  { key: 'behavior', label: '行為一致性' },
+  { key: 'dialogue', label: '對白風格' },
+  { key: 'world', label: '世界觀衝突' },
+  { key: 'rewrite', label: '修稿' },
+];
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[name="default-checks"]').forEach((el) => {
@@ -131,7 +167,85 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.getElementById('review-bias').value = reviewBias;
   document.getElementById('rewrite-bias').value = rewriteBias;
+  setSourcesByName('global-retrieval-source', retrievalSources);
+  document.getElementById('global-retrieval-topk').value = retrievalTopK;
+  document.getElementById('global-retrieval-threshold').value = retrievalThreshold;
+  document.getElementById('global-retrieval-threshold').addEventListener('input', updateGlobalThresholdDisplay);
+  updateGlobalThresholdDisplay();
+  renderPresetEditors();
 });
+
+function updateGlobalThresholdDisplay() {
+  document.getElementById('global-threshold-display').textContent =
+    Number(document.getElementById('global-retrieval-threshold').value || 0).toFixed(2);
+}
+
+function setSourcesByName(name, selected) {
+  const wanted = new Set(selected || []);
+  document.querySelectorAll(`[name="${name}"]`).forEach((el) => {
+    el.checked = wanted.has(el.value);
+  });
+}
+
+function collectSourcesByName(name) {
+  return Array.from(document.querySelectorAll(`[name="${name}"]:checked`)).map((el) => el.value);
+}
+
+function fallbackPreset(task) {
+  const preset = retrievalPresets[task] || {};
+  return {
+    sources: Array.isArray(preset.sources) && preset.sources.length ? preset.sources : retrievalSources,
+    top_k: Number(preset.top_k) || retrievalTopK,
+    threshold: Number.isFinite(Number(preset.threshold)) ? Number(preset.threshold) : retrievalThreshold,
+  };
+}
+
+function renderPresetEditors() {
+  const host = document.getElementById('retrieval-preset-list');
+  host.innerHTML = presetTasks.map((task) => {
+    const base = fallbackPreset(task.key);
+    return `
+      <details class="card" style="margin-top:12px">
+        <summary style="cursor:pointer;font-weight:600">${task.label}</summary>
+        <div style="margin-top:12px">
+          <div class="form-group">
+            <label>啟用來源</label>
+            <div class="checkbox-group">
+              ${['character', 'world', 'style'].map((source) => `
+                <label class="checkbox-label">
+                  <input type="checkbox" name="preset-${task.key}-source" value="${source}" ${base.sources.includes(source) ? 'checked' : ''}>
+                  ${source === 'character' ? '角色設定' : source === 'world' ? '世界觀' : '寫作風格'}
+                </label>
+              `).join('')}
+            </div>
+          </div>
+          <div class="grid-2">
+            <div class="form-group">
+              <label for="preset-${task.key}-topk">Top-K</label>
+              <input type="number" id="preset-${task.key}-topk" min="1" max="20" value="${base.top_k}">
+            </div>
+            <div class="form-group">
+              <label for="preset-${task.key}-threshold">相似度門檻 <span id="preset-${task.key}-threshold-display">${Number(base.threshold).toFixed(2)}</span></label>
+              <input type="range" id="preset-${task.key}-threshold" min="0" max="1" step="0.01" value="${base.threshold}" oninput="document.getElementById('preset-${task.key}-threshold-display').textContent=Number(this.value||0).toFixed(2)">
+            </div>
+          </div>
+        </div>
+      </details>
+    `;
+  }).join('');
+}
+
+function collectRetrievalPresets() {
+  const out = {};
+  for (const task of presetTasks) {
+    out[task.key] = {
+      sources: collectSourcesByName(`preset-${task.key}-source`),
+      top_k: Math.max(1, Number(document.getElementById(`preset-${task.key}-topk`).value) || retrievalTopK),
+      threshold: Number(document.getElementById(`preset-${task.key}-threshold`).value) || 0,
+    };
+  }
+  return out;
+}
 
 async function saveSettings() {
   const status = document.getElementById('settings-status');
@@ -147,9 +261,10 @@ async function saveSettings() {
         default_styles: Array.from(document.querySelectorAll('[name="default-styles"]:checked')).map(el => el.value),
         review_bias: document.getElementById('review-bias').value,
         rewrite_bias: document.getElementById('rewrite-bias').value,
-        retrieval_sources: retrievalSources,
-        retrieval_top_k: retrievalTopK,
-        retrieval_threshold: retrievalThreshold,
+        retrieval_sources: collectSourcesByName('global-retrieval-source'),
+        retrieval_top_k: Math.max(1, Number(document.getElementById('global-retrieval-topk').value) || retrievalTopK),
+        retrieval_threshold: Number(document.getElementById('global-retrieval-threshold').value) || 0,
+        presets: collectRetrievalPresets(),
         ollama_url: document.getElementById('ollama-url').value.trim(),
         llm_model: document.getElementById('llm-model').value.trim(),
         embed_model: document.getElementById('embed-model').value.trim(),


### PR DESCRIPTION
## Summary

- 新增 `RetrievalPreset` 型別與 `Presets map[string]RetrievalPreset` 欄位至 `reviewrules.Settings`，四個任務（behavior / dialogue / world / rewrite）各有獨立 preset 預設值
- `mergeRetrieval()` 以 `ThresholdSet bool` 旗標區分零值與明確覆蓋，解決 threshold 無法 override 回 0 的問題
- check 頁面載入後從 `/api/settings` 取得 presets，切換任務時自動套用；使用者修改後才送 override，`runRewrite()` 在切換 preset 前保留並恢復使用者輸入
- settings 頁面新增各任務 preset 編輯器與全域 retrieval 設定區塊

## Test plan

- [ ] `go test ./internal/reviewrules/...` 通過（含 `TestPresetFor`、`TestNormalizePresets`）
- [ ] `go test ./internal/server/...` 通過（含 `TestMergeRetrievalUsesPresetUntilOverrideProvided`、threshold override 至 0 的 case）
- [ ] 在 check 頁面切換任務，確認 retrieval UI 自動更新為對應 preset
- [ ] 手動修改後送出審查，確認 override 值被後端採用
- [ ] 在 settings 頁面修改 preset 並儲存，重新整理後確認值保留

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)