### PR TITLE
feat: add manuscript export selection

### DIFF
--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -24,6 +24,16 @@ type chapterReportRequest struct {
 	Name string `json:"name"`
 }
 
+type manuscriptExportSelection struct {
+	Name   string   `json:"name"`
+	Scenes []string `json:"scenes,omitempty"`
+}
+
+type manuscriptExportRequest struct {
+	Selections      []manuscriptExportSelection `json:"selections"`
+	IncludeMetadata bool                        `json:"include_metadata"`
+}
+
 type backupItem struct {
 	Name      string    `json:"name"`
 	CreatedAt time.Time `json:"created_at"`
@@ -292,7 +302,111 @@ func (s *Server) handleExportChapterBundle(c *gin.Context) {
 	c.Data(http.StatusOK, "application/zip", buf.Bytes())
 }
 
-func (s *Server) buildManuscriptMarkdown() (string, error) {
+func filterScenesForExport(scenes []Scene, wanted []string) []Scene {
+	if len(wanted) == 0 {
+		return scenes
+	}
+
+	keep := make(map[string]struct{}, len(wanted))
+	for _, title := range wanted {
+		title = strings.TrimSpace(title)
+		if title != "" {
+			keep[title] = struct{}{}
+		}
+	}
+
+	filtered := make([]Scene, 0, len(scenes))
+	for _, scene := range scenes {
+		if _, ok := keep[scene.Title]; ok {
+			filtered = append(filtered, scene)
+		}
+	}
+	return filtered
+}
+
+func rebuildChapterFromScenes(scenes []Scene) string {
+	if len(scenes) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(scenes))
+	for _, scene := range scenes {
+		parts = append(parts, "## "+scene.Title+"\n"+scene.Content)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func rebuildChapterSelection(content string, scenes []Scene) string {
+	if len(scenes) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(scenes)+1)
+	if preamble := chapterPreamble(content); preamble != "" {
+		parts = append(parts, preamble)
+	}
+	parts = append(parts, rebuildChapterFromScenes(scenes))
+	return strings.Join(parts, "\n\n")
+}
+
+func (s *Server) buildSceneMetadataComment(chapterName string, scenes []Scene) string {
+	if len(scenes) == 0 {
+		return ""
+	}
+
+	plans, err := s.loadScenePlans(chapterName)
+	if err != nil || len(plans) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<!-- manuscript-metadata\n")
+
+	wroteScene := false
+	for _, scene := range scenes {
+		plan, ok := plans[scene.Title]
+		if !ok {
+			continue
+		}
+
+		hasFields := false
+		var sceneSB strings.Builder
+		sceneSB.WriteString("### ")
+		sceneSB.WriteString(scene.Title)
+		sceneSB.WriteString("\n")
+		if plan.Synopsis != "" {
+			sceneSB.WriteString("- 摘要：" + plan.Synopsis + "\n")
+			hasFields = true
+		}
+		if plan.POV != "" {
+			sceneSB.WriteString("- POV：" + plan.POV + "\n")
+			hasFields = true
+		}
+		if plan.Conflict != "" {
+			sceneSB.WriteString("- 衝突：" + plan.Conflict + "\n")
+			hasFields = true
+		}
+		if plan.Purpose != "" {
+			sceneSB.WriteString("- 目的：" + plan.Purpose + "\n")
+			hasFields = true
+		}
+		if !hasFields {
+			continue
+		}
+		sceneSB.WriteString("\n")
+		sb.WriteString(sceneSB.String())
+		wroteScene = true
+	}
+
+	if !wroteScene {
+		return ""
+	}
+
+	sb.WriteString("-->")
+	return sb.String()
+}
+
+func (s *Server) buildManuscriptMarkdown(req manuscriptExportRequest) (string, error) {
 	files, err := s.listChapterFiles()
 	if err != nil {
 		return "", err
@@ -301,10 +415,25 @@ func (s *Server) buildManuscriptMarkdown() (string, error) {
 		return "", fmt.Errorf("目前沒有章節可匯出")
 	}
 
+	selected := make(map[string]manuscriptExportSelection, len(req.Selections))
+	for _, item := range req.Selections {
+		normalized, err := normalizeChapterName(item.Name)
+		if err != nil {
+			continue
+		}
+		item.Name = normalized
+		selected[normalized] = item
+	}
+
 	var sb strings.Builder
 	sb.WriteString("# 小說手稿匯出\n\n")
 
 	for _, item := range files {
+		selection, selectedThisChapter := selected[item.Name]
+		if len(selected) > 0 && !selectedThisChapter {
+			continue
+		}
+
 		file, err := s.loadChapterFile(item.Name)
 		if err != nil {
 			return "", err
@@ -313,19 +442,54 @@ func (s *Server) buildManuscriptMarkdown() (string, error) {
 		if err != nil {
 			return "", err
 		}
-		content := rebuildChapterWithSceneOrder(file.Content, file.Scenes, sceneOrder)
+
+		content := strings.TrimSpace(file.Content)
+		exportScenes := orderedScenes(file.Scenes, sceneOrder)
+		if len(file.Scenes) > 0 && len(selection.Scenes) > 0 {
+			filteredScenes := filterScenesForExport(exportScenes, selection.Scenes)
+			if len(filteredScenes) != len(selection.Scenes) {
+				return "", fmt.Errorf("找不到指定場景：%s", strings.Join(selection.Scenes, "、"))
+			}
+			exportScenes = filteredScenes
+		}
+		if len(file.Scenes) > 0 && len(selection.Scenes) > 0 {
+			if len(exportScenes) == 0 {
+				continue
+			}
+			content = rebuildChapterSelection(file.Content, exportScenes)
+		} else if len(file.Scenes) > 0 {
+			content = rebuildChapterWithSceneOrder(file.Content, file.Scenes, sceneOrder)
+		}
+
 		sb.WriteString("## ")
 		sb.WriteString(file.Title)
 		sb.WriteString("\n\n")
 		sb.WriteString(strings.TrimSpace(content))
 		sb.WriteString("\n\n")
+
+		if req.IncludeMetadata {
+			if metadata := s.buildSceneMetadataComment(item.Name, exportScenes); metadata != "" {
+				sb.WriteString(metadata)
+				sb.WriteString("\n\n")
+			}
+		}
 	}
 
-	return strings.TrimSpace(sb.String()) + "\n", nil
+	result := strings.TrimSpace(sb.String())
+	if result == "# 小說手稿匯出" {
+		return "", fmt.Errorf("沒有符合條件的章節或場景可匯出")
+	}
+	return result + "\n", nil
 }
 
 func (s *Server) handleExportManuscript(c *gin.Context) {
-	report, err := s.buildManuscriptMarkdown()
+	var req manuscriptExportRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err != io.EOF {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	report, err := s.buildManuscriptMarkdown(req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"novel-assistant/internal/config"
-	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 
 	"github.com/gin-gonic/gin"

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -4,15 +4,20 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/tracker"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestBuildChapterBundleMarkdownIncludesLinkedData(t *testing.T) {
@@ -112,13 +117,7 @@ func TestBuildManuscriptMarkdownUsesSavedChapterAndSceneOrder(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	s := &Server{
-		cfg:        &config.Config{DataDir: dir},
-		profiles:   profile.NewManager(dir),
-		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
-		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
-		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
-	}
+	s := newOpsTestServer(dir)
 
 	if _, err := s.saveChapterFile("第02章", "第二章內容"); err != nil {
 		t.Fatalf("save chapter 2: %v", err)
@@ -139,7 +138,7 @@ Rain.`); err != nil {
 		t.Fatalf("save scene order: %v", err)
 	}
 
-	manuscript, err := s.buildManuscriptMarkdown()
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{})
 	if err != nil {
 		t.Fatalf("build manuscript markdown: %v", err)
 	}
@@ -156,5 +155,159 @@ Rain.`); err != nil {
 	}
 	if strings.Contains(manuscript, "第二章內容\n\n\n\n## 第01章") {
 		t.Fatalf("expected manuscript chapters to be separated by two newlines, got %q", manuscript)
+	}
+}
+
+func TestBuildManuscriptMarkdownFiltersChaptersAndScenes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第02章", "第二章內容"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	if _, err := s.saveChapterFile("第01章", `前言
+
+## Scene 1: Opening
+Open.
+
+## Scene 2: Rain
+Rain.`); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{
+			{Name: "第01章.md", Scenes: []string{"Scene 2: Rain"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+	if strings.Contains(manuscript, "## 第02章") {
+		t.Fatalf("expected chapter filter to exclude 第02章, got %q", manuscript)
+	}
+	if strings.Contains(manuscript, "## Scene 1: Opening") {
+		t.Fatalf("expected scene filter to exclude Scene 1, got %q", manuscript)
+	}
+	if !strings.Contains(manuscript, "## Scene 2: Rain") {
+		t.Fatalf("expected selected scene to remain, got %q", manuscript)
+	}
+	if !strings.Contains(manuscript, "前言") {
+		t.Fatalf("expected chapter preamble to be preserved, got %q", manuscript)
+	}
+}
+
+func TestBuildManuscriptMarkdownIncludesMetadataCommentWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", `## Scene 1: Opening
+Open.`); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+	if err := s.saveScenePlan("第01章.md", scenePlan{
+		Title:    "Scene 1: Opening",
+		Synopsis: "主角登場",
+		POV:      "林昊",
+		Conflict: "是否進門",
+		Purpose:  "建立懸念",
+	}); err != nil {
+		t.Fatalf("save scene plan: %v", err)
+	}
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		IncludeMetadata: true,
+		Selections: []manuscriptExportSelection{
+			{Name: "第01章.md", Scenes: []string{"Scene 1: Opening"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+	for _, fragment := range []string{
+		"<!-- manuscript-metadata",
+		"### Scene 1: Opening",
+		"- 摘要：主角登場",
+		"- POV：林昊",
+		"- 衝突：是否進門",
+		"- 目的：建立懸念",
+	} {
+		if !strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected metadata fragment %q, got %q", fragment, manuscript)
+		}
+	}
+}
+
+func TestHandleExportManuscriptAllowsEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/manuscript/export", http.NoBody)
+
+	s.handleExportManuscript(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected empty body export to pass, got %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestBuildManuscriptMarkdownRejectsUnknownSelectionOnly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	_, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{{Name: "不存在.md"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "沒有符合條件") {
+		t.Fatalf("expected filtered export error, got %v", err)
+	}
+}
+
+func TestBuildManuscriptMarkdownRejectsUnknownSceneSelection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+	if _, err := s.saveChapterFile("第01章", `前言
+
+## Scene 1: Opening
+Open.`); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	_, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{
+			{Name: "第01章.md", Scenes: []string{"Scene 9: Missing"}},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "找不到指定場景") {
+		t.Fatalf("expected unknown scene selection error, got %v", err)
+	}
+}
+
+func newOpsTestServer(dir string) *Server {
+	return &Server{
+		cfg:        &config.Config{DataDir: dir},
+		profiles:   profile.NewManager(dir),
+		rules:      reviewrules.New(filepath.Join(dir, "review_rules.json")),
+		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
+		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
+		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
 	}
 }

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -20,6 +20,45 @@
     </div>
 
     {{if .Chapters}}
+    <details id="manuscript-export-panel" class="card" style="margin-bottom:12px">
+      <summary class="history-title-row" style="cursor:pointer">
+        <div>
+          <strong>手稿匯出設定</strong>
+          <div class="helper-text">可指定章節、scene 與是否附加場景 metadata。</div>
+        </div>
+      </summary>
+      <div style="margin-top:12px">
+        {{range .Chapters}}
+        {{$chapterName := .Name}}
+        <div class="writeback-card" style="margin-bottom:10px">
+          <label class="checkbox-label">
+            <input type="checkbox" name="manuscript-chapter" value="{{$chapterName}}" data-chapter="{{$chapterName}}" onchange="toggleManuscriptSceneGroup(this)">
+            {{.Title}}
+          </label>
+          {{if .SceneCards}}
+          <div class="checkbox-group" data-scene-group="{{$chapterName}}" style="margin-top:8px;padding-left:18px">
+            {{range .SceneCards}}
+            <label class="checkbox-label">
+              <input type="checkbox" name="manuscript-scene-{{$chapterName}}" value="{{.Title}}" disabled>
+              {{.Title}}
+            </label>
+            {{end}}
+          </div>
+          {{end}}
+        </div>
+        {{end}}
+
+        <label class="checkbox-label">
+          <input type="checkbox" id="manuscript-include-metadata">
+          附加場景 metadata（HTML comment）
+        </label>
+
+        <div style="margin-top:12px">
+          <button class="btn" type="button" onclick="exportManuscriptWithOptions()">匯出手稿</button>
+        </div>
+      </div>
+    </details>
+
     <div class="chapter-overview-list" id="chapter-overview-list">
       {{range .Chapters}}
       <div class="card chapter-overview-card" data-chapter="{{.Name}}" draggable="true">
@@ -196,8 +235,43 @@ async function exportChapterBundle(name) {
 }
 
 async function exportManuscript() {
+  return exportManuscriptWithOptions();
+}
+
+function toggleManuscriptSceneGroup(checkbox) {
+  const chapterName = checkbox.dataset.chapter;
+  const group = document.querySelector(`[data-scene-group="${CSS.escape(chapterName)}"]`);
+  if (!group) return;
+
+  group.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+    if (!checkbox.checked) {
+      input.checked = false;
+    }
+    input.disabled = !checkbox.checked;
+  });
+}
+
+function collectManuscriptSelections() {
+  return Array.from(document.querySelectorAll('[name="manuscript-chapter"]:checked')).map((input) => {
+    const chapter = input.value;
+    const scenes = Array.from(
+      document.querySelectorAll(`[name="manuscript-scene-${CSS.escape(chapter)}"]:checked`)
+    ).map((sceneInput) => sceneInput.value);
+
+    return { name: chapter, scenes };
+  });
+}
+
+async function exportManuscriptWithOptions() {
   try {
-    const resp = await fetch('/api/manuscript/export', { method: 'POST' });
+    const resp = await fetch('/api/manuscript/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        selections: collectManuscriptSelections(),
+        include_metadata: document.getElementById('manuscript-include-metadata').checked
+      })
+    });
     if (!resp.ok) {
       const data = await resp.json();
       throw new Error(data.error || '匯出手稿失敗');


### PR DESCRIPTION
## Summary
- add configurable manuscript export so authors can export selected chapters and selected scenes while preserving saved order
- support optional scene metadata comments in the exported markdown
- fix scene-subset export to preserve chapter preamble and reject unknown selected scene titles instead of silently dropping them

Closes #7

## Test Plan
- [x] `go test ./internal/server -run "TestBuildManuscriptMarkdown|TestHandleExportManuscript" -count=1`
- [x] `go test ./...`