### PR TITLE
feat: add html manuscript export

### DIFF
--- a/internal/exporter/html.go
+++ b/internal/exporter/html.go
@@ -1,0 +1,93 @@
+package exporter
+
+import (
+	"fmt"
+	"html"
+	"strings"
+)
+
+// ManuscriptToHTML converts a manuscript markdown export into a self-contained HTML5 document.
+func ManuscriptToHTML(markdown string) string {
+	lines := strings.Split(strings.ReplaceAll(markdown, "\r\n", "\n"), "\n")
+
+	var body strings.Builder
+	var paraLines []string
+
+	flushPara := func() {
+		if len(paraLines) == 0 {
+			return
+		}
+		text := html.EscapeString(strings.Join(paraLines, "\n"))
+		body.WriteString("<p>" + strings.ReplaceAll(text, "\n", "<br>") + "</p>\n")
+		paraLines = paraLines[:0]
+	}
+
+	inMetadata := false
+	var metaLines []string
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "<!-- manuscript-metadata") {
+			flushPara()
+			inMetadata = true
+			metaLines = metaLines[:0]
+			continue
+		}
+		if inMetadata {
+			if strings.TrimSpace(line) == "-->" {
+				inMetadata = false
+				if len(metaLines) > 0 {
+					body.WriteString("<details class=\"manuscript-meta\"><summary>場景規劃</summary><div>\n")
+					for _, ml := range metaLines {
+						body.WriteString(html.EscapeString(ml) + "<br>\n")
+					}
+					body.WriteString("</div></details>\n")
+				}
+			} else {
+				metaLines = append(metaLines, line)
+			}
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(line, "# "):
+			flushPara()
+			body.WriteString(fmt.Sprintf("<h1>%s</h1>\n", html.EscapeString(line[2:])))
+		case strings.HasPrefix(line, "### "):
+			flushPara()
+			body.WriteString(fmt.Sprintf("<h3>%s</h3>\n", html.EscapeString(line[4:])))
+		case strings.HasPrefix(line, "## "):
+			flushPara()
+			body.WriteString(fmt.Sprintf("<h2>%s</h2>\n", html.EscapeString(line[3:])))
+		case strings.TrimSpace(line) == "":
+			flushPara()
+		default:
+			paraLines = append(paraLines, line)
+		}
+	}
+	flushPara()
+
+	return manuscriptHTMLTemplate(body.String())
+}
+
+func manuscriptHTMLTemplate(body string) string {
+	return `<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>手稿匯出</title>
+<style>
+  body { font-family: "Noto Serif TC", serif; max-width: 800px; margin: 0 auto; padding: 2rem; line-height: 1.9; color: #1a1a1a; }
+  h1 { font-size: 2rem; border-bottom: 2px solid #333; padding-bottom: .5rem; margin-top: 2rem; }
+  h2 { font-size: 1.5rem; margin-top: 2rem; color: #222; }
+  h3 { font-size: 1.1rem; margin-top: 1.5rem; color: #555; }
+  p  { margin: 1rem 0; text-indent: 2em; }
+  details.manuscript-meta { margin: 1rem 0; background: #f5f5f5; border: 1px solid #ddd; border-radius: 4px; padding: .5rem 1rem; font-size: .85rem; color: #555; }
+  details.manuscript-meta summary { cursor: pointer; font-weight: bold; }
+  @media print { details.manuscript-meta { display: none; } }
+</style>
+</head>
+<body>
+` + body + `</body>
+</html>`
+}

--- a/internal/exporter/html_test.go
+++ b/internal/exporter/html_test.go
@@ -1,0 +1,51 @@
+package exporter_test
+
+import (
+	"strings"
+	"testing"
+
+	"novel-assistant/internal/exporter"
+)
+
+func TestManuscriptToHTMLConvertsHeadings(t *testing.T) {
+	md := "# 手稿\n\n## 第一章\n\n### 場景一\n\n正文內容。\n"
+	out := exporter.ManuscriptToHTML(md)
+
+	for _, want := range []string{"<h1>手稿</h1>", "<h2>第一章</h2>", "<h3>場景一</h3>", "<p>正文內容。</p>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got %q", want, out)
+		}
+	}
+}
+
+func TestManuscriptToHTMLRendersMetadataAsDetails(t *testing.T) {
+	md := "## 第一章\n\n<!-- manuscript-metadata\n### Scene 1\n- 摘要：開頭\n-->\n"
+	out := exporter.ManuscriptToHTML(md)
+
+	if !strings.Contains(out, "<details class=\"manuscript-meta\">") {
+		t.Fatalf("expected metadata details block, got %q", out)
+	}
+	if !strings.Contains(out, "摘要：開頭") {
+		t.Fatalf("expected metadata content in output, got %q", out)
+	}
+}
+
+func TestManuscriptToHTMLEscapesHTML(t *testing.T) {
+	md := "## <script>alert(1)</script>\n"
+	out := exporter.ManuscriptToHTML(md)
+
+	if strings.Contains(out, "<script>") {
+		t.Fatalf("expected HTML to be escaped in output, got %q", out)
+	}
+	if !strings.Contains(out, "&lt;script&gt;alert(1)&lt;/script&gt;") {
+		t.Fatalf("expected escaped heading content, got %q", out)
+	}
+}
+
+func TestManuscriptToHTMLIsValidHTML5(t *testing.T) {
+	out := exporter.ManuscriptToHTML("# Title\n\nBody.\n")
+
+	if !strings.Contains(out, "<!DOCTYPE html>") || !strings.Contains(out, "</html>") {
+		t.Fatalf("expected valid HTML5 document wrapper, got %q", out)
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -276,6 +276,34 @@ func TestGetSettingsReturnsRetrievalDefaults(t *testing.T) {
 	}
 }
 
+func TestHandleExportManuscriptHTMLFormat(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, "http://127.0.0.1:0")
+	if _, err := s.saveChapterFile("第01章", "內容正文"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/api/manuscript/export", map[string]any{
+		"format": "html",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	if !strings.Contains(body, "<!DOCTYPE html>") {
+		t.Fatalf("expected HTML document in response, got %s", body)
+	}
+	if !strings.Contains(body, "內容正文") {
+		t.Fatalf("expected chapter content in HTML output, got %s", body)
+	}
+}
+
 func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 	t.Helper()
 

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"novel-assistant/internal/extractor"
+	"novel-assistant/internal/exporter"
 
 	"github.com/gin-gonic/gin"
 )
@@ -32,6 +33,7 @@ type manuscriptExportSelection struct {
 type manuscriptExportRequest struct {
 	Selections      []manuscriptExportSelection `json:"selections"`
 	IncludeMetadata bool                        `json:"include_metadata"`
+	Format          string                      `json:"format"`
 }
 
 type backupItem struct {
@@ -489,13 +491,20 @@ func (s *Server) handleExportManuscript(c *gin.Context) {
 		return
 	}
 
-	report, err := s.buildManuscriptMarkdown(req)
+	markdown, err := s.buildManuscriptMarkdown(req)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.Header("Content-Type", "text/markdown; charset=utf-8")
-	c.Header("Content-Disposition", `attachment; filename="novel_manuscript.md"`)
-	c.Data(http.StatusOK, "text/markdown; charset=utf-8", []byte(report))
+	switch req.Format {
+	case "html":
+		c.Header("Content-Type", "text/html; charset=utf-8")
+		c.Header("Content-Disposition", `attachment; filename="novel_manuscript.html"`)
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(exporter.ManuscriptToHTML(markdown)))
+	default:
+		c.Header("Content-Type", "text/markdown; charset=utf-8")
+		c.Header("Content-Disposition", `attachment; filename="novel_manuscript.md"`)
+		c.Data(http.StatusOK, "text/markdown; charset=utf-8", []byte(markdown))
+	}
 }

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"novel-assistant/internal/extractor"
 	"novel-assistant/internal/exporter"
+	"novel-assistant/internal/extractor"
 
 	"github.com/gin-gonic/gin"
 )

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"novel-assistant/internal/config"
-	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/reviewrules"

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/reviewrules"

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -48,6 +48,14 @@
         </div>
         {{end}}
 
+        <div class="form-group" style="margin-top:10px">
+          <label>匯出格式</label>
+          <select id="manuscript-format">
+            <option value="markdown">Markdown (.md)</option>
+            <option value="html">HTML (.html) — 適合編輯交付</option>
+          </select>
+        </div>
+
         <label class="checkbox-label">
           <input type="checkbox" id="manuscript-include-metadata">
           附加場景 metadata（HTML comment）
@@ -238,6 +246,10 @@ async function exportManuscript() {
   return exportManuscriptWithOptions();
 }
 
+function manuscriptExportFilename(format) {
+  return format === 'html' ? 'novel_manuscript.html' : 'novel_manuscript.md';
+}
+
 function toggleManuscriptSceneGroup(checkbox) {
   const chapterName = checkbox.dataset.chapter;
   const group = document.querySelector(`[data-scene-group="${CSS.escape(chapterName)}"]`);
@@ -263,13 +275,16 @@ function collectManuscriptSelections() {
 }
 
 async function exportManuscriptWithOptions() {
+  const format = document.getElementById('manuscript-format').value || 'markdown';
+  const filename = manuscriptExportFilename(format);
   try {
     const resp = await fetch('/api/manuscript/export', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         selections: collectManuscriptSelections(),
-        include_metadata: document.getElementById('manuscript-include-metadata').checked
+        include_metadata: document.getElementById('manuscript-include-metadata').checked,
+        format
       })
     });
     if (!resp.ok) {
@@ -280,7 +295,7 @@ async function exportManuscriptWithOptions() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = 'novel_manuscript.md';
+    link.download = filename;
     document.body.appendChild(link);
     link.click();
     link.remove();


### PR DESCRIPTION
## Summary
- add a pure-Go `ManuscriptToHTML` exporter for controlled manuscript markdown output
- support `format: html` in `/api/manuscript/export` and return `.html` downloads from the same endpoint
- extend the chapters export panel with a format selector and dynamic download filename handling

Closes #8

## Test Plan
- [x] `go test ./internal/exporter ./internal/server -run "TestManuscriptToHTML|TestHandleExportManuscriptHTMLFormat" -count=1`
- [x] `go test ./...`