### PR TITLE
feat: add manuscript export appendix

### DIFF
--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -13,6 +13,7 @@ import (
 
 	"novel-assistant/internal/exporter"
 	"novel-assistant/internal/extractor"
+	"novel-assistant/internal/reviewhistory"
 
 	"github.com/gin-gonic/gin"
 )
@@ -30,9 +31,15 @@ type manuscriptExportSelection struct {
 	Scenes []string `json:"scenes,omitempty"`
 }
 
+type manuscriptAppendixOptions struct {
+	Reviews bool `json:"reviews"`
+	Tracker bool `json:"tracker"`
+}
+
 type manuscriptExportRequest struct {
 	Selections      []manuscriptExportSelection `json:"selections"`
 	IncludeMetadata bool                        `json:"include_metadata"`
+	Appendix        manuscriptAppendixOptions   `json:"appendix"`
 	Format          string                      `json:"format"`
 }
 
@@ -408,6 +415,166 @@ func (s *Server) buildSceneMetadataComment(chapterName string, scenes []Scene) s
 	return sb.String()
 }
 
+func normalizedSelectionMap(selections []manuscriptExportSelection) map[string]manuscriptExportSelection {
+	selected := make(map[string]manuscriptExportSelection, len(selections))
+	for _, item := range selections {
+		normalized, err := normalizeChapterName(item.Name)
+		if err != nil {
+			continue
+		}
+		item.Name = normalized
+		selected[normalized] = item
+	}
+	return selected
+}
+
+func chapterIncludedForAppendix(selected map[string]manuscriptExportSelection, chapterFile, chapterTitle string) bool {
+	if len(selected) == 0 {
+		return true
+	}
+	if chapterFile != "" {
+		if normalized, err := normalizeChapterName(chapterFile); err == nil {
+			if _, ok := selected[normalized]; ok {
+				return true
+			}
+		}
+	}
+	if chapterTitle != "" {
+		if normalized, err := normalizeChapterName(chapterTitle); err == nil {
+			if _, ok := selected[normalized]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func buildReviewAppendixLine(entry *reviewhistory.Entry) string {
+	line := historyEntryLabel(entry)
+	if !entry.CreatedAt.IsZero() {
+		line += "・" + entry.CreatedAt.Format("2006-01-02 15:04:05")
+	}
+	if entry.RewriteMode != "" {
+		line += "・模式：" + entry.RewriteMode
+	}
+	if scene := strings.TrimSpace(entry.SceneTitle); scene != "" {
+		line += "・場景：" + scene
+	}
+	return line
+}
+
+func writeAppendixListSection(sb *strings.Builder, title string, lines []string) {
+	if len(lines) == 0 {
+		return
+	}
+	sb.WriteString("### ")
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+	for _, line := range lines {
+		sb.WriteString("- ")
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+	sb.WriteString("\n")
+}
+
+func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest) string {
+	selected := normalizedSelectionMap(req.Selections)
+	sections := make([]string, 0, 2)
+
+	if req.Appendix.Reviews {
+		groups := make(map[string][]string)
+		order := make([]string, 0)
+		for _, entry := range s.history.Recent(0) {
+			if !chapterIncludedForAppendix(selected, entry.ChapterFile, entry.ChapterTitle) {
+				continue
+			}
+			title := strings.TrimSpace(entry.ChapterTitle)
+			if title == "" {
+				switch {
+				case entry.ChapterFile != "":
+					title = chapterTitle(entry.ChapterFile)
+				default:
+					title = "未分類章節"
+				}
+			}
+			if _, ok := groups[title]; !ok {
+				order = append(order, title)
+			}
+			groups[title] = append(groups[title], buildReviewAppendixLine(entry))
+		}
+		if len(order) > 0 {
+			var sb strings.Builder
+			sb.WriteString("## 審查與修稿歷史\n\n")
+			for _, title := range order {
+				sb.WriteString("### ")
+				sb.WriteString(title)
+				sb.WriteString("\n\n")
+				for _, line := range groups[title] {
+					sb.WriteString("- ")
+					sb.WriteString(line)
+					sb.WriteString("\n")
+				}
+				sb.WriteString("\n")
+			}
+			sections = append(sections, strings.TrimSpace(sb.String()))
+		}
+	}
+
+	if req.Appendix.Tracker {
+		var sb strings.Builder
+		sb.WriteString("## Tracker\n\n")
+
+		timelineLines := make([]string, 0)
+		for _, event := range s.timeline.GetSorted() {
+			chapterName := fmt.Sprintf("第%02d章.md", event.Chapter)
+			chapterTitle := chapterTitle(chapterName)
+			if !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
+				continue
+			}
+			timelineLines = append(timelineLines, fmt.Sprintf("%s：%s：%s", chapterTitle, event.Scene, event.Description))
+		}
+		writeAppendixListSection(&sb, "時間軸", timelineLines)
+
+		foreshadowLines := make([]string, 0)
+		for _, item := range s.foreshadow.GetAll() {
+			chapterName := item.PlantedIn
+			if chapterName == "" && item.Chapter > 0 {
+				chapterName = fmt.Sprintf("第%02d章.md", item.Chapter)
+			}
+			chapterTitle := chapterTitle(chapterName)
+			if !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
+				continue
+			}
+			foreshadowLines = append(foreshadowLines, fmt.Sprintf("%s：%s（%s）", chapterTitle, item.Description, item.Status))
+		}
+		writeAppendixListSection(&sb, "伏筆", foreshadowLines)
+
+		relationshipLines := make([]string, 0)
+		for _, rel := range s.relationships.GetAll() {
+			line := fmt.Sprintf("%s ↔ %s：%s", rel.From, rel.To, rel.Status)
+			if note := strings.TrimSpace(rel.Note); note != "" {
+				line += "・" + note
+			}
+			if trigger := strings.TrimSpace(rel.TriggerEvent); trigger != "" {
+				line += "・事件：" + trigger
+			}
+			relationshipLines = append(relationshipLines, line)
+		}
+		writeAppendixListSection(&sb, "角色關係", relationshipLines)
+
+		trackerSection := strings.TrimSpace(sb.String())
+		if trackerSection != "## Tracker" {
+			sections = append(sections, trackerSection)
+		}
+	}
+
+	if len(sections) == 0 {
+		return ""
+	}
+	return "# 附錄\n\n" + strings.Join(sections, "\n\n") + "\n"
+}
+
 func (s *Server) buildManuscriptMarkdown(req manuscriptExportRequest) (string, error) {
 	files, err := s.listChapterFiles()
 	if err != nil {
@@ -417,15 +584,7 @@ func (s *Server) buildManuscriptMarkdown(req manuscriptExportRequest) (string, e
 		return "", fmt.Errorf("目前沒有章節可匯出")
 	}
 
-	selected := make(map[string]manuscriptExportSelection, len(req.Selections))
-	for _, item := range req.Selections {
-		normalized, err := normalizeChapterName(item.Name)
-		if err != nil {
-			continue
-		}
-		item.Name = normalized
-		selected[normalized] = item
-	}
+	selected := normalizedSelectionMap(req.Selections)
 
 	var sb strings.Builder
 	sb.WriteString("# 小說手稿匯出\n\n")
@@ -475,6 +634,11 @@ func (s *Server) buildManuscriptMarkdown(req manuscriptExportRequest) (string, e
 				sb.WriteString("\n\n")
 			}
 		}
+	}
+
+	if appendix := strings.TrimSpace(s.buildManuscriptAppendix(req)); appendix != "" {
+		sb.WriteString(appendix)
+		sb.WriteString("\n")
 	}
 
 	result := strings.TrimSpace(sb.String())

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -478,8 +478,61 @@ func writeAppendixListSection(sb *strings.Builder, title string, lines []string)
 	sb.WriteString("\n")
 }
 
-func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest) string {
+type appendixChapterRef struct {
+	Name  string
+	Title string
+}
+
+func buildAppendixChapterRefs(files []chapterFile) map[int][]appendixChapterRef {
+	refs := make(map[int][]appendixChapterRef, len(files))
+	for _, file := range files {
+		number := chapterNumberFromName(file.Name)
+		refs[number] = append(refs[number], appendixChapterRef{
+			Name:  file.Name,
+			Title: file.Title,
+		})
+	}
+	return refs
+}
+
+func resolveAppendixChapterRef(selected map[string]manuscriptExportSelection, refs map[int][]appendixChapterRef, chapter int, fallback string) (string, string) {
+	if fallback != "" {
+		if normalized, err := normalizeChapterName(fallback); err == nil {
+			return normalized, chapterTitle(normalized)
+		}
+		return fallback, strings.TrimSpace(fallback)
+	}
+
+	candidates := refs[chapter]
+	if len(candidates) == 0 {
+		if chapter > 0 {
+			name := fmt.Sprintf("第%02d章.md", chapter)
+			return name, chapterTitle(name)
+		}
+		return "", ""
+	}
+
+	if len(selected) > 0 {
+		selectedMatches := make([]appendixChapterRef, 0, len(candidates))
+		for _, candidate := range candidates {
+			if _, ok := selected[candidate.Name]; ok {
+				selectedMatches = append(selectedMatches, candidate)
+			}
+		}
+		if len(selectedMatches) == 1 {
+			return selectedMatches[0].Name, selectedMatches[0].Title
+		}
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0].Name, candidates[0].Title
+	}
+	return "", ""
+}
+
+func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest, files []chapterFile) string {
 	selected := normalizedSelectionMap(req.Selections)
+	chapterRefs := buildAppendixChapterRefs(files)
 	sections := make([]string, 0, 2)
 
 	if req.Appendix.Reviews {
@@ -523,13 +576,12 @@ func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest) string {
 
 	if req.Appendix.Tracker {
 		var sb strings.Builder
-		sb.WriteString("## Tracker\n\n")
+		sb.WriteString("## 追蹤資料\n\n")
 
 		timelineLines := make([]string, 0)
 		for _, event := range s.timeline.GetSorted() {
-			chapterName := fmt.Sprintf("第%02d章.md", event.Chapter)
-			chapterTitle := chapterTitle(chapterName)
-			if !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
+			chapterName, chapterTitle := resolveAppendixChapterRef(selected, chapterRefs, event.Chapter, "")
+			if chapterName == "" || !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
 				continue
 			}
 			timelineLines = append(timelineLines, fmt.Sprintf("%s：%s：%s", chapterTitle, event.Scene, event.Description))
@@ -538,12 +590,8 @@ func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest) string {
 
 		foreshadowLines := make([]string, 0)
 		for _, item := range s.foreshadow.GetAll() {
-			chapterName := item.PlantedIn
-			if chapterName == "" && item.Chapter > 0 {
-				chapterName = fmt.Sprintf("第%02d章.md", item.Chapter)
-			}
-			chapterTitle := chapterTitle(chapterName)
-			if !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
+			chapterName, chapterTitle := resolveAppendixChapterRef(selected, chapterRefs, item.Chapter, item.PlantedIn)
+			if chapterName == "" || !chapterIncludedForAppendix(selected, chapterName, chapterTitle) {
 				continue
 			}
 			foreshadowLines = append(foreshadowLines, fmt.Sprintf("%s：%s（%s）", chapterTitle, item.Description, item.Status))
@@ -564,7 +612,7 @@ func (s *Server) buildManuscriptAppendix(req manuscriptExportRequest) string {
 		writeAppendixListSection(&sb, "角色關係", relationshipLines)
 
 		trackerSection := strings.TrimSpace(sb.String())
-		if trackerSection != "## Tracker" {
+		if trackerSection != "## 追蹤資料" {
 			sections = append(sections, trackerSection)
 		}
 	}
@@ -636,7 +684,7 @@ func (s *Server) buildManuscriptMarkdown(req manuscriptExportRequest) (string, e
 		}
 	}
 
-	if appendix := strings.TrimSpace(s.buildManuscriptAppendix(req)); appendix != "" {
+	if appendix := strings.TrimSpace(s.buildManuscriptAppendix(req, files)); appendix != "" {
 		sb.WriteString(appendix)
 		sb.WriteString("\n")
 	}

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -300,7 +300,7 @@ func TestBuildManuscriptMarkdownAppendsTrackerAppendix(t *testing.T) {
 
 	for _, fragment := range []string{
 		"# 附錄",
-		"## Tracker",
+		"## 追蹤資料",
 		"### 時間軸",
 		"第01章：夜港塔：主角抵達現場",
 		"### 伏筆",
@@ -311,6 +311,36 @@ func TestBuildManuscriptMarkdownAppendsTrackerAppendix(t *testing.T) {
 	} {
 		if !strings.Contains(manuscript, fragment) {
 			t.Fatalf("expected tracker appendix fragment %q, got %q", fragment, manuscript)
+		}
+	}
+}
+
+func TestBuildManuscriptMarkdownMatchesNonStandardChapterNamesInTrackerAppendix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("prologue", "序章內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+	s.timeline.Add(&tracker.TimelineEvent{Chapter: 0, Scene: "開場", Description: "序章事件"})
+	s.foreshadow.Add(&tracker.Foreshadowing{Chapter: 0, Description: "序章伏筆", PlantedIn: "prologue"})
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{{Name: "prologue.md"}},
+		Appendix:   manuscriptAppendixOptions{Tracker: true},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+	for _, fragment := range []string{
+		"## 追蹤資料",
+		"prologue：開場：序章事件",
+		"prologue：序章伏筆（未回收）",
+	} {
+		if !strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected nonstandard chapter appendix fragment %q, got %q", fragment, manuscript)
 		}
 	}
 }

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -242,6 +242,171 @@ Open.`); err != nil {
 	}
 }
 
+func TestBuildManuscriptMarkdownAppendsReviewsAppendix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+	s.history.Add(&reviewhistory.Entry{Kind: "review", ChapterFile: "第01章.md", ChapterTitle: "第01章"})
+	s.history.Add(&reviewhistory.Entry{Kind: "rewrite", ChapterFile: "第01章.md", ChapterTitle: "第01章", RewriteMode: "強化張力"})
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Appendix: manuscriptAppendixOptions{Reviews: true},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+
+	for _, fragment := range []string{
+		"# 附錄",
+		"## 審查與修稿歷史",
+		"### 第01章",
+		"第 1 次審查",
+		"第 1 次修稿",
+		"模式：強化張力",
+	} {
+		if !strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected reviews appendix fragment %q, got %q", fragment, manuscript)
+		}
+	}
+}
+
+func TestBuildManuscriptMarkdownAppendsTrackerAppendix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if _, err := s.saveChapterFile("第02章", "內容"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	s.timeline.Add(&tracker.TimelineEvent{Chapter: 1, Scene: "夜港塔", Description: "主角抵達現場"})
+	s.foreshadow.Add(&tracker.Foreshadowing{Chapter: 1, Description: "塔上的異象", PlantedIn: "第01章"})
+	s.relationships.Upsert(&tracker.Relationship{From: "林昊", To: "張雷", Status: "信任", Note: "一起追查夜港塔"})
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Appendix: manuscriptAppendixOptions{Tracker: true},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+
+	for _, fragment := range []string{
+		"# 附錄",
+		"## Tracker",
+		"### 時間軸",
+		"第01章：夜港塔：主角抵達現場",
+		"### 伏筆",
+		"第01章：塔上的異象（未回收）",
+		"### 角色關係",
+		"林昊 ↔ 張雷：信任",
+		"一起追查夜港塔",
+	} {
+		if !strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected tracker appendix fragment %q, got %q", fragment, manuscript)
+		}
+	}
+}
+
+func TestBuildManuscriptMarkdownFiltersAppendixToSelectedChapters(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if _, err := s.saveChapterFile("第02章", "內容"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	s.history.Add(&reviewhistory.Entry{Kind: "review", ChapterFile: "第01章.md", ChapterTitle: "第01章"})
+	s.history.Add(&reviewhistory.Entry{Kind: "review", ChapterFile: "第02章.md", ChapterTitle: "第02章"})
+	s.timeline.Add(&tracker.TimelineEvent{Chapter: 1, Scene: "A", Description: "第一章事件"})
+	s.timeline.Add(&tracker.TimelineEvent{Chapter: 2, Scene: "B", Description: "第二章事件"})
+	s.foreshadow.Add(&tracker.Foreshadowing{Chapter: 1, Description: "第一章伏筆", PlantedIn: "第01章"})
+	s.foreshadow.Add(&tracker.Foreshadowing{Chapter: 2, Description: "第二章伏筆", PlantedIn: "第02章"})
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{{Name: "第01章.md"}},
+		Appendix: manuscriptAppendixOptions{
+			Reviews: true,
+			Tracker: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+
+	for _, fragment := range []string{"第01章", "第一章事件", "第一章伏筆"} {
+		if !strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected selected chapter appendix data %q, got %q", fragment, manuscript)
+		}
+	}
+	for _, fragment := range []string{"第02章", "第二章事件", "第二章伏筆"} {
+		if strings.Contains(manuscript, fragment) {
+			t.Fatalf("expected appendix to exclude unselected chapter data %q, got %q", fragment, manuscript)
+		}
+	}
+}
+
+func TestBuildManuscriptMarkdownKeepsRelationshipsUnfilteredInAppendix(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "只出現林昊"); err != nil {
+		t.Fatalf("save chapter 1: %v", err)
+	}
+	if _, err := s.saveChapterFile("第02章", "只出現張雷"); err != nil {
+		t.Fatalf("save chapter 2: %v", err)
+	}
+	s.relationships.Upsert(&tracker.Relationship{From: "林昊", To: "張雷", Status: "信任"})
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Selections: []manuscriptExportSelection{{Name: "第01章.md"}},
+		Appendix:   manuscriptAppendixOptions{Tracker: true},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+	if !strings.Contains(manuscript, "林昊 ↔ 張雷：信任") {
+		t.Fatalf("expected relationships appendix to remain unfiltered, got %q", manuscript)
+	}
+}
+
+func TestBuildManuscriptMarkdownSkipsAppendixHeadingWhenNoAppendixData(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	manuscript, err := s.buildManuscriptMarkdown(manuscriptExportRequest{
+		Appendix: manuscriptAppendixOptions{
+			Reviews: true,
+			Tracker: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("build manuscript markdown: %v", err)
+	}
+	if strings.Contains(manuscript, "# 附錄") {
+		t.Fatalf("expected empty appendix to be omitted, got %q", manuscript)
+	}
+}
+
 func TestHandleExportManuscriptAllowsEmptyBody(t *testing.T) {
 	t.Parallel()
 
@@ -303,11 +468,12 @@ Open.`); err != nil {
 
 func newOpsTestServer(dir string) *Server {
 	return &Server{
-		cfg:        &config.Config{DataDir: dir},
-		profiles:   profile.NewManager(dir),
-		rules:      reviewrules.New(filepath.Join(dir, "review_rules.json")),
-		history:    reviewhistory.New(filepath.Join(dir, "reviews.json")),
-		timeline:   tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
-		foreshadow: tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
+		cfg:           &config.Config{DataDir: dir},
+		profiles:      profile.NewManager(dir),
+		rules:         reviewrules.New(filepath.Join(dir, "review_rules.json")),
+		history:       reviewhistory.New(filepath.Join(dir, "reviews.json")),
+		timeline:      tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),
+		foreshadow:    tracker.NewForeshadowTracker(filepath.Join(dir, "foreshadow.json")),
+		relationships: tracker.NewRelationshipTracker(filepath.Join(dir, "relationships.json")),
 	}
 }

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -61,6 +61,18 @@
           附加場景 metadata（HTML comment）
         </label>
 
+        <div class="form-group" style="margin-top:10px">
+          <label>附錄</label>
+          <label class="checkbox-label">
+            <input type="checkbox" id="manuscript-appendix-reviews">
+            附加審查與修稿歷史
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" id="manuscript-appendix-tracker">
+            附加 tracker 摘要（時間軸、伏筆、角色關係）
+          </label>
+        </div>
+
         <div style="margin-top:12px">
           <button class="btn" type="button" onclick="exportManuscriptWithOptions()">匯出手稿</button>
         </div>
@@ -284,6 +296,10 @@ async function exportManuscriptWithOptions() {
       body: JSON.stringify({
         selections: collectManuscriptSelections(),
         include_metadata: document.getElementById('manuscript-include-metadata').checked,
+        appendix: {
+          reviews: document.getElementById('manuscript-appendix-reviews').checked,
+          tracker: document.getElementById('manuscript-appendix-tracker').checked
+        },
         format
       })
     });


### PR DESCRIPTION
## Summary
- add optional manuscript appendix sections for review history and tracker data
- filter review, timeline, and foreshadow appendix content to selected chapters while keeping relationships unfiltered
- add appendix export controls to the chapters page and send appendix options with manuscript export requests

## Testing
- go test ./internal/server -run "TestBuildManuscriptMarkdown|TestHandleExportManuscript" -count=1
- go test ./...

Closes #9