### PR TITLE
feat: add multi-project workspace switching

### DIFF
--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -94,8 +94,12 @@ func chapterTitle(name string) string {
 	return strings.TrimSuffix(name, filepath.Ext(name))
 }
 
+func chapterDirFor(dataDir string) string {
+	return filepath.Join(dataDir, "chapters")
+}
+
 func (s *Server) chapterDir() string {
-	return filepath.Join(s.cfg.DataDir, "chapters")
+	return chapterDirFor(s.cfg.DataDir)
 }
 
 func (s *Server) listChapterFiles() ([]chapterFile, error) {

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -8,8 +8,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var ensureWorkspaceIndex = workspace.EnsureIndex
+var saveWorkspaceIndex = workspace.SaveIndex
+
 func (s *Server) handleListProjects(c *gin.Context) {
-	idx, err := workspace.EnsureIndex()
+	idx, err := ensureWorkspaceIndex()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -34,7 +37,7 @@ func (s *Server) handleCreateProject(c *gin.Context) {
 		return
 	}
 
-	idx, err := workspace.EnsureIndex()
+	idx, err := ensureWorkspaceIndex()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -51,7 +54,7 @@ func (s *Server) handleCreateProject(c *gin.Context) {
 	}
 
 	idx.Names = append(idx.Names, req.Name)
-	if err := workspace.SaveIndex(idx); err != nil {
+	if err := saveWorkspaceIndex(idx); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -61,7 +64,7 @@ func (s *Server) handleCreateProject(c *gin.Context) {
 func (s *Server) handleSwitchProject(c *gin.Context) {
 	name := c.Param("name")
 
-	idx, err := workspace.EnsureIndex()
+	idx, err := ensureWorkspaceIndex()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -70,15 +73,18 @@ func (s *Server) handleSwitchProject(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "找不到專案：" + name})
 		return
 	}
-	if err := s.switchProject(name); err != nil {
+	newState, err := s.loadProjectState(name)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
 	idx.Active = name
-	if err := workspace.SaveIndex(idx); err != nil {
+	if err := saveWorkspaceIndex(idx); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	s.setProjectState(newState)
+	s.applyProjectSettings()
 	c.JSON(http.StatusOK, gin.H{"active": name})
 }

--- a/internal/server/projects.go
+++ b/internal/server/projects.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"net/http"
+	"novel-assistant/internal/workspace"
+	"os"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleListProjects(c *gin.Context) {
+	idx, err := workspace.EnsureIndex()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, idx)
+}
+
+func (s *Server) handleCreateProject(c *gin.Context) {
+	var req struct {
+		Name string `json:"name"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := workspace.ValidateName(req.Name); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Name == "default" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "default 是保留名稱"})
+		return
+	}
+
+	idx, err := workspace.EnsureIndex()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if workspace.ContainsName(idx, req.Name) {
+		c.JSON(http.StatusConflict, gin.H{"error": "專案名稱已存在"})
+		return
+	}
+
+	dataDir := workspace.ProjectDataDir(req.Name)
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	idx.Names = append(idx.Names, req.Name)
+	if err := workspace.SaveIndex(idx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"name": req.Name})
+}
+
+func (s *Server) handleSwitchProject(c *gin.Context) {
+	name := c.Param("name")
+
+	idx, err := workspace.EnsureIndex()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !workspace.ContainsName(idx, name) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "找不到專案：" + name})
+		return
+	}
+	if err := s.switchProject(name); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	idx.Active = name
+	if err := workspace.SaveIndex(idx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"active": name})
+}

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +15,9 @@ import (
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
+	"novel-assistant/internal/workspace"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestSwitchProject_IsolatesChapterFiles(t *testing.T) {
@@ -71,5 +77,154 @@ func TestSwitchProject_IsolatesChapterFiles(t *testing.T) {
 	}
 	if len(files) != 1 || files[0].Name != "第02章.md" {
 		t.Fatalf("expected only p2 chapter, got %#v", files)
+	}
+}
+
+func TestSwitchProject_KeepsGlobalModelSettings(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prev)
+	}()
+
+	if err := workspace.SaveIndex(workspace.Index{
+		Active: "default",
+		Names:  []string{"default", "p2"},
+	}); err != nil {
+		t.Fatalf("save workspace index: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("web", "templates"), 0755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("web", "templates", "dummy.html"), []byte(`{{define "dummy.html"}}ok{{end}}`), 0644); err != nil {
+		t.Fatalf("seed dummy template: %v", err)
+	}
+
+	globalStore := projectsettings.New(filepath.Join("data", "project_settings.json"), projectsettings.Settings{
+		OllamaURL:  "http://global-ollama:11434",
+		LLMModel:   "global-llm",
+		EmbedModel: "global-embed",
+		Port:       "18080",
+		DataDir:    "data",
+	})
+	if err := globalStore.Save(); err != nil {
+		t.Fatalf("save global settings: %v", err)
+	}
+
+	customStore := projectsettings.New(filepath.Join("workspaces", "p2", "project_settings.json"), projectsettings.Settings{
+		OllamaURL:  "http://project-ollama:11434",
+		LLMModel:   "project-llm",
+		EmbedModel: "project-embed",
+		Port:       "28080",
+		DataDir:    filepath.Join("workspaces", "p2"),
+	})
+	if err := customStore.Save(); err != nil {
+		t.Fatalf("save custom settings: %v", err)
+	}
+
+	s, err := New(&config.Config{
+		DataDir:    "data",
+		OllamaURL:  "http://bootstrap-ollama:11434",
+		LLMModel:   "bootstrap-llm",
+		EmbedModel: "bootstrap-embed",
+		Port:       "8080",
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+
+	if err := s.switchProject("p2"); err != nil {
+		t.Fatalf("switch project: %v", err)
+	}
+
+	if s.cfg.OllamaURL != "http://global-ollama:11434" {
+		t.Fatalf("expected global ollama url to stay global, got %q", s.cfg.OllamaURL)
+	}
+	if s.cfg.LLMModel != "global-llm" {
+		t.Fatalf("expected global llm model to stay global, got %q", s.cfg.LLMModel)
+	}
+	if s.cfg.EmbedModel != "global-embed" {
+		t.Fatalf("expected global embed model to stay global, got %q", s.cfg.EmbedModel)
+	}
+	if s.cfg.Port != "18080" {
+		t.Fatalf("expected global port to stay global, got %q", s.cfg.Port)
+	}
+}
+
+func TestHandleSwitchProject_DoesNotChangeStateWhenIndexSaveFails(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prev)
+	}()
+
+	if err := workspace.SaveIndex(workspace.Index{
+		Active: "default",
+		Names:  []string{"default", "p2"},
+	}); err != nil {
+		t.Fatalf("save workspace index: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("web", "templates"), 0755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("web", "templates", "dummy.html"), []byte(`{{define "dummy.html"}}ok{{end}}`), 0644); err != nil {
+		t.Fatalf("seed dummy template: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("workspaces", "p2"), 0755); err != nil {
+		t.Fatalf("mkdir p2: %v", err)
+	}
+
+	s, err := New(&config.Config{
+		DataDir:    "data",
+		OllamaURL:  "http://localhost:11434",
+		LLMModel:   "llama3.2",
+		EmbedModel: "nomic-embed-text",
+		Port:       "8080",
+	})
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	originalDataDir := s.currentState().dataDir
+
+	prevSave := saveWorkspaceIndex
+	saveWorkspaceIndex = func(idx workspace.Index) error {
+		return errors.New("disk full")
+	}
+	defer func() {
+		saveWorkspaceIndex = prevSave
+	}()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "name", Value: "p2"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/projects/p2/switch", http.NoBody)
+
+	s.handleSwitchProject(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when index save fails, got %d", w.Code)
+	}
+	if s.currentState().dataDir != originalDataDir {
+		t.Fatalf("expected active state to stay %q, got %q", originalDataDir, s.currentState().dataDir)
+	}
+
+	idx, err := workspace.EnsureIndex()
+	if err != nil {
+		t.Fatalf("reload workspace index: %v", err)
+	}
+	if idx.Active != "default" {
+		t.Fatalf("expected persisted active project to stay default, got %q", idx.Active)
 	}
 }

--- a/internal/server/projects_test.go
+++ b/internal/server/projects_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"novel-assistant/internal/config"
+	"novel-assistant/internal/profile"
+	"novel-assistant/internal/projectsettings"
+	"novel-assistant/internal/reviewhistory"
+	"novel-assistant/internal/reviewrules"
+	"novel-assistant/internal/tracker"
+	"novel-assistant/internal/vectorstore"
+)
+
+func TestSwitchProject_IsolatesChapterFiles(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prev)
+	}()
+
+	s := &Server{
+		cfg: &config.Config{DataDir: dir},
+		state: &projectState{
+			dataDir:       filepath.Join(dir, "data"),
+			profiles:      profile.NewManager(filepath.Join(dir, "data")),
+			store:         vectorstore.New(filepath.Join(dir, "data", "store.json")),
+			project:       projectsettings.New(filepath.Join(dir, "data", "project_settings.json"), projectsettings.Settings{DataDir: filepath.Join(dir, "data")}),
+			rules:         reviewrules.New(filepath.Join(dir, "data", "review_rules.json")),
+			history:       reviewhistory.New(filepath.Join(dir, "data", "reviews.json")),
+			relationships: tracker.NewRelationshipTracker(filepath.Join(dir, "data", "relationships.json")),
+			timeline:      tracker.NewTimelineTracker(filepath.Join(dir, "data", "timeline.json")),
+			foreshadow:    tracker.NewForeshadowTracker(filepath.Join(dir, "data", "foreshadow.json")),
+		},
+	}
+	s.setProjectState(s.state)
+
+	if _, err := s.saveChapterFile("第01章", "default chapter"); err != nil {
+		t.Fatalf("save default chapter: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join("workspaces", "p2", "chapters"), 0755); err != nil {
+		t.Fatalf("mkdir p2 chapters: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join("workspaces", "p2", "chapters", "第02章.md"), []byte("project 2 chapter"), 0644); err != nil {
+		t.Fatalf("seed p2 chapter: %v", err)
+	}
+
+	files, err := s.listChapterFiles()
+	if err != nil {
+		t.Fatalf("list default chapters: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "第01章.md" {
+		t.Fatalf("expected only default chapter, got %#v", files)
+	}
+
+	if err := s.switchProject("p2"); err != nil {
+		t.Fatalf("switch project: %v", err)
+	}
+
+	files, err = s.listChapterFiles()
+	if err != nil {
+		t.Fatalf("list p2 chapters: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "第02章.md" {
+		t.Fatalf("expected only p2 chapter, got %#v", files)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
+	"novel-assistant/internal/workspace"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,9 +24,23 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type projectState struct {
+	dataDir       string
+	profiles      *profile.Manager
+	store         *vectorstore.Store
+	project       *projectsettings.Store
+	rules         *reviewrules.Store
+	history       *reviewhistory.Store
+	relationships *tracker.RelationshipTracker
+	timeline      *tracker.TimelineTracker
+	foreshadow    *tracker.ForeshadowTracker
+}
+
 type Server struct {
 	cfg            *config.Config
 	router         *gin.Engine
+	stateMu        sync.RWMutex
+	state          *projectState
 	profiles       *profile.Manager
 	store          *vectorstore.Store
 	project        *projectsettings.Store
@@ -41,55 +56,23 @@ type Server struct {
 }
 
 func New(cfg *config.Config) (*Server, error) {
-	s := &Server{cfg: cfg}
-
-	s.project = projectsettings.New(cfg.DataDir+"/project_settings.json", projectsettings.Settings{
-		OllamaURL:  cfg.OllamaURL,
-		LLMModel:   cfg.LLMModel,
-		EmbedModel: cfg.EmbedModel,
-		Port:       cfg.Port,
-		DataDir:    cfg.DataDir,
-	})
-	if err := s.project.Load(); err != nil {
-		log.Printf("project settings load: %v", err)
+	idx, err := workspace.EnsureIndex()
+	if err != nil {
+		return nil, fmt.Errorf("load workspace index: %w", err)
 	}
+
+	s := &Server{
+		cfg:      cfg,
+		embedder: embedder.New(cfg.OllamaURL, cfg.EmbedModel),
+		checker:  checker.New(cfg.OllamaURL, cfg.LLMModel),
+	}
+
+	st, err := s.loadProjectState(idx.Active)
+	if err != nil {
+		return nil, fmt.Errorf("load project state: %w", err)
+	}
+	s.setProjectState(st)
 	s.applyProjectSettings()
-
-	s.profiles = profile.NewManager(cfg.DataDir)
-	if err := s.profiles.Load(); err != nil {
-		log.Printf("profiles load: %v", err)
-	}
-
-	s.store = vectorstore.New(cfg.DataDir + "/store.json")
-	if err := s.store.Load(); err != nil {
-		log.Printf("store load: %v", err)
-	}
-
-	s.embedder = embedder.New(cfg.OllamaURL, cfg.EmbedModel)
-	s.checker = checker.New(cfg.OllamaURL, cfg.LLMModel)
-	s.rules = reviewrules.New(cfg.DataDir + "/review_rules.json")
-	if err := s.rules.Load(); err != nil {
-		log.Printf("review rules load: %v", err)
-	}
-	s.history = reviewhistory.New(cfg.DataDir + "/reviews.json")
-	if err := s.history.Load(); err != nil {
-		log.Printf("review history load: %v", err)
-	}
-
-	s.relationships = tracker.NewRelationshipTracker(cfg.DataDir + "/relationships.json")
-	if err := s.relationships.Load(); err != nil {
-		log.Printf("relationships load: %v", err)
-	}
-
-	s.timeline = tracker.NewTimelineTracker(cfg.DataDir + "/timeline.json")
-	if err := s.timeline.Load(); err != nil {
-		log.Printf("timeline load: %v", err)
-	}
-
-	s.foreshadow = tracker.NewForeshadowTracker(cfg.DataDir + "/foreshadow.json")
-	if err := s.foreshadow.Load(); err != nil {
-		log.Printf("foreshadow load: %v", err)
-	}
 
 	gin.SetMode(gin.ReleaseMode)
 	s.router = gin.Default()
@@ -134,6 +117,7 @@ func (s *Server) setupRoutes() {
 	r.GET("/api/history/:id", s.handleGetHistoryEntry)
 	r.GET("/api/history/:id/diff", s.handleGetHistoryDiff)
 	r.GET("/api/backups", s.handleListBackups)
+	r.GET("/api/projects", s.handleListProjects)
 	r.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
 	r.GET("/api/chapters", s.handleListChapters)
 	r.GET("/api/chapters/:name", s.handleGetChapter)
@@ -152,6 +136,8 @@ func (s *Server) setupRoutes() {
 	r.POST("/api/history/delete", s.handleDeleteHistoryEntry)
 	r.POST("/api/history/export", s.handleExportHistory)
 	r.POST("/api/settings", s.handleSaveSettings)
+	r.POST("/api/projects", s.handleCreateProject)
+	r.POST("/api/projects/:name/switch", s.handleSwitchProject)
 	r.POST("/api/emotion-curve", s.handleEmotionCurve)
 	r.POST("/check/stream", s.handleCheckStream)
 	r.POST("/chat/stream", s.handleChatStream)
@@ -174,18 +160,128 @@ func (s *Server) setupRoutes() {
 	r.POST("/export", s.handleExport)
 }
 
+func (s *Server) loadProjectState(name string) (*projectState, error) {
+	dataDir := workspace.ProjectDataDir(name)
+
+	st := &projectState{dataDir: dataDir}
+	st.project = projectsettings.New(
+		filepath.Join(dataDir, "project_settings.json"),
+		projectsettings.Settings{
+			OllamaURL:  s.cfg.OllamaURL,
+			LLMModel:   s.cfg.LLMModel,
+			EmbedModel: s.cfg.EmbedModel,
+			Port:       s.cfg.Port,
+			DataDir:    dataDir,
+		},
+	)
+	if err := st.project.Load(); err != nil {
+		log.Printf("project settings load: %v", err)
+	}
+
+	st.profiles = profile.NewManager(dataDir)
+	if err := st.profiles.Load(); err != nil {
+		log.Printf("profiles load: %v", err)
+	}
+
+	st.store = vectorstore.New(filepath.Join(dataDir, "store.json"))
+	if err := st.store.Load(); err != nil {
+		log.Printf("store load: %v", err)
+	}
+
+	st.rules = reviewrules.New(filepath.Join(dataDir, "review_rules.json"))
+	if err := st.rules.Load(); err != nil {
+		log.Printf("review rules load: %v", err)
+	}
+
+	st.history = reviewhistory.New(filepath.Join(dataDir, "reviews.json"))
+	if err := st.history.Load(); err != nil {
+		log.Printf("review history load: %v", err)
+	}
+
+	st.relationships = tracker.NewRelationshipTracker(filepath.Join(dataDir, "relationships.json"))
+	if err := st.relationships.Load(); err != nil {
+		log.Printf("relationships load: %v", err)
+	}
+
+	st.timeline = tracker.NewTimelineTracker(filepath.Join(dataDir, "timeline.json"))
+	if err := st.timeline.Load(); err != nil {
+		log.Printf("timeline load: %v", err)
+	}
+
+	st.foreshadow = tracker.NewForeshadowTracker(filepath.Join(dataDir, "foreshadow.json"))
+	if err := st.foreshadow.Load(); err != nil {
+		log.Printf("foreshadow load: %v", err)
+	}
+
+	return st, nil
+}
+
+func (s *Server) currentState() *projectState {
+	s.stateMu.RLock()
+	st := s.state
+	s.stateMu.RUnlock()
+	if st != nil {
+		return st
+	}
+	if s.profiles == nil && s.store == nil && s.project == nil && s.rules == nil && s.history == nil &&
+		s.relationships == nil && s.timeline == nil && s.foreshadow == nil {
+		return nil
+	}
+	dataDir := s.cfg.DataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	return &projectState{
+		dataDir:       dataDir,
+		profiles:      s.profiles,
+		store:         s.store,
+		project:       s.project,
+		rules:         s.rules,
+		history:       s.history,
+		relationships: s.relationships,
+		timeline:      s.timeline,
+		foreshadow:    s.foreshadow,
+	}
+}
+
+func (s *Server) setProjectState(st *projectState) {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+	s.state = st
+	s.profiles = st.profiles
+	s.store = st.store
+	s.project = st.project
+	s.rules = st.rules
+	s.history = st.history
+	s.relationships = st.relationships
+	s.timeline = st.timeline
+	s.foreshadow = st.foreshadow
+	s.cfg.DataDir = st.dataDir
+}
+
+func (s *Server) switchProject(name string) error {
+	newState, err := s.loadProjectState(name)
+	if err != nil {
+		return err
+	}
+	s.setProjectState(newState)
+	s.applyProjectSettings()
+	return nil
+}
+
 func (s *Server) Ingest(ctx context.Context) error {
-	if err := s.profiles.Load(); err != nil {
+	st := s.currentState()
+	if err := st.profiles.Load(); err != nil {
 		return fmt.Errorf("load profiles: %w", err)
 	}
-	s.store.Clear()
+	st.store.Clear()
 
-	for _, char := range s.profiles.Characters {
+	for _, char := range st.profiles.Characters {
 		vec, err := s.embedder.Embed(ctx, char.RawContent)
 		if err != nil {
 			return fmt.Errorf("embed %s: %w", char.Name, err)
 		}
-		s.store.Upsert(vectorstore.Document{
+		st.store.Upsert(vectorstore.Document{
 			ID:        "char_" + char.Name,
 			Type:      "character",
 			Content:   char.RawContent,
@@ -194,12 +290,12 @@ func (s *Server) Ingest(ctx context.Context) error {
 		log.Printf("indexed character: %s", char.Name)
 	}
 
-	for _, world := range s.profiles.Worlds {
+	for _, world := range st.profiles.Worlds {
 		vec, err := s.embedder.Embed(ctx, world.RawContent)
 		if err != nil {
 			return fmt.Errorf("embed world %s: %w", world.Name, err)
 		}
-		s.store.Upsert(vectorstore.Document{
+		st.store.Upsert(vectorstore.Document{
 			ID:        "world_" + world.Name,
 			Type:      "world",
 			Content:   world.RawContent,
@@ -208,12 +304,12 @@ func (s *Server) Ingest(ctx context.Context) error {
 		log.Printf("indexed world: %s", world.Name)
 	}
 
-	for _, style := range s.profiles.Styles {
+	for _, style := range st.profiles.Styles {
 		vec, err := s.embedder.Embed(ctx, style.RawContent)
 		if err != nil {
 			return fmt.Errorf("embed style %s: %w", style.Name, err)
 		}
-		s.store.Upsert(vectorstore.Document{
+		st.store.Upsert(vectorstore.Document{
 			ID:        "style_" + style.Name,
 			Type:      "style",
 			Content:   style.RawContent,
@@ -222,7 +318,7 @@ func (s *Server) Ingest(ctx context.Context) error {
 		log.Printf("indexed style: %s", style.Name)
 	}
 
-	files, err := os.ReadDir(s.chapterDir())
+	files, err := os.ReadDir(chapterDirFor(st.dataDir))
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("list chapters: %w", err)
 	}
@@ -230,7 +326,7 @@ func (s *Server) Ingest(ctx context.Context) error {
 		if file.IsDir() || !strings.HasSuffix(strings.ToLower(file.Name()), ".md") {
 			continue
 		}
-		content, err := os.ReadFile(filepath.Join(s.chapterDir(), file.Name()))
+		content, err := os.ReadFile(filepath.Join(chapterDirFor(st.dataDir), file.Name()))
 		if err != nil {
 			return fmt.Errorf("read chapter %s: %w", file.Name(), err)
 		}
@@ -238,7 +334,7 @@ func (s *Server) Ingest(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("embed chapter %s: %w", file.Name(), err)
 		}
-		s.store.Upsert(vectorstore.Document{
+		st.store.Upsert(vectorstore.Document{
 			ID:        "chapter_" + file.Name(),
 			Type:      "chapter",
 			Content:   string(content),
@@ -247,7 +343,7 @@ func (s *Server) Ingest(ctx context.Context) error {
 		log.Printf("indexed chapter: %s", file.Name())
 	}
 
-	return s.store.Save()
+	return st.store.Save()
 }
 
 func (s *Server) Run() error {
@@ -255,12 +351,16 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) applyProjectSettings() {
-	settings := s.project.Get()
+	st := s.currentState()
+	if st == nil || st.project == nil {
+		return
+	}
+	settings := st.project.Get()
 	s.cfg.OllamaURL = settings.OllamaURL
 	s.cfg.LLMModel = settings.LLMModel
 	s.cfg.EmbedModel = settings.EmbedModel
 	s.cfg.Port = settings.Port
-	if settings.DataDir != "" {
-		s.cfg.DataDir = settings.DataDir
-	}
+	s.cfg.DataDir = st.dataDir
+	s.embedder = embedder.New(s.cfg.OllamaURL, s.cfg.EmbedModel)
+	s.checker = checker.New(s.cfg.OllamaURL, s.cfg.LLMModel)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,7 @@ type projectState struct {
 
 type Server struct {
 	cfg            *config.Config
+	globalDataDir  string
 	router         *gin.Engine
 	stateMu        sync.RWMutex
 	state          *projectState
@@ -62,9 +63,24 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 
 	s := &Server{
-		cfg:      cfg,
-		embedder: embedder.New(cfg.OllamaURL, cfg.EmbedModel),
-		checker:  checker.New(cfg.OllamaURL, cfg.LLMModel),
+		cfg:           cfg,
+		globalDataDir: cfg.DataDir,
+		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
+		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
+	}
+	if s.globalDataDir == "" {
+		s.globalDataDir = "data"
+	}
+
+	s.project = projectsettings.New(filepath.Join(s.globalDataDir, "project_settings.json"), projectsettings.Settings{
+		OllamaURL:  cfg.OllamaURL,
+		LLMModel:   cfg.LLMModel,
+		EmbedModel: cfg.EmbedModel,
+		Port:       cfg.Port,
+		DataDir:    s.globalDataDir,
+	})
+	if err := s.project.Load(); err != nil {
+		log.Printf("project settings load: %v", err)
 	}
 
 	st, err := s.loadProjectState(idx.Active)
@@ -164,19 +180,7 @@ func (s *Server) loadProjectState(name string) (*projectState, error) {
 	dataDir := workspace.ProjectDataDir(name)
 
 	st := &projectState{dataDir: dataDir}
-	st.project = projectsettings.New(
-		filepath.Join(dataDir, "project_settings.json"),
-		projectsettings.Settings{
-			OllamaURL:  s.cfg.OllamaURL,
-			LLMModel:   s.cfg.LLMModel,
-			EmbedModel: s.cfg.EmbedModel,
-			Port:       s.cfg.Port,
-			DataDir:    dataDir,
-		},
-	)
-	if err := st.project.Load(); err != nil {
-		log.Printf("project settings load: %v", err)
-	}
+	st.project = s.project
 
 	st.profiles = profile.NewManager(dataDir)
 	if err := st.profiles.Load(); err != nil {
@@ -351,16 +355,17 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) applyProjectSettings() {
-	st := s.currentState()
-	if st == nil || st.project == nil {
+	if s.project == nil {
 		return
 	}
-	settings := st.project.Get()
+	settings := s.project.Get()
 	s.cfg.OllamaURL = settings.OllamaURL
 	s.cfg.LLMModel = settings.LLMModel
 	s.cfg.EmbedModel = settings.EmbedModel
 	s.cfg.Port = settings.Port
-	s.cfg.DataDir = st.dataDir
+	if st := s.currentState(); st != nil {
+		s.cfg.DataDir = st.dataDir
+	}
 	s.embedder = embedder.New(s.cfg.OllamaURL, s.cfg.EmbedModel)
 	s.checker = checker.New(s.cfg.OllamaURL, s.cfg.LLMModel)
 }

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -87,7 +87,7 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		LLMModel:   req.LLMModel,
 		EmbedModel: req.EmbedModel,
 		Port:       req.Port,
-		DataDir:    s.cfg.DataDir,
+		DataDir:    s.globalDataDir,
 	})
 	if err := s.project.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "專案設定保存失敗"})

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,73 @@
+package workspace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var validName = regexp.MustCompile(`^[a-zA-Z0-9_\-]{1,64}$`)
+
+const indexPath = "workspaces/index.json"
+
+type Index struct {
+	Active string   `json:"active"`
+	Names  []string `json:"names"`
+}
+
+func ProjectDataDir(name string) string {
+	if name == "default" {
+		return "data"
+	}
+	return filepath.Join("workspaces", name)
+}
+
+func ValidateName(name string) error {
+	if !validName.MatchString(name) {
+		return fmt.Errorf("專案名稱只能包含英數字、-、_，長度 1-64")
+	}
+	return nil
+}
+
+func EnsureIndex() (Index, error) {
+	data, err := os.ReadFile(indexPath)
+	if os.IsNotExist(err) {
+		return Index{Active: "default", Names: []string{"default"}}, nil
+	}
+	if err != nil {
+		return Index{}, err
+	}
+	var idx Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return Index{}, err
+	}
+	if idx.Active == "" {
+		idx.Active = "default"
+	}
+	if len(idx.Names) == 0 {
+		idx.Names = []string{"default"}
+	}
+	return idx, nil
+}
+
+func SaveIndex(idx Index) error {
+	if err := os.MkdirAll("workspaces", 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(indexPath, data, 0644)
+}
+
+func ContainsName(idx Index, name string) bool {
+	for _, n := range idx.Names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,100 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProjectDataDir_Default(t *testing.T) {
+	t.Parallel()
+
+	if got := ProjectDataDir("default"); got != "data" {
+		t.Fatalf("expected default data dir to be data, got %q", got)
+	}
+}
+
+func TestProjectDataDir_Custom(t *testing.T) {
+	t.Parallel()
+
+	if got := ProjectDataDir("novel2"); got != filepath.Join("workspaces", "novel2") {
+		t.Fatalf("expected custom data dir under workspaces, got %q", got)
+	}
+}
+
+func TestEnsureIndex_NoFile_ReturnsDefault(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prev)
+	}()
+
+	idx, err := EnsureIndex()
+	if err != nil {
+		t.Fatalf("ensure index: %v", err)
+	}
+	if idx.Active != "default" {
+		t.Fatalf("expected active default, got %q", idx.Active)
+	}
+	if len(idx.Names) != 1 || idx.Names[0] != "default" {
+		t.Fatalf("expected names [default], got %#v", idx.Names)
+	}
+}
+
+func TestSaveAndLoadIndex(t *testing.T) {
+	dir := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(prev)
+	}()
+
+	want := Index{
+		Active: "novel2",
+		Names:  []string{"default", "novel2"},
+	}
+	if err := SaveIndex(want); err != nil {
+		t.Fatalf("save index: %v", err)
+	}
+
+	got, err := EnsureIndex()
+	if err != nil {
+		t.Fatalf("reload index: %v", err)
+	}
+	if got.Active != want.Active {
+		t.Fatalf("expected active %q, got %q", want.Active, got.Active)
+	}
+	if strings.Join(got.Names, ",") != strings.Join(want.Names, ",") {
+		t.Fatalf("expected names %v, got %v", want.Names, got.Names)
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"my-novel", "novel_2", "NovelA"}
+	for _, name := range valid {
+		if err := ValidateName(name); err != nil {
+			t.Fatalf("expected %q valid, got %v", name, err)
+		}
+	}
+
+	invalid := []string{"", "../../etc", "a b", strings.Repeat("a", 65)}
+	for _, name := range invalid {
+		if err := ValidateName(name); err == nil {
+			t.Fatalf("expected %q invalid", name)
+		}
+	}
+}

--- a/web/static/workspace.js
+++ b/web/static/workspace.js
@@ -1,0 +1,57 @@
+async function loadProjects() {
+  const sel = document.getElementById('project-select');
+  if (!sel) return;
+
+  const res = await fetch('/api/projects');
+  if (!res.ok) return;
+
+  const data = await res.json();
+  sel.innerHTML = '';
+  for (const name of data.names || []) {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === data.active) opt.selected = true;
+    sel.appendChild(opt);
+  }
+}
+
+async function switchProject(name) {
+  const res = await fetch(`/api/projects/${encodeURIComponent(name)}/switch`, { method: 'POST' });
+  if (!res.ok) {
+    let error = '切換失敗';
+    try {
+      const data = await res.json();
+      error = data.error || error;
+    } catch (_) {
+    }
+    alert(error);
+    await loadProjects();
+    return;
+  }
+  location.reload();
+}
+
+async function promptCreateProject() {
+  const name = prompt('新增專案名稱（英數、-、_，最長 64 字元）：');
+  if (!name) return;
+
+  const res = await fetch('/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) {
+    let error = '建立失敗';
+    try {
+      const data = await res.json();
+      error = data.error || error;
+    } catch (_) {
+    }
+    alert('建立失敗：' + error);
+    return;
+  }
+  await switchProject(name);
+}
+
+document.addEventListener('DOMContentLoaded', loadProjects);

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -17,9 +17,15 @@
     </ul>
   </nav>
   <div class="sidebar-footer">
+    <div id="project-switcher" style="margin-bottom:12px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+      <span style="font-size:0.85em;color:#888">專案：</span>
+      <select id="project-select" onchange="switchProject(this.value)" style="font-size:0.85em;flex:1;min-width:0"></select>
+      <button type="button" onclick="promptCreateProject()" style="font-size:0.8em">＋新增</button>
+    </div>
     <button class="btn-reindex" onclick="reindex()">重新索引</button>
   </div>
 </div>
+<script src="/static/workspace.js"></script>
 <script>
 function reindex() {
   fetch('/ingest', {method:'POST'})


### PR DESCRIPTION
## Summary
- add workspace index management and per-project server state loading
- add create/list/switch project APIs and a shared project switcher in the navigation
- keep the existing default data directory backward compatible while isolating project data under workspaces/

## Testing
- go test ./internal/workspace ./internal/server -run "TestProjectDataDir|TestEnsureIndex|TestSaveAndLoadIndex|TestValidateName|TestSwitchProject_IsolatesChapterFiles" -count=1
- go test ./internal/server -count=1
- go test ./...

Closes #10