### PR TITLE
chore: enforce PR scope rules via CI and template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
+## PR Type（只能勾一個）
+
+- [ ] feat — 新功能
+- [ ] fix — 修 bug
+- [ ] refactor — 不改行為的重構
+- [ ] chore — 格式、文件、依賴
+
 ## Summary
 
-- Issue:
+- Issue: Closes #
 - Explain the problem this PR solves.
 - Describe the main changes.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,35 @@ on:
   pull_request:
 
 jobs:
+  pr-size:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check PR size
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          lines=$(gh pr diff ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} | grep -cE '^[+-]' || true)
+          echo "Changed lines: $lines"
+          if [ "$lines" -gt 600 ]; then
+            echo "PR too large ($lines lines, limit 600). Split into smaller PRs."
+            exit 1
+          fi
+
+      - name: Check branch name
+        run: |
+          branch="${{ github.head_ref }}"
+          if ! echo "$branch" | grep -qE '^(feat|fix|refactor|chore)/'; then
+            echo "Branch name must start with feat/, fix/, refactor/, or chore/"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## PR Type（只能勾一個）

- [x] chore — 格式、文件、依賴

## Summary

- Issue: N/A
- 限制 PR 顆粒度，避免大 diff 導致 review 品質下降。

## Changes

- CI 新增 `pr-size` job：PR diff 超過 600 行則 fail
- CI 新增 branch 命名驗證：需以 `feat/`、`fix/`、`refactor/`、`chore/` 開頭
- PR template 新增 type checklist 與 `Closes #` 欄位

## Verification

- [x] `go test ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)