### PR TITLE
feat: backup manifest, preview, rotation, and restore safety snapshot

### DIFF
--- a/docs/plans/issue-11-backup-preview-rotation.md
+++ b/docs/plans/issue-11-backup-preview-rotation.md
@@ -1,0 +1,58 @@
+# Issue #11 Plan: Backup Preview and Snapshot Rotation
+
+## Goal
+
+Make backup and restore safer by showing users what a snapshot contains before restore, limiting snapshot growth automatically, and making restore messaging clearer.
+
+## Why
+
+Raw restore is too risky once a project contains meaningful manuscript work.
+
+Users need enough context to trust a restore action, and the app should not keep snapshots forever without any cleanup policy.
+
+## Scope
+
+1. Add snapshot metadata so each backup can be previewed without opening raw files.
+2. Expose backup preview data to the settings page and restore flow.
+3. Add a project-level retention setting for automatic snapshot rotation.
+4. Create a safety snapshot before restore and report it clearly to the user.
+5. Add regression tests for metadata generation, rotation, and restore safety behavior.
+
+## Proposed Design
+
+### Snapshot Manifest
+
+Each backup directory includes a `.backup_manifest.json` file containing:
+
+- snapshot name and creation time
+- counts for chapters, characters, worldbuilding files, style guides, and JSON state files
+- total file count
+- a short sample list of chapter filenames
+
+This allows the UI and API to show preview details without traversing the snapshot every time.
+
+### Preview Flow
+
+- `GET /api/backups` returns backup items plus preview metadata when available
+- `GET /api/backups/:name/preview` returns one snapshot preview for focused UI refresh
+- settings page shows the selected backup summary before restore
+
+### Retention Policy
+
+- add `backup_retention` to project settings
+- default to a small safe cap
+- after each new snapshot, delete oldest backups beyond the retention cap
+- keep the rule simple: count-based retention only
+
+### Restore Safety
+
+- before restore, create an automatic safety snapshot of the current data
+- return a clearer restore message that includes both the restored backup name and the new safety snapshot name
+- reload in-memory data after restore as before
+
+## Done When
+
+- users can preview the selected snapshot before restoring
+- backups rotate automatically according to project settings
+- restore messaging explains what happened and where the safety snapshot is
+- focused backend tests cover metadata, rotation, and restore behavior

--- a/internal/projectsettings/store.go
+++ b/internal/projectsettings/store.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Settings struct {
-	OllamaURL  string `json:"ollama_url"`
-	LLMModel   string `json:"llm_model"`
-	EmbedModel string `json:"embed_model"`
-	Port       string `json:"port"`
-	DataDir    string `json:"data_dir"`
+	OllamaURL       string `json:"ollama_url"`
+	LLMModel        string `json:"llm_model"`
+	EmbedModel      string `json:"embed_model"`
+	Port            string `json:"port"`
+	DataDir         string `json:"data_dir"`
+	BackupRetention int    `json:"backup_retention"`
 }
 
 type Store struct {
@@ -23,11 +24,12 @@ type Store struct {
 
 func Defaults() Settings {
 	return Settings{
-		OllamaURL:  "http://localhost:11434",
-		LLMModel:   "llama3.2",
-		EmbedModel: "nomic-embed-text",
-		Port:       "8080",
-		DataDir:    "data",
+		OllamaURL:       "http://localhost:11434",
+		LLMModel:        "llama3.2",
+		EmbedModel:      "nomic-embed-text",
+		Port:            "8080",
+		DataDir:         "data",
+		BackupRetention: 10,
 	}
 }
 
@@ -97,6 +99,9 @@ func normalize(item Settings) Settings {
 	}
 	if item.DataDir == "" {
 		item.DataDir = def.DataDir
+	}
+	if item.BackupRetention < 1 {
+		item.BackupRetention = def.BackupRetention
 	}
 	return item
 }

--- a/internal/projectsettings/store_test.go
+++ b/internal/projectsettings/store_test.go
@@ -9,4 +9,7 @@ func TestNormalizeFillsDefaults(t *testing.T) {
 	if item.OllamaURL == "" || item.LLMModel == "" || item.EmbedModel == "" || item.Port == "" {
 		t.Fatalf("expected defaults, got %#v", item)
 	}
+	if item.BackupRetention < 1 {
+		t.Fatalf("expected backup retention default, got %#v", item)
+	}
 }

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -3,11 +3,13 @@ package server
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -44,12 +46,99 @@ type manuscriptExportRequest struct {
 }
 
 type backupItem struct {
-	Name      string    `json:"name"`
-	CreatedAt time.Time `json:"created_at"`
+	Name      string        `json:"name"`
+	CreatedAt time.Time     `json:"created_at"`
+	Preview   backupPreview `json:"preview"`
+}
+
+type backupPreview struct {
+	Name           string    `json:"name"`
+	CreatedAt      time.Time `json:"created_at"`
+	ChapterCount   int       `json:"chapter_count"`
+	CharacterCount int       `json:"character_count"`
+	WorldCount     int       `json:"world_count"`
+	StyleCount     int       `json:"style_count"`
+	JSONFileCount  int       `json:"json_file_count"`
+	TotalFileCount int       `json:"total_file_count"`
+	ChapterSamples []string  `json:"chapter_samples"`
 }
 
 func (s *Server) backupDir() string {
 	return filepath.Join(s.cfg.DataDir, "backups")
+}
+
+func backupManifestPath(dir string) string {
+	return filepath.Join(dir, ".backup_manifest.json")
+}
+
+func loadBackupPreview(dir string, fallbackName string, fallbackTime time.Time) (backupPreview, error) {
+	data, err := os.ReadFile(backupManifestPath(dir))
+	if err == nil {
+		var preview backupPreview
+		if err := json.Unmarshal(data, &preview); err == nil {
+			if preview.Name == "" {
+				preview.Name = fallbackName
+			}
+			if preview.CreatedAt.IsZero() {
+				preview.CreatedAt = fallbackTime
+			}
+			return preview, nil
+		}
+	}
+	return buildBackupPreview(dir, fallbackName, fallbackTime)
+}
+
+func buildBackupPreview(dir string, name string, createdAt time.Time) (backupPreview, error) {
+	preview := backupPreview{Name: name, CreatedAt: createdAt}
+	chapterSamples := make([]string, 0, 3)
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == ".backup_manifest.json" {
+			return nil
+		}
+
+		preview.TotalFileCount++
+		switch {
+		case strings.HasPrefix(rel, "chapters"+string(filepath.Separator)) && strings.HasSuffix(strings.ToLower(d.Name()), ".md"):
+			preview.ChapterCount++
+			if len(chapterSamples) < 3 {
+				chapterSamples = append(chapterSamples, d.Name())
+			}
+		case strings.HasPrefix(rel, "characters"+string(filepath.Separator)) && strings.HasSuffix(strings.ToLower(d.Name()), ".md"):
+			preview.CharacterCount++
+		case strings.HasPrefix(rel, "worldbuilding"+string(filepath.Separator)) && strings.HasSuffix(strings.ToLower(d.Name()), ".md"):
+			preview.WorldCount++
+		case strings.HasPrefix(rel, "style"+string(filepath.Separator)) && strings.HasSuffix(strings.ToLower(d.Name()), ".md"):
+			preview.StyleCount++
+		case strings.HasSuffix(strings.ToLower(d.Name()), ".json"):
+			preview.JSONFileCount++
+		}
+		return nil
+	})
+	if err != nil {
+		return backupPreview{}, err
+	}
+	sort.Strings(chapterSamples)
+	preview.ChapterSamples = chapterSamples
+	return preview, nil
+}
+
+func writeBackupPreview(dir string, preview backupPreview) error {
+	data, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(backupManifestPath(dir), data, 0644)
 }
 
 func listBackupItems(dir string) ([]backupItem, error) {
@@ -69,8 +158,15 @@ func listBackupItems(dir string) ([]backupItem, error) {
 		if err != nil {
 			continue
 		}
-		items = append(items, backupItem{Name: entry.Name(), CreatedAt: info.ModTime()})
+		preview, err := loadBackupPreview(filepath.Join(dir, entry.Name()), entry.Name(), info.ModTime())
+		if err != nil {
+			continue
+		}
+		items = append(items, backupItem{Name: entry.Name(), CreatedAt: info.ModTime(), Preview: preview})
 	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].CreatedAt.After(items[j].CreatedAt)
+	})
 	return items, nil
 }
 
@@ -116,16 +212,66 @@ func copySnapshotTree(srcDir, dstDir string) error {
 	})
 }
 
-func (s *Server) createBackupSnapshot() (backupItem, error) {
-	name := "backup_" + time.Now().Format("20060102_150405")
+func pruneOldBackups(dir string, retain int, protected map[string]struct{}) ([]string, error) {
+	if retain < 1 {
+		return nil, nil
+	}
+	items, err := listBackupItems(dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) <= retain {
+		return nil, nil
+	}
+
+	removed := make([]string, 0, len(items)-retain)
+	for _, item := range items[retain:] {
+		if _, ok := protected[item.Name]; ok {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(dir, item.Name)); err != nil {
+			return removed, err
+		}
+		removed = append(removed, item.Name)
+	}
+	return removed, nil
+}
+
+func (s *Server) createBackupSnapshotWithPrefix(prefix string) (backupItem, []string, error) {
+	return s.createBackupSnapshotWithPrefixProtected(prefix, nil)
+}
+
+func (s *Server) createBackupSnapshotWithPrefixProtected(prefix string, protected map[string]struct{}) (backupItem, []string, error) {
+	name := prefix + "_" + time.Now().Format("20060102_150405")
+	createdAt := time.Now()
 	target := filepath.Join(s.backupDir(), name)
 	if err := os.MkdirAll(target, 0755); err != nil {
-		return backupItem{}, err
+		return backupItem{}, nil, err
 	}
 	if err := copySnapshotTree(s.cfg.DataDir, target); err != nil {
-		return backupItem{}, err
+		return backupItem{}, nil, err
 	}
-	return backupItem{Name: name, CreatedAt: time.Now()}, nil
+	preview, err := buildBackupPreview(target, name, createdAt)
+	if err != nil {
+		return backupItem{}, nil, err
+	}
+	if err := writeBackupPreview(target, preview); err != nil {
+		return backupItem{}, nil, err
+	}
+	retention := 10
+	if s.project != nil {
+		retention = s.project.Get().BackupRetention
+	}
+	removed, err := pruneOldBackups(s.backupDir(), retention, protected)
+	if err != nil {
+		return backupItem{}, removed, err
+	}
+	return backupItem{Name: name, CreatedAt: createdAt, Preview: preview}, removed, nil
+}
+
+func (s *Server) createBackupSnapshot() (backupItem, error) {
+	item, _, err := s.createBackupSnapshotWithPrefix("backup")
+	return item, err
 }
 
 func (s *Server) handleListBackups(c *gin.Context) {
@@ -137,13 +283,37 @@ func (s *Server) handleListBackups(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": items})
 }
 
-func (s *Server) handleCreateBackup(c *gin.Context) {
-	item, err := s.createBackupSnapshot()
+func (s *Server) handleGetBackupPreview(c *gin.Context) {
+	name := strings.TrimSpace(c.Param("name"))
+	if name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "缺少備份名稱"})
+		return
+	}
+	src := filepath.Join(s.backupDir(), name)
+	info, err := os.Stat(src)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "找不到指定備份"})
+		return
+	}
+	preview, err := loadBackupPreview(src, name, info.ModTime())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"ok": true, "item": item, "message": "備份已建立"})
+	c.JSON(http.StatusOK, gin.H{"item": backupItem{Name: name, CreatedAt: info.ModTime(), Preview: preview}})
+}
+
+func (s *Server) handleCreateBackup(c *gin.Context) {
+	item, removed, err := s.createBackupSnapshotWithPrefix("backup")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	message := "備份已建立"
+	if len(removed) > 0 {
+		message += fmt.Sprintf("，並清理 %d 份舊備份", len(removed))
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "item": item, "removed": removed, "message": message})
 }
 
 func (s *Server) handleRestoreBackup(c *gin.Context) {
@@ -164,6 +334,12 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 		return
 	}
 
+	safetySnapshot, removed, err := s.createBackupSnapshotWithPrefixProtected("pre_restore", map[string]struct{}{name: {}})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "建立還原前安全備份失敗：" + err.Error()})
+		return
+	}
+
 	if err := copySnapshotTree(src, s.cfg.DataDir); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -179,7 +355,13 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 	_ = s.timeline.Load()
 	_ = s.foreshadow.Load()
 
-	c.JSON(http.StatusOK, gin.H{"ok": true, "message": "備份已還原，建議重新索引"})
+	c.JSON(http.StatusOK, gin.H{
+		"ok":              true,
+		"message":         fmt.Sprintf("已還原備份 %s，並先建立安全備份 %s。建議重新索引。", name, safetySnapshot.Name),
+		"restored":        name,
+		"safety_snapshot": safetySnapshot,
+		"removed":         removed,
+	})
 }
 
 func addZipFile(zw *zip.Writer, path, name string) error {

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -212,6 +212,38 @@ func copySnapshotTree(srcDir, dstDir string) error {
 	})
 }
 
+// cleanDataDirForRestore removes all managed files (.md, .json, .gitkeep)
+// from dataDir before a restore so that files absent from the snapshot are
+// not left behind (true point-in-time restore, not an overlay).
+func cleanDataDirForRestore(dataDir string) error {
+	return filepath.WalkDir(dataDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == dataDir {
+			return nil
+		}
+		rel, err := filepath.Rel(dataDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "backups" || strings.HasPrefix(rel, "backups"+string(filepath.Separator)) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(d.Name())
+		if ext == ".md" || ext == ".json" || d.Name() == ".gitkeep" {
+			return os.Remove(path)
+		}
+		return nil
+	})
+}
+
 func pruneOldBackups(dir string, retain int, protected map[string]struct{}) ([]string, error) {
 	if retain < 1 {
 		return nil, nil
@@ -237,25 +269,34 @@ func pruneOldBackups(dir string, retain int, protected map[string]struct{}) ([]s
 	return removed, nil
 }
 
+// writeSnapshot creates a snapshot directory and manifest without pruning.
+func (s *Server) writeSnapshot(prefix string) (backupItem, error) {
+	name := prefix + "_" + time.Now().Format("20060102_150405")
+	createdAt := time.Now()
+	target := filepath.Join(s.backupDir(), name)
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return backupItem{}, err
+	}
+	if err := copySnapshotTree(s.cfg.DataDir, target); err != nil {
+		return backupItem{}, err
+	}
+	preview, err := buildBackupPreview(target, name, createdAt)
+	if err != nil {
+		return backupItem{}, err
+	}
+	if err := writeBackupPreview(target, preview); err != nil {
+		return backupItem{}, err
+	}
+	return backupItem{Name: name, CreatedAt: createdAt, Preview: preview}, nil
+}
+
 func (s *Server) createBackupSnapshotWithPrefix(prefix string) (backupItem, []string, error) {
 	return s.createBackupSnapshotWithPrefixProtected(prefix, nil)
 }
 
 func (s *Server) createBackupSnapshotWithPrefixProtected(prefix string, protected map[string]struct{}) (backupItem, []string, error) {
-	name := prefix + "_" + time.Now().Format("20060102_150405")
-	createdAt := time.Now()
-	target := filepath.Join(s.backupDir(), name)
-	if err := os.MkdirAll(target, 0755); err != nil {
-		return backupItem{}, nil, err
-	}
-	if err := copySnapshotTree(s.cfg.DataDir, target); err != nil {
-		return backupItem{}, nil, err
-	}
-	preview, err := buildBackupPreview(target, name, createdAt)
+	item, err := s.writeSnapshot(prefix)
 	if err != nil {
-		return backupItem{}, nil, err
-	}
-	if err := writeBackupPreview(target, preview); err != nil {
 		return backupItem{}, nil, err
 	}
 	retention := 10
@@ -266,7 +307,7 @@ func (s *Server) createBackupSnapshotWithPrefixProtected(prefix string, protecte
 	if err != nil {
 		return backupItem{}, removed, err
 	}
-	return backupItem{Name: name, CreatedAt: createdAt, Preview: preview}, removed, nil
+	return item, removed, nil
 }
 
 func (s *Server) createBackupSnapshot() (backupItem, error) {
@@ -334,12 +375,16 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 		return
 	}
 
-	safetySnapshot, removed, err := s.createBackupSnapshotWithPrefixProtected("pre_restore", map[string]struct{}{name: {}})
+	safetySnapshot, err := s.writeSnapshot("pre_restore")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "建立還原前安全備份失敗：" + err.Error()})
 		return
 	}
 
+	if err := cleanDataDirForRestore(s.cfg.DataDir); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "清除現有資料失敗：" + err.Error()})
+		return
+	}
 	if err := copySnapshotTree(src, s.cfg.DataDir); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -354,6 +399,13 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 	_ = s.relationships.Load()
 	_ = s.timeline.Load()
 	_ = s.foreshadow.Load()
+
+	retention := 10
+	if s.project != nil {
+		retention = s.project.Get().BackupRetention
+	}
+	protected := map[string]struct{}{name: {}, safetySnapshot.Name: {}}
+	removed, _ := pruneOldBackups(s.backupDir(), retention, protected)
 
 	c.JSON(http.StatusOK, gin.H{
 		"ok":              true,

--- a/internal/server/ops.go
+++ b/internal/server/ops.go
@@ -399,6 +399,10 @@ func (s *Server) handleRestoreBackup(c *gin.Context) {
 	_ = s.relationships.Load()
 	_ = s.timeline.Load()
 	_ = s.foreshadow.Load()
+	if s.project != nil {
+		_ = s.project.Load()
+		s.applyProjectSettings()
+	}
 
 	retention := 10
 	if s.project != nil {

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -173,6 +173,49 @@ func TestHandleRestoreBackupCreatesSafetySnapshot(t *testing.T) {
 	}
 }
 
+func TestRestoreBackupRemovesFilesAbsentFromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+
+	if _, err := s.saveChapterFile("第01章", "快照時的內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+	item, err := s.createBackupSnapshot()
+	if err != nil {
+		t.Fatalf("create backup: %v", err)
+	}
+
+	if _, err := s.saveChapterFile("第02章", "快照後新增的章節"); err != nil {
+		t.Fatalf("save new chapter: %v", err)
+	}
+	newChapter := filepath.Join(dir, "chapters", "第02章.md")
+	if _, err := os.Stat(newChapter); err != nil {
+		t.Fatalf("expected new chapter to exist before restore: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/backups/restore", strings.NewReader(`{"name":"`+item.Name+`"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	s.handleRestoreBackup(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected restore success, got %d %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(newChapter); !os.IsNotExist(err) {
+		t.Fatalf("expected post-snapshot chapter to be removed after restore, but it still exists")
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "chapters", "第01章.md"))
+	if err != nil {
+		t.Fatalf("expected snapshot chapter to be restored: %v", err)
+	}
+	if string(content) != "快照時的內容" {
+		t.Fatalf("unexpected chapter content after restore: %q", content)
+	}
+}
+
 func TestZipHelperWritesReadableFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/ops_test.go
+++ b/internal/server/ops_test.go
@@ -10,12 +10,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"novel-assistant/internal/config"
 	"novel-assistant/internal/profile"
+	"novel-assistant/internal/projectsettings"
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
+	"novel-assistant/internal/vectorstore"
 
 	"github.com/gin-gonic/gin"
 )
@@ -70,13 +73,103 @@ func TestCreateBackupSnapshotCopiesMarkdownAndJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{cfg: &config.Config{DataDir: dir}}
+	s := &Server{
+		cfg:     &config.Config{DataDir: dir},
+		project: projectsettings.New(filepath.Join(dir, "project_settings.json"), projectsettings.Settings{DataDir: dir}),
+	}
 	item, err := s.createBackupSnapshot()
 	if err != nil {
 		t.Fatalf("expected backup snapshot, got error: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "backups", item.Name, "chapters", "第01章.md")); err != nil {
 		t.Fatalf("expected chapter in backup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "backups", item.Name, ".backup_manifest.json")); err != nil {
+		t.Fatalf("expected backup manifest: %v", err)
+	}
+}
+
+func TestCreateBackupSnapshotPrunesOldSnapshots(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	for i, name := range []string{"backup_newest", "backup_middle", "backup_oldest"} {
+		target := filepath.Join(backupDir, name)
+		if err := os.MkdirAll(target, 0755); err != nil {
+			t.Fatal(err)
+		}
+		ts := now.Add(-time.Duration(i) * time.Hour)
+		if err := writeBackupPreview(target, backupPreview{Name: name, CreatedAt: ts}); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(target, ts, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removed, err := pruneOldBackups(backupDir, 2, nil)
+	if err != nil {
+		t.Fatalf("prune backups: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "backup_oldest" {
+		t.Fatalf("expected oldest backup pruned, got %v", removed)
+	}
+}
+
+func TestHandleRestoreBackupCreatesSafetySnapshot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := newOpsTestServer(dir)
+	if _, err := s.saveChapterFile("第01章", "目前內容"); err != nil {
+		t.Fatalf("save chapter: %v", err)
+	}
+
+	item, err := s.createBackupSnapshot()
+	if err != nil {
+		t.Fatalf("create backup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "chapters", "第01章.md"), []byte("被覆蓋前的現況"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/backups/restore", strings.NewReader(`{"name":"`+item.Name+`"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	s.handleRestoreBackup(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected restore success, got %d %s", w.Code, w.Body.String())
+	}
+	content, err := os.ReadFile(filepath.Join(dir, "chapters", "第01章.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "目前內容" {
+		t.Fatalf("expected restored chapter content, got %q", content)
+	}
+
+	items, err := listBackupItems(filepath.Join(dir, "backups"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundSafety := false
+	for _, candidate := range items {
+		if strings.HasPrefix(candidate.Name, "pre_restore_") {
+			foundSafety = true
+			break
+		}
+	}
+	if !foundSafety {
+		t.Fatalf("expected safety snapshot before restore, got %#v", items)
 	}
 }
 
@@ -497,9 +590,12 @@ Open.`); err != nil {
 }
 
 func newOpsTestServer(dir string) *Server {
+	project := projectsettings.New(filepath.Join(dir, "project_settings.json"), projectsettings.Settings{DataDir: dir})
 	return &Server{
 		cfg:           &config.Config{DataDir: dir},
+		project:       project,
 		profiles:      profile.NewManager(dir),
+		store:         vectorstore.New(filepath.Join(dir, "store.json")),
 		rules:         reviewrules.New(filepath.Join(dir, "review_rules.json")),
 		history:       reviewhistory.New(filepath.Join(dir, "reviews.json")),
 		timeline:      tracker.NewTimelineTracker(filepath.Join(dir, "timeline.json")),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -133,6 +133,7 @@ func (s *Server) setupRoutes() {
 	r.GET("/api/history/:id", s.handleGetHistoryEntry)
 	r.GET("/api/history/:id/diff", s.handleGetHistoryDiff)
 	r.GET("/api/backups", s.handleListBackups)
+	r.GET("/api/backups/:name/preview", s.handleGetBackupPreview)
 	r.GET("/api/projects", s.handleListProjects)
 	r.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
 	r.GET("/api/chapters", s.handleListChapters)

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -85,11 +85,11 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 	}
 
 	s.project.Update(projectsettings.Settings{
-		OllamaURL:  req.OllamaURL,
-		LLMModel:   req.LLMModel,
-		EmbedModel: req.EmbedModel,
-		Port:       req.Port,
-		DataDir:    s.cfg.DataDir,
+		OllamaURL:       req.OllamaURL,
+		LLMModel:        req.LLMModel,
+		EmbedModel:      req.EmbedModel,
+		Port:            req.Port,
+		DataDir:         s.cfg.DataDir,
 		BackupRetention: req.BackupRetention,
 	})
 	if err := s.project.Save(); err != nil {

--- a/internal/server/settings.go
+++ b/internal/server/settings.go
@@ -24,6 +24,7 @@ type settingsSaveRequest struct {
 	LLMModel           string                                 `json:"llm_model"`
 	EmbedModel         string                                 `json:"embed_model"`
 	Port               string                                 `json:"port"`
+	BackupRetention    int                                    `json:"backup_retention"`
 }
 
 func (s *Server) handleSettingsPage(c *gin.Context) {
@@ -57,6 +58,7 @@ func (s *Server) handleGetSettings(c *gin.Context) {
 		"llm_model":           project.LLMModel,
 		"embed_model":         project.EmbedModel,
 		"port":                project.Port,
+		"backup_retention":    project.BackupRetention,
 	})
 }
 
@@ -87,7 +89,8 @@ func (s *Server) handleSaveSettings(c *gin.Context) {
 		LLMModel:   req.LLMModel,
 		EmbedModel: req.EmbedModel,
 		Port:       req.Port,
-		DataDir:    s.globalDataDir,
+		DataDir:    s.cfg.DataDir,
+		BackupRetention: req.BackupRetention,
 	})
 	if err := s.project.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "專案設定保存失敗"})

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -35,6 +35,10 @@
           <label for="project-port">服務 Port</label>
           <input type="text" id="project-port" value="{{.Project.Port}}">
         </div>
+        <div class="form-group">
+          <label for="backup-retention">備份保留數量</label>
+          <input type="number" id="backup-retention" min="1" max="100" value="{{.Project.BackupRetention}}">
+        </div>
         <div class="helper-text">修改 Ollama URL 或模型後會立即影響後續審查；若修改 Port，需重啟服務才會生效。</div>
       </div>
 
@@ -43,13 +47,14 @@
         <button class="btn btn-ghost" type="button" onclick="createBackup()">建立資料備份</button>
         <div class="form-group" style="margin-top:16px">
           <label for="backup-select">可還原備份</label>
-          <select id="backup-select">
+          <select id="backup-select" onchange="renderBackupPreview()">
             <option value="">選擇備份...</option>
             {{range .Backups}}
             <option value="{{.Name}}">{{.Name}}（{{.CreatedAt.Format "2006-01-02 15:04:05"}}）</option>
             {{end}}
           </select>
         </div>
+        <div id="backup-preview" class="helper-text" style="margin-top:12px">選取備份後，這裡會顯示章節數、角色數與快照摘要。</div>
         <button class="btn btn-danger" type="button" onclick="restoreBackup()">還原選取備份</button>
         <div id="backup-status" class="helper-text">每次備份都會將目前 `data/` 內的 Markdown / JSON 資料快照到 `data/backups/`。</div>
       </div>
@@ -152,6 +157,7 @@ const retrievalSources = {{ jsonJS .Settings.RetrievalSources }};
 const retrievalTopK = {{ jsonJS .Settings.RetrievalTopK }};
 const retrievalThreshold = {{ jsonJS .Settings.RetrievalThreshold }};
 const retrievalPresets = {{ jsonJS .Settings.Presets }} || {};
+const backupItems = {{ jsonJS .Backups }} || [];
 const presetTasks = [
   { key: 'behavior', label: '行為一致性' },
   { key: 'dialogue', label: '對白風格' },
@@ -174,6 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('global-retrieval-threshold').addEventListener('input', updateGlobalThresholdDisplay);
   updateGlobalThresholdDisplay();
   renderPresetEditors();
+  renderBackupPreview();
 });
 
 function updateGlobalThresholdDisplay() {
@@ -248,6 +255,26 @@ function collectRetrievalPresets() {
   return out;
 }
 
+function selectedBackupItem() {
+  const name = document.getElementById('backup-select').value;
+  return backupItems.find((item) => item.name === name) || null;
+}
+
+function backupPreviewText(item) {
+  if (!item || !item.preview) {
+    return '選取備份後，這裡會顯示章節數、角色數與快照摘要。';
+  }
+  const preview = item.preview;
+  const samples = Array.isArray(preview.chapter_samples) && preview.chapter_samples.length
+    ? ` 章節樣本：${preview.chapter_samples.join('、')}`
+    : '';
+  return `建立時間：${new Date(preview.created_at).toLocaleString()}，章節 ${preview.chapter_count}、角色 ${preview.character_count}、世界觀 ${preview.world_count}、風格 ${preview.style_count}、JSON 狀態 ${preview.json_file_count}、總檔案 ${preview.total_file_count}。${samples}`;
+}
+
+function renderBackupPreview() {
+  document.getElementById('backup-preview').textContent = backupPreviewText(selectedBackupItem());
+}
+
 async function saveSettings() {
   const status = document.getElementById('settings-status');
   status.textContent = '保存中...';
@@ -269,7 +296,8 @@ async function saveSettings() {
         ollama_url: document.getElementById('ollama-url').value.trim(),
         llm_model: document.getElementById('llm-model').value.trim(),
         embed_model: document.getElementById('embed-model').value.trim(),
-        port: document.getElementById('project-port').value.trim()
+        port: document.getElementById('project-port').value.trim(),
+        backup_retention: Math.max(1, Number(document.getElementById('backup-retention').value) || 1)
       })
     });
     const data = await resp.json();
@@ -303,7 +331,11 @@ async function restoreBackup() {
     alert('請先選擇要還原的備份');
     return;
   }
-  if (!confirm('要還原這份備份嗎？目前 data/ 內容會被覆蓋。')) return;
+  const item = selectedBackupItem();
+  const warning = item
+    ? `要還原 ${name} 嗎？\n\n這份快照包含 ${item.preview.chapter_count} 個章節、${item.preview.character_count} 個角色與 ${item.preview.total_file_count} 個檔案。\n還原前系統會先自動建立一份安全備份。`
+    : '要還原這份備份嗎？目前 data/ 內容會被覆蓋，且系統會先建立安全備份。';
+  if (!confirm(warning)) return;
 
   const status = document.getElementById('backup-status');
   status.textContent = '還原備份中...';


### PR DESCRIPTION
## PR Type（只能勾一個）

- [x] feat — 新功能

## Summary

- Issue: Closes #11
- 新增備份 manifest/preview、count-based rotation，以及 restore 前自動建立安全備份。

## Changes

**後端**
- `ops.go`：backup manifest / preview、`GET /api/backups/:name/preview`、count-based snapshot rotation、restore 前自動建立 `pre_restore_*` 安全備份

**設定**
- `store.go` / `settings.go`：新增 `backup_retention` 專案設定，預設為 10

**UI**
- `settings.html`：備份保留數量欄位、所選備份 preview 摘要、更清楚的 restore 確認文案

**測試**
- `ops_test.go` / `store_test.go`：覆蓋 manifest、rotation、restore safety snapshot

## Verification

- [x] `go test ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)