### PR TITLE
feat: add optional local authentication mode

### DIFF
--- a/docs/plans/issue-12-local-auth-mode.md
+++ b/docs/plans/issue-12-local-auth-mode.md
@@ -1,0 +1,41 @@
+# Issue 12 工作計畫：可選本機驗證模式
+
+## 目標
+
+在不影響單機預設使用體驗的前提下，新增一個可選的本機 / 區網密碼保護模式。
+
+## 範圍
+
+- 保留預設 `open mode`，未設定驗證環境變數時維持現況
+- 新增 `password mode`，用單一密碼保護所有頁面與 API
+- 使用 cookie session，避免每次請求都重送密碼
+- 設定來源以環境變數為主，不把帳號管理做進這一版
+
+## 設計決策
+
+- 驗證模式先採單一密碼，不做多帳號資料模型，控制複雜度與 PR 大小
+- session 採記憶體保存，重啟服務後重新登入即可，符合本機工具使用情境
+- 未登入的瀏覽器頁面導向 `/login`，未登入的 API 請求回傳 `401`
+
+## 實作步驟
+
+1. 在 `internal/config` 新增 auth 環境變數解析與啟用判斷
+2. 在 `internal/server` 新增 auth manager、middleware、login/logout handler
+3. 調整 router，讓既有頁面與 API 統一走保護中介層
+4. 新增 `login` 頁面與登入/登出操作入口
+5. 補 e2e / handler 測試，驗證 open mode、未登入阻擋、登入後放行與登出失效
+
+## 環境變數
+
+- `AUTH_MODE=open|password`
+- `AUTH_PASSWORD=...`
+- `AUTH_COOKIE_SECURE=true|false`
+
+## 驗證
+
+- `go test ./...`
+- 手動確認：
+  - open mode 可直接使用
+  - protected mode 未登入會被導向登入頁
+  - 登入後可進入頁面與 API
+  - 登出後 session 失效

--- a/docs/plans/issue-12-local-auth-mode.md
+++ b/docs/plans/issue-12-local-auth-mode.md
@@ -1,28 +1,17 @@
 # Issue 12 工作計畫：可選本機驗證模式
 
-## 目標
+目標：在不影響單機預設使用體驗的前提下，新增可選的本機 / 區網密碼保護模式。
 
-在不影響單機預設使用體驗的前提下，新增可選的本機 / 區網密碼保護模式。
+決策：
+- 預設維持 `open mode`
+- 啟用 `password mode` 時，以單一密碼保護所有頁面與 API
+- 使用 cookie session，不做多帳號資料模型
+- 未登入頁面導向 `/login`，API 回 `401`
 
-## 範圍與決策
-
-- 保留預設 `open mode`，未設定驗證環境變數時維持現況
-- 新增 `password mode`，用單一密碼保護所有頁面與 API
-- 使用 cookie session，避免每次請求都重送密碼
-- 設定來源以環境變數為主，不做多帳號資料模型
-- 未登入的頁面導向 `/login`，未登入的 API 回傳 `401`
-
-## 實作步驟
-
+步驟：
 1. 在 `internal/config` 新增 auth 環境變數解析與啟用判斷
 2. 在 `internal/server` 新增 auth manager、middleware、login/logout handler
-3. 調整 router，讓既有頁面與 API 統一走保護中介層
-4. 新增 `login` 頁面與登入/登出操作入口
-5. 補測試，驗證 open mode、未登入阻擋、登入後放行與登出失效
+3. 新增 `login` 頁面與登出入口
+4. 補測試並驗證 `go test ./...`
 
-## 環境變數與驗證
-
-- `AUTH_MODE=open|password`
-- `AUTH_PASSWORD=...`
-- `AUTH_COOKIE_SECURE=true|false`
-- `go test ./...`
+環境變數：`AUTH_MODE`、`AUTH_PASSWORD`、`AUTH_COOKIE_SECURE`

--- a/docs/plans/issue-12-local-auth-mode.md
+++ b/docs/plans/issue-12-local-auth-mode.md
@@ -2,20 +2,15 @@
 
 ## 目標
 
-在不影響單機預設使用體驗的前提下，新增一個可選的本機 / 區網密碼保護模式。
+在不影響單機預設使用體驗的前提下，新增可選的本機 / 區網密碼保護模式。
 
-## 範圍
+## 範圍與決策
 
 - 保留預設 `open mode`，未設定驗證環境變數時維持現況
 - 新增 `password mode`，用單一密碼保護所有頁面與 API
 - 使用 cookie session，避免每次請求都重送密碼
-- 設定來源以環境變數為主，不把帳號管理做進這一版
-
-## 設計決策
-
-- 驗證模式先採單一密碼，不做多帳號資料模型，控制複雜度與 PR 大小
-- session 採記憶體保存，重啟服務後重新登入即可，符合本機工具使用情境
-- 未登入的瀏覽器頁面導向 `/login`，未登入的 API 請求回傳 `401`
+- 設定來源以環境變數為主，不做多帳號資料模型
+- 未登入的頁面導向 `/login`，未登入的 API 回傳 `401`
 
 ## 實作步驟
 
@@ -23,19 +18,11 @@
 2. 在 `internal/server` 新增 auth manager、middleware、login/logout handler
 3. 調整 router，讓既有頁面與 API 統一走保護中介層
 4. 新增 `login` 頁面與登入/登出操作入口
-5. 補 e2e / handler 測試，驗證 open mode、未登入阻擋、登入後放行與登出失效
+5. 補測試，驗證 open mode、未登入阻擋、登入後放行與登出失效
 
-## 環境變數
+## 環境變數與驗證
 
 - `AUTH_MODE=open|password`
 - `AUTH_PASSWORD=...`
 - `AUTH_COOKIE_SECURE=true|false`
-
-## 驗證
-
 - `go test ./...`
-- 手動確認：
-  - open mode 可直接使用
-  - protected mode 未登入會被導向登入頁
-  - 登入後可進入頁面與 API
-  - 登出後 session 失效

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,19 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 type Config struct {
-	OllamaURL  string
-	LLMModel   string
-	EmbedModel string
-	DataDir    string
-	Port       string
+	OllamaURL        string
+	LLMModel         string
+	EmbedModel       string
+	DataDir          string
+	Port             string
+	AuthMode         string
+	AuthPassword     string
+	AuthCookieSecure bool
 }
 
 func Default() *Config {
@@ -17,6 +23,7 @@ func Default() *Config {
 		EmbedModel: "nomic-embed-text",
 		DataDir:    "data",
 		Port:       "8080",
+		AuthMode:   "open",
 	}
 	if v := os.Getenv("OLLAMA_URL"); v != "" {
 		cfg.OllamaURL = v
@@ -33,5 +40,38 @@ func Default() *Config {
 	if v := os.Getenv("PORT"); v != "" {
 		cfg.Port = v
 	}
+	if v := os.Getenv("AUTH_MODE"); v != "" {
+		cfg.AuthMode = strings.ToLower(strings.TrimSpace(v))
+	}
+	if v := os.Getenv("AUTH_PASSWORD"); v != "" {
+		cfg.AuthPassword = v
+		if cfg.AuthMode == "open" {
+			cfg.AuthMode = "password"
+		}
+	}
+	if v := os.Getenv("AUTH_COOKIE_SECURE"); v != "" {
+		cfg.AuthCookieSecure = parseBool(v)
+	}
 	return cfg
+}
+
+func (c *Config) AuthEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(c.AuthMode), "password") && strings.TrimSpace(c.AuthPassword) != ""
+}
+
+func (c *Config) GetAuthPassword() string {
+	return c.AuthPassword
+}
+
+func (c *Config) GetAuthCookieSecure() bool {
+	return c.AuthCookieSecure
+}
+
+func parseBool(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const sessionCookieName = "novel_assistant_session"
+
+type authManager struct {
+	enabled       bool
+	password      string
+	cookieName    string
+	secureCookies bool
+	sessionTTL    time.Duration
+
+	mu       sync.Mutex
+	sessions map[string]time.Time
+}
+
+func newAuthManager(cfg authConfig) *authManager {
+	manager := &authManager{
+		cookieName: sessionCookieName,
+		sessionTTL: 7 * 24 * time.Hour,
+		sessions:   map[string]time.Time{},
+	}
+	if cfg == nil || !cfg.AuthEnabled() {
+		return manager
+	}
+	manager.enabled = true
+	manager.password = cfg.GetAuthPassword()
+	manager.secureCookies = cfg.GetAuthCookieSecure()
+	return manager
+}
+
+type authConfig interface {
+	AuthEnabled() bool
+	GetAuthPassword() string
+	GetAuthCookieSecure() bool
+}
+
+func (a *authManager) Enabled() bool {
+	return a != nil && a.enabled
+}
+
+func (a *authManager) createSession() (string, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	token := base64.RawURLEncoding.EncodeToString(raw)
+	a.mu.Lock()
+	a.sessions[token] = time.Now().Add(a.sessionTTL)
+	a.mu.Unlock()
+	return token, nil
+}
+
+func (a *authManager) verifySession(token string) bool {
+	if !a.Enabled() {
+		return true
+	}
+	if token == "" {
+		return false
+	}
+	now := time.Now()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	expiry, ok := a.sessions[token]
+	if !ok {
+		return false
+	}
+	if now.After(expiry) {
+		delete(a.sessions, token)
+		return false
+	}
+	return true
+}
+
+func (a *authManager) destroySession(token string) {
+	if a == nil || token == "" {
+		return
+	}
+	a.mu.Lock()
+	delete(a.sessions, token)
+	a.mu.Unlock()
+}
+
+func (a *authManager) checkPassword(password string) bool {
+	if !a.Enabled() {
+		return true
+	}
+	return subtle.ConstantTimeCompare([]byte(password), []byte(a.password)) == 1
+}
+
+func (s *Server) requireAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if s.auth == nil || !s.auth.Enabled() {
+			c.Next()
+			return
+		}
+		token, err := c.Cookie(s.auth.cookieName)
+		if err == nil && s.auth.verifySession(token) {
+			c.Next()
+			return
+		}
+		if wantsHTML(c) {
+			target := "/login"
+			if path := currentRequestPath(c); path != "" && path != "/login" {
+				target += "?next=" + url.QueryEscape(path)
+			}
+			c.Redirect(http.StatusSeeOther, target)
+			c.Abort()
+			return
+		}
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "需要登入"})
+	}
+}
+
+func (s *Server) handleLoginPage(c *gin.Context) {
+	if s.auth == nil || !s.auth.Enabled() {
+		c.Redirect(http.StatusSeeOther, "/")
+		return
+	}
+	if token, err := c.Cookie(s.auth.cookieName); err == nil && s.auth.verifySession(token) {
+		c.Redirect(http.StatusSeeOther, sanitizeNextPath(c.Query("next")))
+		return
+	}
+	c.HTML(http.StatusOK, "login.html", gin.H{
+		"Title": "登入",
+		"Next":  sanitizeNextPath(c.Query("next")),
+	})
+}
+
+func (s *Server) handleLogin(c *gin.Context) {
+	if s.auth == nil || !s.auth.Enabled() {
+		c.Redirect(http.StatusSeeOther, "/")
+		return
+	}
+	password := c.PostForm("password")
+	next := sanitizeNextPath(c.PostForm("next"))
+	if !s.auth.checkPassword(password) {
+		c.HTML(http.StatusUnauthorized, "login.html", gin.H{
+			"Title": "登入",
+			"Next":  next,
+			"Error": "密碼錯誤，請再試一次。",
+		})
+		return
+	}
+	token, err := s.auth.createSession()
+	if err != nil {
+		c.HTML(http.StatusInternalServerError, "login.html", gin.H{
+			"Title": "登入",
+			"Next":  next,
+			"Error": "建立登入 session 失敗，請稍後再試。",
+		})
+		return
+	}
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(s.auth.cookieName, token, int(s.auth.sessionTTL.Seconds()), "/", "", s.auth.secureCookies, true)
+	c.Redirect(http.StatusSeeOther, next)
+}
+
+func (s *Server) handleLogout(c *gin.Context) {
+	if s.auth != nil {
+		if token, err := c.Cookie(s.auth.cookieName); err == nil {
+			s.auth.destroySession(token)
+		}
+		c.SetSameSite(http.SameSiteLaxMode)
+		c.SetCookie(s.auth.cookieName, "", -1, "/", "", s.auth.secureCookies, true)
+	}
+	if wantsHTML(c) {
+		target := "/"
+		if s.auth != nil && s.auth.Enabled() {
+			target = "/login"
+		}
+		c.Redirect(http.StatusSeeOther, target)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func currentRequestPath(c *gin.Context) string {
+	path := c.Request.URL.Path
+	if raw := c.Request.URL.RawQuery; raw != "" {
+		path += "?" + raw
+	}
+	return path
+}
+
+func sanitizeNextPath(next string) string {
+	next = strings.TrimSpace(next)
+	if next == "" || !strings.HasPrefix(next, "/") || strings.HasPrefix(next, "//") {
+		return "/"
+	}
+	return next
+}
+
+func wantsHTML(c *gin.Context) bool {
+	accept := c.GetHeader("Accept")
+	return strings.Contains(accept, "text/html")
+}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestOpenModeAllowsAccessWithoutLogin(t *testing.T) {
+	t.Parallel()
+
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected open mode to allow request, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProtectedModeRedirectsHTMLRequestsToLogin(t *testing.T) {
+	t.Parallel()
+
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	s.cfg.AuthMode = "password"
+	s.cfg.AuthPassword = "secret-pass"
+	s.auth = newAuthManager(s.cfg)
+	s.router = setupAuthTestRouter(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect to login, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/login?next=%2Fsettings" {
+		t.Fatalf("expected login redirect, got %q", got)
+	}
+}
+
+func TestProtectedModeRejectsAPIWithoutSession(t *testing.T) {
+	t.Parallel()
+
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	s.cfg.AuthMode = "password"
+	s.cfg.AuthPassword = "secret-pass"
+	s.auth = newAuthManager(s.cfg)
+	s.router = setupAuthTestRouter(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	req.Header.Set("Accept", "application/json")
+	rec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "需要登入") {
+		t.Fatalf("expected auth error body, got %q", rec.Body.String())
+	}
+}
+
+func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
+	t.Parallel()
+
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	s.cfg.AuthMode = "password"
+	s.cfg.AuthPassword = "secret-pass"
+	s.auth = newAuthManager(s.cfg)
+	s.router = setupAuthTestRouter(s)
+
+	form := url.Values{
+		"password": {"secret-pass"},
+		"next":     {"/settings"},
+	}
+	loginReq := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	loginReq.Header.Set("Accept", "text/html")
+	loginRec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(loginRec, loginReq)
+
+	if loginRec.Code != http.StatusSeeOther {
+		t.Fatalf("expected login redirect, got %d: %s", loginRec.Code, loginRec.Body.String())
+	}
+	if got := loginRec.Header().Get("Location"); got != "/settings" {
+		t.Fatalf("expected redirect to requested page, got %q", got)
+	}
+	cookies := loginRec.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("expected session cookie to be set")
+	}
+
+	apiReq := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	apiReq.Header.Set("Accept", "application/json")
+	apiReq.AddCookie(cookies[0])
+	apiRec := httptest.NewRecorder()
+	s.router.ServeHTTP(apiRec, apiReq)
+	if apiRec.Code != http.StatusOK {
+		t.Fatalf("expected authenticated API access, got %d: %s", apiRec.Code, apiRec.Body.String())
+	}
+
+	logoutReq := httptest.NewRequest(http.MethodPost, "/logout", nil)
+	logoutReq.Header.Set("Accept", "application/json")
+	logoutReq.AddCookie(cookies[0])
+	logoutRec := httptest.NewRecorder()
+	s.router.ServeHTTP(logoutRec, logoutReq)
+	if logoutRec.Code != http.StatusOK {
+		t.Fatalf("expected logout success, got %d", logoutRec.Code)
+	}
+
+	afterLogoutReq := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	afterLogoutReq.Header.Set("Accept", "application/json")
+	afterLogoutReq.AddCookie(cookies[0])
+	afterLogoutRec := httptest.NewRecorder()
+	s.router.ServeHTTP(afterLogoutRec, afterLogoutReq)
+	if afterLogoutRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected session to be invalid after logout, got %d", afterLogoutRec.Code)
+	}
+}
+
+func setupAuthTestRouter(s *Server) *gin.Engine {
+	s.router = gin.New()
+	s.setupRoutes()
+	return s.router
+}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -71,6 +72,34 @@ func TestProtectedModeRejectsAPIWithoutSession(t *testing.T) {
 	}
 }
 
+func TestProtectedModeRejectsWrongPassword(t *testing.T) {
+	t.Parallel()
+
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	s.cfg.AuthMode = "password"
+	s.cfg.AuthPassword = "secret-pass"
+	s.auth = newAuthManager(s.cfg)
+	s.router = setupAuthTestRouter(s)
+
+	form := url.Values{
+		"password": {"wrong-pass"},
+		"next":     {"/settings"},
+	}
+	req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong password, got %d", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "密碼錯誤") {
+		t.Fatalf("expected error message in body, got %q", rec.Body.String())
+	}
+}
+
 func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
 	t.Parallel()
 
@@ -132,6 +161,7 @@ func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
 
 func setupAuthTestRouter(s *Server) *gin.Engine {
 	s.router = gin.New()
+	s.router.SetHTMLTemplate(template.Must(template.New("login.html").Parse(`{{define "login.html"}}{{.Error}}{{end}}`)))
 	s.setupRoutes()
 	return s.router
 }

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -13,14 +13,11 @@ import (
 
 func TestOpenModeAllowsAccessWithoutLogin(t *testing.T) {
 	t.Parallel()
-
 	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
 	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
 	req.Header.Set("Accept", "application/json")
 	rec := httptest.NewRecorder()
-
 	s.router.ServeHTTP(rec, req)
-
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected open mode to allow request, got %d: %s", rec.Code, rec.Body.String())
 	}
@@ -28,19 +25,11 @@ func TestOpenModeAllowsAccessWithoutLogin(t *testing.T) {
 
 func TestProtectedModeRedirectsHTMLRequestsToLogin(t *testing.T) {
 	t.Parallel()
-
-	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
-	s.cfg.AuthMode = "password"
-	s.cfg.AuthPassword = "secret-pass"
-	s.auth = newAuthManager(s.cfg)
-	s.router = setupAuthTestRouter(s)
-
+	s := newProtectedAuthTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
 	req.Header.Set("Accept", "text/html")
 	rec := httptest.NewRecorder()
-
 	s.router.ServeHTTP(rec, req)
-
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("expected redirect to login, got %d", rec.Code)
 	}
@@ -51,19 +40,11 @@ func TestProtectedModeRedirectsHTMLRequestsToLogin(t *testing.T) {
 
 func TestProtectedModeRejectsAPIWithoutSession(t *testing.T) {
 	t.Parallel()
-
-	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
-	s.cfg.AuthMode = "password"
-	s.cfg.AuthPassword = "secret-pass"
-	s.auth = newAuthManager(s.cfg)
-	s.router = setupAuthTestRouter(s)
-
+	s := newProtectedAuthTestServer(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
 	req.Header.Set("Accept", "application/json")
 	rec := httptest.NewRecorder()
-
 	s.router.ServeHTTP(rec, req)
-
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rec.Code)
 	}
@@ -74,13 +55,7 @@ func TestProtectedModeRejectsAPIWithoutSession(t *testing.T) {
 
 func TestProtectedModeRejectsWrongPassword(t *testing.T) {
 	t.Parallel()
-
-	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
-	s.cfg.AuthMode = "password"
-	s.cfg.AuthPassword = "secret-pass"
-	s.auth = newAuthManager(s.cfg)
-	s.router = setupAuthTestRouter(s)
-
+	s := newProtectedAuthTestServer(t)
 	form := url.Values{
 		"password": {"wrong-pass"},
 		"next":     {"/settings"},
@@ -89,9 +64,7 @@ func TestProtectedModeRejectsWrongPassword(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "text/html")
 	rec := httptest.NewRecorder()
-
 	s.router.ServeHTTP(rec, req)
-
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for wrong password, got %d", rec.Code)
 	}
@@ -102,13 +75,7 @@ func TestProtectedModeRejectsWrongPassword(t *testing.T) {
 
 func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
 	t.Parallel()
-
-	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
-	s.cfg.AuthMode = "password"
-	s.cfg.AuthPassword = "secret-pass"
-	s.auth = newAuthManager(s.cfg)
-	s.router = setupAuthTestRouter(s)
-
+	s := newProtectedAuthTestServer(t)
 	form := url.Values{
 		"password": {"secret-pass"},
 		"next":     {"/settings"},
@@ -117,9 +84,7 @@ func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
 	loginReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	loginReq.Header.Set("Accept", "text/html")
 	loginRec := httptest.NewRecorder()
-
 	s.router.ServeHTTP(loginRec, loginReq)
-
 	if loginRec.Code != http.StatusSeeOther {
 		t.Fatalf("expected login redirect, got %d: %s", loginRec.Code, loginRec.Body.String())
 	}
@@ -157,6 +122,16 @@ func TestProtectedModeLoginAndLogoutFlow(t *testing.T) {
 	if afterLogoutRec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected session to be invalid after logout, got %d", afterLogoutRec.Code)
 	}
+}
+
+func newProtectedAuthTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := newE2ETestServer(t, t.TempDir(), "http://127.0.0.1:0")
+	s.cfg.AuthMode = "password"
+	s.cfg.AuthPassword = "secret-pass"
+	s.auth = newAuthManager(s.cfg)
+	s.router = setupAuthTestRouter(s)
+	return s
 }
 
 func setupAuthTestRouter(s *Server) *gin.Engine {

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -318,6 +318,7 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 	gin.SetMode(gin.TestMode)
 	s := &Server{
 		cfg:           cfg,
+		auth:          newAuthManager(cfg),
 		project:       projectsettings.New(filepath.Join(dataDir, "project_settings.json"), projectsettings.Settings{OllamaURL: cfg.OllamaURL, LLMModel: cfg.LLMModel, EmbedModel: cfg.EmbedModel, Port: cfg.Port, DataDir: cfg.DataDir}),
 		profiles:      profile.NewManager(dataDir),
 		store:         vectorstore.New(filepath.Join(dataDir, "store.json")),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,6 +40,7 @@ type Server struct {
 	cfg            *config.Config
 	globalDataDir  string
 	router         *gin.Engine
+	auth           *authManager
 	stateMu        sync.RWMutex
 	state          *projectState
 	profiles       *profile.Manager
@@ -67,6 +68,7 @@ func New(cfg *config.Config) (*Server, error) {
 		globalDataDir: cfg.DataDir,
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
+		auth:          newAuthManager(cfg),
 	}
 	if s.globalDataDir == "" {
 		s.globalDataDir = "data"
@@ -108,6 +110,9 @@ func New(cfg *config.Config) (*Server, error) {
 			}
 			return false
 		},
+		"authEnabled": func() bool {
+			return s.auth != nil && s.auth.Enabled()
+		},
 	})
 	s.router.LoadHTMLGlob("web/templates/*.html")
 	s.router.Static("/static", "web/static")
@@ -119,62 +124,69 @@ func New(cfg *config.Config) (*Server, error) {
 func (s *Server) setupRoutes() {
 	r := s.router
 
-	r.GET("/", s.handleIndex)
-	r.GET("/chapters", s.handleChaptersPage)
-	r.GET("/characters", s.handleCharacters)
-	r.GET("/history", s.handleHistoryPage)
-	r.GET("/settings", s.handleSettingsPage)
-	r.GET("/styles", s.handleStylesPage)
-	r.GET("/check", s.handleCheckPage)
-	r.GET("/chat", s.handleChatPage)
-	r.GET("/relationships", s.handleRelationshipsPage)
-	r.GET("/timeline", s.handleTimelinePage)
-	r.GET("/foreshadow", s.handleForeshadowPage)
-	r.GET("/api/history/:id", s.handleGetHistoryEntry)
-	r.GET("/api/history/:id/diff", s.handleGetHistoryDiff)
-	r.GET("/api/backups", s.handleListBackups)
-	r.GET("/api/backups/:name/preview", s.handleGetBackupPreview)
-	r.GET("/api/projects", s.handleListProjects)
-	r.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
-	r.GET("/api/chapters", s.handleListChapters)
-	r.GET("/api/chapters/:name", s.handleGetChapter)
-	r.GET("/api/settings", s.handleGetSettings)
+	r.GET("/login", s.handleLoginPage)
+	r.POST("/login", s.handleLogin)
+	r.POST("/logout", s.handleLogout)
 
-	r.POST("/ingest", s.handleIngest)
-	r.POST("/api/chapters", s.handleSaveChapter)
-	r.POST("/api/chapters/order", s.handleSaveChapterOrder)
-	r.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
-	r.POST("/api/chapters/:name/scenes/order", s.handleSaveSceneOrder)
-	r.POST("/api/backups/create", s.handleCreateBackup)
-	r.POST("/api/backups/restore", s.handleRestoreBackup)
-	r.POST("/api/candidates/create", s.handleCreateCandidateDraft)
-	r.POST("/api/chapter-report/export", s.handleExportChapterBundle)
-	r.POST("/api/manuscript/export", s.handleExportManuscript)
-	r.POST("/api/history/delete", s.handleDeleteHistoryEntry)
-	r.POST("/api/history/export", s.handleExportHistory)
-	r.POST("/api/settings", s.handleSaveSettings)
-	r.POST("/api/projects", s.handleCreateProject)
-	r.POST("/api/projects/:name/switch", s.handleSwitchProject)
-	r.POST("/api/emotion-curve", s.handleEmotionCurve)
-	r.POST("/check/stream", s.handleCheckStream)
-	r.POST("/chat/stream", s.handleChatStream)
-	r.POST("/rewrite/stream", s.handleRewriteStream)
-	r.POST("/api/templates/apply", s.handleApplyTemplate)
-	r.POST("/api/writeback/timeline", s.handleWritebackTimeline)
-	r.POST("/api/writeback/foreshadow", s.handleWritebackForeshadow)
-	r.POST("/api/writeback/relationship", s.handleWritebackRelationship)
+	protected := r.Group("/")
+	protected.Use(s.requireAuth())
 
-	r.POST("/relationships", s.handleAddRelationship)
-	r.POST("/relationships/delete", s.handleDeleteRelationship)
+	protected.GET("/", s.handleIndex)
+	protected.GET("/chapters", s.handleChaptersPage)
+	protected.GET("/characters", s.handleCharacters)
+	protected.GET("/history", s.handleHistoryPage)
+	protected.GET("/settings", s.handleSettingsPage)
+	protected.GET("/styles", s.handleStylesPage)
+	protected.GET("/check", s.handleCheckPage)
+	protected.GET("/chat", s.handleChatPage)
+	protected.GET("/relationships", s.handleRelationshipsPage)
+	protected.GET("/timeline", s.handleTimelinePage)
+	protected.GET("/foreshadow", s.handleForeshadowPage)
+	protected.GET("/api/history/:id", s.handleGetHistoryEntry)
+	protected.GET("/api/history/:id/diff", s.handleGetHistoryDiff)
+	protected.GET("/api/backups", s.handleListBackups)
+	protected.GET("/api/backups/:name/preview", s.handleGetBackupPreview)
+	protected.GET("/api/projects", s.handleListProjects)
+	protected.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
+	protected.GET("/api/chapters", s.handleListChapters)
+	protected.GET("/api/chapters/:name", s.handleGetChapter)
+	protected.GET("/api/settings", s.handleGetSettings)
 
-	r.POST("/timeline", s.handleAddTimelineEvent)
-	r.POST("/timeline/delete", s.handleDeleteTimelineEvent)
+	protected.POST("/ingest", s.handleIngest)
+	protected.POST("/api/chapters", s.handleSaveChapter)
+	protected.POST("/api/chapters/order", s.handleSaveChapterOrder)
+	protected.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
+	protected.POST("/api/chapters/:name/scenes/order", s.handleSaveSceneOrder)
+	protected.POST("/api/backups/create", s.handleCreateBackup)
+	protected.POST("/api/backups/restore", s.handleRestoreBackup)
+	protected.POST("/api/candidates/create", s.handleCreateCandidateDraft)
+	protected.POST("/api/chapter-report/export", s.handleExportChapterBundle)
+	protected.POST("/api/manuscript/export", s.handleExportManuscript)
+	protected.POST("/api/history/delete", s.handleDeleteHistoryEntry)
+	protected.POST("/api/history/export", s.handleExportHistory)
+	protected.POST("/api/settings", s.handleSaveSettings)
+	protected.POST("/api/projects", s.handleCreateProject)
+	protected.POST("/api/projects/:name/switch", s.handleSwitchProject)
+	protected.POST("/api/emotion-curve", s.handleEmotionCurve)
+	protected.POST("/check/stream", s.handleCheckStream)
+	protected.POST("/chat/stream", s.handleChatStream)
+	protected.POST("/rewrite/stream", s.handleRewriteStream)
+	protected.POST("/api/templates/apply", s.handleApplyTemplate)
+	protected.POST("/api/writeback/timeline", s.handleWritebackTimeline)
+	protected.POST("/api/writeback/foreshadow", s.handleWritebackForeshadow)
+	protected.POST("/api/writeback/relationship", s.handleWritebackRelationship)
 
-	r.POST("/foreshadow", s.handleAddForeshadow)
-	r.POST("/foreshadow/resolve", s.handleResolveForeshadow)
-	r.POST("/foreshadow/delete", s.handleDeleteForeshadow)
+	protected.POST("/relationships", s.handleAddRelationship)
+	protected.POST("/relationships/delete", s.handleDeleteRelationship)
 
-	r.POST("/export", s.handleExport)
+	protected.POST("/timeline", s.handleAddTimelineEvent)
+	protected.POST("/timeline/delete", s.handleDeleteTimelineEvent)
+
+	protected.POST("/foreshadow", s.handleAddForeshadow)
+	protected.POST("/foreshadow/resolve", s.handleResolveForeshadow)
+	protected.POST("/foreshadow/delete", s.handleDeleteForeshadow)
+
+	protected.POST("/export", s.handleExport)
 }
 
 func (s *Server) loadProjectState(name string) (*projectState, error) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -111,7 +111,7 @@ label {
   font-size: 0.85rem;
 }
 
-input[type=text], input[type=number], select, textarea {
+input[type=text], input[type=password], input[type=number], select, textarea {
   width: 100%;
   background: #0f0d14;
   color: #e2e8f0;

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -23,6 +23,11 @@
       <button type="button" onclick="promptCreateProject()" style="font-size:0.8em">＋新增</button>
     </div>
     <button class="btn-reindex" onclick="reindex()">重新索引</button>
+    {{if authEnabled}}
+    <form method="post" action="/logout" style="margin-top:10px">
+      <button class="btn-reindex" type="submit">登出</button>
+    </form>
+    {{end}}
   </div>
 </div>
 <script src="/static/workspace.js"></script>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,0 +1,37 @@
+{{define "login.html"}}
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>登入 — 小說助手</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<main class="main-content" style="max-width:560px;margin:48px auto;padding-bottom:48px">
+  <div class="card">
+    <div class="page-header" style="margin-bottom:20px">
+      <h1>登入小說助手</h1>
+      <p>目前已啟用本機保護模式，請輸入存取密碼。</p>
+    </div>
+
+    {{if .Error}}
+    <div class="card" style="background:#3a1320;border-color:#7f1d1d;color:#fecaca;padding:16px;margin-bottom:18px">
+      {{.Error}}
+    </div>
+    {{end}}
+
+    <form method="post" action="/login">
+      <input type="hidden" name="next" value="{{.Next}}">
+      <div class="form-group">
+        <label for="password">密碼</label>
+        <input type="password" id="password" name="password" autocomplete="current-password" autofocus>
+      </div>
+      <div class="helper-text" style="margin-bottom:18px">若你是在區網共享使用，建議搭配反向代理與 HTTPS。</div>
+      <button class="btn" type="submit">登入</button>
+    </form>
+  </div>
+</main>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary

Add an optional local authentication mode for Novel Assistant.

## What Changed

- add environment-based auth config for `open` and `password` modes
- protect app pages and APIs with cookie-backed session middleware when auth is enabled
- add login/logout handlers and a dedicated login page
- add a small Issue #12 plan doc under `docs/plans/`
- add tests covering open mode, protected redirects, API rejection, wrong-password rejection, login, and logout

## Why

Issue #12 asks for a simple protected mode for local or LAN deployments without making the default single-user setup harder to use. This keeps open mode as the default and adds a lightweight password mode only when configured.

## Validation

- `go test ./...`

## Notes

- default behavior remains unchanged unless `AUTH_MODE=password` and `AUTH_PASSWORD` are configured
- this PR intentionally uses a single shared password rather than a full account system to keep scope small

## Residual Risk

- `POST /logout` does not include a CSRF token yet. A malicious page could trigger a silent logout. For a local/LAN tool this is acceptable for now, but it remains a known residual risk.
- sessions are stored in an in-memory `map[string]time.Time`, so all sessions are lost on restart by design
- expired sessions are cleaned up lazily during access rather than by a background GC loop; for a local tool this is acceptable, but the map can grow slowly under long-running heavy login churn