### PR TITLE
chore: raise PR size limit from 600 to 700 lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           lines=$(gh pr diff ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} | grep -cE '^[+-]' || true)
           echo "Changed lines: $lines"
-          if [ "$lines" -gt 600 ]; then
-            echo "PR too large ($lines lines, limit 600). Split into smaller PRs."
+          if [ "$lines" -gt 700 ]; then
+            echo "PR too large ($lines lines, limit 700). Split into smaller PRs."
             exit 1
           fi
 


### PR DESCRIPTION
## PR Type（只能勾一個）

- [x] chore — 格式、文件、依賴

## Summary

- Issue: N/A
- PR #37 merge 時帶的是 600 行，700 行的修改在 merge 後才推上去，未進 main，補上。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>