### PR TITLE
feat: add retrieval diagnostics page

### DIFF
--- a/docs/plans/issue-13-retrieval-diagnostics.md
+++ b/docs/plans/issue-13-retrieval-diagnostics.md
@@ -1,0 +1,15 @@
+# Issue 13 工作計畫：Retrieval Diagnostics Page
+
+目標：提供專門頁面，讓使用者不用看 server log 也能檢查 index 健康度與 retrieval 行為。
+
+範圍：
+- 顯示向量索引總量與各類型 counts
+- 顯示最近一次 reindex 狀態
+- 顯示最近幾次 retrieval trace
+- 顯示 retrieval latency summary
+
+做法：
+1. 在 server 內新增 diagnostics 狀態，保存最近一次 reindex 與 recent traces
+2. 在 check / rewrite 的 retrieval 載入點記錄 trace 與 latency
+3. 新增 `/diagnostics` 頁面與導覽入口
+4. 補測試並驗證 `go test ./...`

--- a/internal/server/diagnostics.go
+++ b/internal/server/diagnostics.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const diagnosticsTraceLimit = 12
+
+type reindexStatus struct {
+	StartedAt   time.Time
+	FinishedAt  time.Time
+	DurationMs  int64
+	Success     bool
+	Error       string
+	Characters  int
+	Worlds      int
+	Styles      int
+	Chapters    int
+	VectorCount int
+}
+
+type retrievalTrace struct {
+	RecordedAt  time.Time
+	Flow        string
+	Task        string
+	ChapterFile string
+	ChapterName string
+	IndexReady  bool
+	LatencyMs   int64
+	ResultCount int
+	Error       string
+	Config      retrievalSummary
+	Sources     []referenceSummary
+}
+
+type latencyAggregate struct {
+	Count        int
+	SuccessCount int
+	FailureCount int
+	MinMs        int64
+	MaxMs        int64
+	TotalMs      int64
+	LastMs       int64
+}
+
+type latencySummaryRow struct {
+	Name         string
+	Count        int
+	SuccessCount int
+	FailureCount int
+	AvgMs        int64
+	MinMs        int64
+	MaxMs        int64
+	LastMs       int64
+}
+
+type retrievalDiagnostics struct {
+	mu           sync.RWMutex
+	lastReindex  reindexStatus
+	recentTraces []retrievalTrace
+	latency      map[string]*latencyAggregate
+}
+
+func newRetrievalDiagnostics() *retrievalDiagnostics {
+	return &retrievalDiagnostics{
+		latency: make(map[string]*latencyAggregate),
+	}
+}
+
+func (d *retrievalDiagnostics) recordReindex(status reindexStatus) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	d.lastReindex = status
+	d.mu.Unlock()
+}
+
+func (d *retrievalDiagnostics) recordTrace(trace retrievalTrace) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.recentTraces = append([]retrievalTrace{trace}, d.recentTraces...)
+	if len(d.recentTraces) > diagnosticsTraceLimit {
+		d.recentTraces = d.recentTraces[:diagnosticsTraceLimit]
+	}
+
+	keys := []string{"overall", trace.Flow + ":" + trace.Task}
+	for _, key := range keys {
+		agg := d.latency[key]
+		if agg == nil {
+			agg = &latencyAggregate{MinMs: trace.LatencyMs, MaxMs: trace.LatencyMs}
+			d.latency[key] = agg
+		}
+		agg.Count++
+		agg.TotalMs += trace.LatencyMs
+		agg.LastMs = trace.LatencyMs
+		if trace.LatencyMs < agg.MinMs {
+			agg.MinMs = trace.LatencyMs
+		}
+		if trace.LatencyMs > agg.MaxMs {
+			agg.MaxMs = trace.LatencyMs
+		}
+		if strings.TrimSpace(trace.Error) == "" {
+			agg.SuccessCount++
+		} else {
+			agg.FailureCount++
+		}
+	}
+}
+
+func (d *retrievalDiagnostics) snapshot() (reindexStatus, []retrievalTrace, []latencySummaryRow) {
+	if d == nil {
+		return reindexStatus{}, nil, nil
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	traces := make([]retrievalTrace, len(d.recentTraces))
+	copy(traces, d.recentTraces)
+
+	rows := make([]latencySummaryRow, 0, len(d.latency))
+	for key, agg := range d.latency {
+		if agg == nil || agg.Count == 0 {
+			continue
+		}
+		rows = append(rows, latencySummaryRow{
+			Name:         key,
+			Count:        agg.Count,
+			SuccessCount: agg.SuccessCount,
+			FailureCount: agg.FailureCount,
+			AvgMs:        agg.TotalMs / int64(agg.Count),
+			MinMs:        agg.MinMs,
+			MaxMs:        agg.MaxMs,
+			LastMs:       agg.LastMs,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Name == "overall" {
+			return true
+		}
+		if rows[j].Name == "overall" {
+			return false
+		}
+		return rows[i].Name < rows[j].Name
+	})
+
+	return d.lastReindex, traces, rows
+}
+
+func (s *Server) recordRetrievalTrace(flow string, summary retrievalSummary, chapterTitle, chapterFile string, refs []vectorProfile, err error, duration time.Duration) {
+	if s == nil || s.diagnostics == nil {
+		return
+	}
+	title := strings.TrimSpace(chapterTitle)
+	if title == "" && chapterFile != "" {
+		title = strings.TrimSuffix(chapterFile, ".md")
+	}
+	trace := retrievalTrace{
+		RecordedAt:  time.Now(),
+		Flow:        flow,
+		Task:        summary.Task,
+		ChapterFile: strings.TrimSpace(chapterFile),
+		ChapterName: title,
+		IndexReady:  s.store != nil && s.store.Len() > 0,
+		LatencyMs:   duration.Milliseconds(),
+		ResultCount: len(refs),
+		Config:      summary,
+		Sources:     summarizeReferences(limitTraceReferences(refs, 3)),
+	}
+	if err != nil {
+		trace.Error = err.Error()
+	}
+	s.diagnostics.recordTrace(trace)
+}
+
+func limitTraceReferences(items []vectorProfile, max int) []vectorProfile {
+	if len(items) <= max {
+		return items
+	}
+	return items[:max]
+}

--- a/internal/server/diagnostics_test.go
+++ b/internal/server/diagnostics_test.go
@@ -1,0 +1,33 @@
+package server
+
+import "testing"
+
+func TestRetrievalDiagnosticsKeepsRecentTracesAndLatencySummary(t *testing.T) {
+	t.Parallel()
+
+	d := newRetrievalDiagnostics()
+	for i := 0; i < diagnosticsTraceLimit+2; i++ {
+		d.recordTrace(retrievalTrace{
+			Flow:      "check",
+			Task:      "behavior",
+			LatencyMs: int64(10 + i),
+		})
+	}
+
+	_, traces, rows := d.snapshot()
+	if len(traces) != diagnosticsTraceLimit {
+		t.Fatalf("expected trace limit %d, got %d", diagnosticsTraceLimit, len(traces))
+	}
+	if traces[0].LatencyMs != int64(10+diagnosticsTraceLimit+1) {
+		t.Fatalf("expected newest trace first, got %#v", traces[0])
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected overall + task latency rows, got %#v", rows)
+	}
+	if rows[0].Name != "overall" {
+		t.Fatalf("expected overall row first, got %#v", rows)
+	}
+	if rows[1].Name != "check:behavior" {
+		t.Fatalf("expected task row, got %#v", rows[1])
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -585,7 +585,6 @@ func (s *Server) handleDiagnosticsPage(c *gin.Context) {
 
 	c.HTML(http.StatusOK, "diagnostics.html", gin.H{
 		"Title":            "Retrieval 診斷",
-		"VectorCounts":     vectorCounts,
 		"VectorCount":      totalVectors,
 		"CharacterVectors": vectorCounts["character"],
 		"WorldVectors":     vectorCounts["world"],

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -15,6 +15,7 @@ import (
 	"novel-assistant/internal/tracker"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -573,6 +574,30 @@ func (s *Server) handleTimelinePage(c *gin.Context) {
 	})
 }
 
+func (s *Server) handleDiagnosticsPage(c *gin.Context) {
+	lastReindex, traces, latencyRows := s.diagnostics.snapshot()
+	vectorCounts := map[string]int{}
+	totalVectors := 0
+	if s.store != nil {
+		vectorCounts = s.store.CountsByType()
+		totalVectors = s.store.Len()
+	}
+
+	c.HTML(http.StatusOK, "diagnostics.html", gin.H{
+		"Title":            "Retrieval 診斷",
+		"VectorCounts":     vectorCounts,
+		"VectorCount":      totalVectors,
+		"CharacterVectors": vectorCounts["character"],
+		"WorldVectors":     vectorCounts["world"],
+		"StyleVectors":     vectorCounts["style"],
+		"ChapterVectors":   vectorCounts["chapter"],
+		"LastReindex":      lastReindex,
+		"RecentTraces":     traces,
+		"LatencyRows":      latencyRows,
+		"IndexReady":       totalVectors > 0,
+	})
+}
+
 func (s *Server) handleForeshadowPage(c *gin.Context) {
 	c.HTML(http.StatusOK, "foreshadow.html", gin.H{
 		"Title":       "伏筆追蹤",
@@ -584,10 +609,34 @@ func (s *Server) handleForeshadowPage(c *gin.Context) {
 
 func (s *Server) handleIngest(c *gin.Context) {
 	ctx := c.Request.Context()
-	if err := s.Ingest(ctx); err != nil {
+	startedAt := time.Now()
+	err := s.Ingest(ctx)
+	finishedAt := time.Now()
+	status := reindexStatus{
+		StartedAt:  startedAt,
+		FinishedAt: finishedAt,
+		DurationMs: finishedAt.Sub(startedAt).Milliseconds(),
+		Success:    err == nil,
+		Characters: len(s.profiles.Characters),
+		Worlds:     len(s.profiles.Worlds),
+		Styles:     len(s.profiles.Styles),
+		VectorCount: func() int {
+			if s.store == nil {
+				return 0
+			}
+			return s.store.Len()
+		}(),
+	}
+	if chapters, listErr := s.listChapterFiles(); listErr == nil {
+		status.Chapters = len(chapters)
+	}
+	if err != nil {
+		status.Error = err.Error()
+		s.diagnostics.recordReindex(status)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	s.diagnostics.recordReindex(status)
 	c.JSON(http.StatusOK, gin.H{
 		"message":    "索引完成",
 		"characters": len(s.profiles.Characters),
@@ -666,7 +715,9 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		if len(req.Checks) == 0 || contains(req.Checks, "behavior") {
 			behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
 			activeRetrieval["behavior"] = summarizeRetrieval("behavior", behaviorOpts)
+			traceStarted := time.Now()
 			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)
+			s.recordRetrievalTrace("check", activeRetrieval["behavior"], req.ChapterTitle, req.ChapterFile, behaviorRefs, err, time.Since(traceStarted))
 			if err != nil {
 				text := fmt.Sprintf("\n> 行為審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)
@@ -676,7 +727,9 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		if contains(req.Checks, "dialogue") {
 			dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
 			activeRetrieval["dialogue"] = summarizeRetrieval("dialogue", dialogueOpts)
+			traceStarted := time.Now()
 			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, dialogueOpts)
+			s.recordRetrievalTrace("check", activeRetrieval["dialogue"], req.ChapterTitle, req.ChapterFile, dialogueRefs, err, time.Since(traceStarted))
 			if err != nil {
 				text := fmt.Sprintf("\n> 對白審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)
@@ -686,7 +739,9 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		if contains(req.Checks, "world") {
 			worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
 			activeRetrieval["world"] = summarizeRetrieval("world", worldOpts)
+			traceStarted := time.Now()
 			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, worldOpts)
+			s.recordRetrievalTrace("check", activeRetrieval["world"], req.ChapterTitle, req.ChapterFile, worldRefs, err, time.Since(traceStarted))
 			if err != nil {
 				text := fmt.Sprintf("\n> 世界觀審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
 				transcript.WriteString(text)
@@ -958,12 +1013,14 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer close(msgChan)
 
 		activeRetrieval := summarizeRetrieval("rewrite", mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval))
+		traceStarted := time.Now()
 		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, retrievalOptions{
 			Sources:      append([]string(nil), activeRetrieval.Sources...),
 			TopK:         activeRetrieval.TopK,
 			Threshold:    activeRetrieval.Threshold,
 			ThresholdSet: true,
 		})
+		s.recordRetrievalTrace("rewrite", activeRetrieval, req.ChapterTitle, req.ChapterFile, references, refErr, time.Since(traceStarted))
 		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		msgChan <- streamEvent{Event: "retrieval", Retrieval: gin.H{"tasks": gin.H{"rewrite": activeRetrieval}}}
 		if refErr != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,7 @@ type Server struct {
 	globalDataDir  string
 	router         *gin.Engine
 	auth           *authManager
+	diagnostics    *retrievalDiagnostics
 	stateMu        sync.RWMutex
 	state          *projectState
 	profiles       *profile.Manager
@@ -69,6 +70,7 @@ func New(cfg *config.Config) (*Server, error) {
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
 		auth:          newAuthManager(cfg),
+		diagnostics:   newRetrievalDiagnostics(),
 	}
 	if s.globalDataDir == "" {
 		s.globalDataDir = "data"
@@ -138,6 +140,7 @@ func (s *Server) setupRoutes() {
 	protected.GET("/settings", s.handleSettingsPage)
 	protected.GET("/styles", s.handleStylesPage)
 	protected.GET("/check", s.handleCheckPage)
+	protected.GET("/diagnostics", s.handleDiagnosticsPage)
 	protected.GET("/chat", s.handleChatPage)
 	protected.GET("/relationships", s.handleRelationshipsPage)
 	protected.GET("/timeline", s.handleTimelinePage)

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -77,6 +77,17 @@ func (s *Store) Len() int {
 	return len(s.docs)
 }
 
+func (s *Store) CountsByType() map[string]int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	counts := make(map[string]int)
+	for _, doc := range s.docs {
+		counts[doc.Type]++
+	}
+	return counts
+}
+
 func (s *Store) Query(queryVec []float64, topK int, docType string) []Document {
 	scored := s.QueryScored(queryVec, topK, docType)
 	out := make([]Document, 0, len(scored))

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -8,6 +8,7 @@
       <li><a href="/characters"   {{if eq .Title "角色管理"}}class="active"{{end}}>角色管理</a></li>
       <li><a href="/styles"       {{if eq .Title "風格管理"}}class="active"{{end}}>風格管理</a></li>
       <li><a href="/check"        {{if eq .Title "一致性審查"}}class="active"{{end}}>一致性審查</a></li>
+      <li><a href="/diagnostics"  {{if eq .Title "Retrieval 診斷"}}class="active"{{end}}>Retrieval 診斷</a></li>
       <li><a href="/history"      {{if eq .Title "審查歷史"}}class="active"{{end}}>審查歷史</a></li>
       <li><a href="/settings"     {{if eq .Title "規則設定"}}class="active"{{end}}>規則設定</a></li>
       <li><a href="/relationships"{{if eq .Title "關係圖"}}class="active"{{end}}>關係圖</a></li>

--- a/web/templates/diagnostics.html
+++ b/web/templates/diagnostics.html
@@ -1,0 +1,157 @@
+{{define "diagnostics.html"}}
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Retrieval 診斷 — 小說助手</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="layout">
+  {{template "nav" .}}
+  <main class="main-content">
+    <div class="page-header">
+      <h1>Retrieval 診斷</h1>
+      <p>集中查看 index 健康度、最近 reindex 狀態、retrieval trace 與延遲概況。</p>
+    </div>
+
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-num">{{.VectorCount}}</div>
+        <div class="stat-label">總向量數</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-num">{{.CharacterVectors}}</div>
+        <div class="stat-label">角色向量</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-num">{{.WorldVectors}}</div>
+        <div class="stat-label">世界觀向量</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-num">{{.StyleVectors}}</div>
+        <div class="stat-label">風格向量</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-num">{{.ChapterVectors}}</div>
+        <div class="stat-label">章節向量</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-num">{{len .RecentTraces}}</div>
+        <div class="stat-label">近期 trace</div>
+      </div>
+    </div>
+
+    <div class="grid-2">
+      <div class="card">
+        <h2>Index 健康度</h2>
+        <div class="helper-text">{{if .IndexReady}}目前已建立索引，可直接檢查 retrieval quality。{{else}}目前索引為空，請先重新索引後再觀察 trace。{{end}}</div>
+        <table style="margin-top:16px">
+          <thead>
+            <tr><th>類型</th><th>數量</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>角色</td><td>{{.CharacterVectors}}</td></tr>
+            <tr><td>世界觀</td><td>{{.WorldVectors}}</td></tr>
+            <tr><td>風格</td><td>{{.StyleVectors}}</td></tr>
+            <tr><td>章節</td><td>{{.ChapterVectors}}</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="card">
+        <h2>最近一次 Reindex</h2>
+        {{if .LastReindex.FinishedAt.IsZero}}
+        <div class="helper-text">本次啟動後尚未執行重新索引。</div>
+        {{else}}
+        <div class="helper-text">完成時間：{{.LastReindex.FinishedAt.Format "2006-01-02 15:04:05"}}，耗時 {{.LastReindex.DurationMs}} ms</div>
+        <table style="margin-top:16px">
+          <tbody>
+            <tr><td>結果</td><td>{{if .LastReindex.Success}}成功{{else}}失敗{{end}}</td></tr>
+            <tr><td>角色</td><td>{{.LastReindex.Characters}}</td></tr>
+            <tr><td>世界觀</td><td>{{.LastReindex.Worlds}}</td></tr>
+            <tr><td>風格</td><td>{{.LastReindex.Styles}}</td></tr>
+            <tr><td>章節</td><td>{{.LastReindex.Chapters}}</td></tr>
+            <tr><td>向量總數</td><td>{{.LastReindex.VectorCount}}</td></tr>
+          </tbody>
+        </table>
+        {{if .LastReindex.Error}}
+        <div class="helper-text" style="margin-top:12px;color:#fca5a5">錯誤：{{.LastReindex.Error}}</div>
+        {{end}}
+        {{end}}
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>Latency Summary</h2>
+      {{if .LatencyRows}}
+      <table>
+        <thead>
+          <tr>
+            <th>流程</th>
+            <th>次數</th>
+            <th>成功</th>
+            <th>失敗</th>
+            <th>平均</th>
+            <th>最小</th>
+            <th>最大</th>
+            <th>最近一次</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .LatencyRows}}
+          <tr>
+            <td>{{.Name}}</td>
+            <td>{{.Count}}</td>
+            <td>{{.SuccessCount}}</td>
+            <td>{{.FailureCount}}</td>
+            <td>{{.AvgMs}} ms</td>
+            <td>{{.MinMs}} ms</td>
+            <td>{{.MaxMs}} ms</td>
+            <td>{{.LastMs}} ms</td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+      {{else}}
+      <div class="helper-text">尚未有 retrieval latency 資料，先執行一次審查或修稿。</div>
+      {{end}}
+    </div>
+
+    <div class="card">
+      <h2>Recent Retrieval Traces</h2>
+      {{if .RecentTraces}}
+      {{range .RecentTraces}}
+      <div style="padding:14px 0;border-bottom:1px solid #2d2540">
+        <div style="display:flex;justify-content:space-between;gap:12px;flex-wrap:wrap">
+          <strong>{{.Flow}} / {{.Task}}</strong>
+          <span class="helper-text">{{.RecordedAt.Format "2006-01-02 15:04:05"}} ・ {{.LatencyMs}} ms</span>
+        </div>
+        <div class="helper-text" style="margin-top:6px">
+          章節：{{if .ChapterName}}{{.ChapterName}}{{else}}未命名章節{{end}} {{if .ChapterFile}}（{{.ChapterFile}}）{{end}}<br>
+          Index：{{if .IndexReady}}ready{{else}}empty{{end}} ・ 結果數：{{.ResultCount}} ・ 來源：{{if .Config.Sources}}{{range $i, $s := .Config.Sources}}{{if $i}}、{{end}}{{$s}}{{end}}{{else}}（無）{{end}} ・ Top-K：{{.Config.TopK}} ・ 門檻：{{printf "%.2f" .Config.Threshold}}
+        </div>
+        {{if .Error}}
+        <div class="helper-text" style="margin-top:8px;color:#fca5a5">錯誤：{{.Error}}</div>
+        {{end}}
+        {{if .Sources}}
+        <div style="margin-top:10px">
+          {{range .Sources}}
+          <div class="helper-text" style="margin-bottom:4px">[{{.Type}}] {{.Name}} ・ 分數 {{printf "%.3f" .Score}} ・ {{.MatchReason}}</div>
+          {{end}}
+        </div>
+        {{else}}
+        <div class="helper-text" style="margin-top:8px">本次沒有可顯示的 retrieval source。</div>
+        {{end}}
+      </div>
+      {{end}}
+      {{else}}
+      <div class="helper-text">尚未累積 retrieval trace，先執行一次審查或修稿。</div>
+      {{end}}
+    </div>
+  </main>
+</div>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary

Add a dedicated retrieval diagnostics page so users can inspect index health and recent retrieval behavior without reading server logs.

Closes #13

## What Changed

- add a `/diagnostics` page and sidebar entry for retrieval/index diagnostics
- record last reindex status, including duration and indexed asset counts
- record recent retrieval traces for check/rewrite flows with latency, result counts, and sample matched sources
- aggregate retrieval latency into simple summary rows for quick health checks
- add a small plan doc for Issue #13 and tests for diagnostics state retention/aggregation

## Why

Issue #13 asks for a dedicated diagnostics surface so users can understand stale indexes, weak retrieval, and latency problems without digging through logs.

## Validation

- `go test ./...`

## Notes

- diagnostics are in-memory runtime state, so recent traces and reindex status reset on service restart
- the page is intended as an operational debugging view rather than a persistent audit log