### PR TITLE
docs: add release asset checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ Start here:
 
 See [CHANGELOG.md](CHANGELOG.md).
 
+## Release Checklist
+
+For public releases, screenshot refreshes, and repo asset updates, use [docs/RELEASE_ASSET_CHECKLIST.md](docs/RELEASE_ASSET_CHECKLIST.md).
+
 ## Planning Docs
 
 - [docs/ROADMAP.md](docs/ROADMAP.md)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -259,6 +259,10 @@ data/
 
 請見 [CHANGELOG.md](CHANGELOG.md)。
 
+## Release Checklist
+
+若要整理公開 release、更新 screenshots 或刷新 repo 資產，請依照 [docs/RELEASE_ASSET_CHECKLIST.md](docs/RELEASE_ASSET_CHECKLIST.md) 執行。
+
 ## 規劃文件
 
 - [docs/ROADMAP.md](docs/ROADMAP.md)

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -77,6 +77,10 @@ go build ./...
 
 If the change affects UI flows, also do a manual smoke test for the changed page.
 
+## Release Documentation Rule
+
+If a PR is part of a public release, or it changes a user-visible workflow that will need refreshed screenshots, check [docs/RELEASE_ASSET_CHECKLIST.md](docs/RELEASE_ASSET_CHECKLIST.md) before the release is finalized.
+
 ## Review Notes for Agents
 
 When Codex, Claude, or another coding agent works on an issue:

--- a/docs/RELEASE_ASSET_CHECKLIST.md
+++ b/docs/RELEASE_ASSET_CHECKLIST.md
@@ -1,0 +1,79 @@
+# Release Asset and Screenshot Checklist
+
+Use this checklist before publishing a tagged release, release notes, or public-facing repo refresh.
+
+The goal is consistency: each release should leave behind clear notes, refreshed screenshots, and updated README-facing assets.
+
+## 1. Release Scope
+
+- Confirm the version number and release date.
+- Review merged PRs since the previous release.
+- Group changes into user-facing highlights, infrastructure/developer changes, and known limitations.
+- Make sure each shipped issue or PR is either closed or clearly tracked for follow-up.
+
+## 2. Screenshot Checklist
+
+- Capture the current app UI using real product flows, not placeholder layouts.
+- Prefer screenshots that reflect the current navigation labels and page structure.
+- Refresh screenshots when any of these change:
+  - sidebar navigation
+  - dashboard cards or counts
+  - review/check page layout
+  - chapter overview or history flow
+  - settings, backup, diagnostics, or tracker pages
+- Check that screenshots do not expose personal manuscript data, secrets, local filesystem details, or private prompts.
+- Use consistent window size and browser chrome where possible.
+- Verify text is readable at GitHub README width.
+- Remove stale screenshots from the repo or release notes when they no longer match the product.
+
+## 3. Release Notes Checklist
+
+- Create or update release notes under `docs/releases/`.
+- Include:
+  - highlights
+  - product changes
+  - developer/deployment changes
+  - validation summary
+- Add both English and Traditional Chinese notes when the release is public-facing.
+- Link to the companion localized release note file when both versions exist.
+- Keep the top section skimmable: readers should understand the release in under a minute.
+
+## 4. Docs Update Checklist
+
+- Re-read `README.md` and `README.zh-TW.md` for stale feature lists.
+- Update docs when the release changes:
+  - setup steps
+  - environment variables
+  - workflow page names
+  - export / backup / diagnostics capabilities
+  - architecture or data layout assumptions
+- Check whether `docs/ROADMAP*.md`, `docs/ARCHITECTURE.md`, or `docs/DEVELOPMENT_WORKFLOW.md` need follow-up edits.
+- If a user-facing workflow changed, confirm that examples and screenshots still describe the current behavior.
+
+## 5. README Asset Refresh Notes
+
+- Refresh the README feature list when a release introduces a new visible workflow or page.
+- Refresh badges, release links, and screenshot references if filenames or URLs changed.
+- Avoid mixing screenshots from different product eras in the same README.
+- If a screenshot is intentionally deferred, leave a short note in the PR or release issue so it does not get forgotten.
+- Make sure the English and Traditional Chinese READMEs stay roughly aligned in structure and claims.
+
+## 6. Final Release Gate
+
+- `go test ./...`
+- `go build ./...`
+- Manual smoke test on the pages highlighted in screenshots or release notes
+- Final proofread for:
+  - version number consistency
+  - broken links
+  - outdated asset names
+  - mismatched screenshot captions
+
+## Output Expectation
+
+A release should not be considered complete until:
+
+- release notes are committed
+- screenshots/assets are either refreshed or explicitly deferred
+- README-facing claims match the shipped product
+- documentation changes are part of the same release trail

--- a/docs/plans/issue-14-release-asset-checklist.md
+++ b/docs/plans/issue-14-release-asset-checklist.md
@@ -1,0 +1,14 @@
+# Issue 14 工作計畫：Release Asset and Screenshot Checklist
+
+目標：建立一份可重複使用的 release 文件流程，統一 screenshots、release notes、README 資產與 docs 更新品質。
+
+範圍：
+- screenshot checklist
+- release checklist
+- docs update checklist
+- README asset refresh notes
+
+做法：
+1. 新增正式的 release / asset checklist 文件
+2. 補上 screenshot 與 README 資產更新指引
+3. 在 README 與開發流程文件加入入口，讓 release 時容易找到


### PR DESCRIPTION
## Summary

Add a repeatable release asset and screenshot checklist for public releases.

Closes #14

## What Changed

- add `docs/RELEASE_ASSET_CHECKLIST.md` for release scope, screenshots, release notes, docs updates, and README asset refresh
- add a small Issue #14 plan doc under `docs/plans/`
- add checklist entry points in `README.md`, `README.zh-TW.md`, and `docs/DEVELOPMENT_WORKFLOW.md`

## Why

Issue #14 asks for a repeatable documentation and asset process so each release follows a more consistent public-facing quality bar.

## Validation

- docs-only change
- manually reviewed links and checklist coverage

## Notes

- this PR does not add screenshot files yet; it establishes the process used for future releases