### PR TITLE
feat: improve behavior checks with pronoun resolution

### DIFF
--- a/docs/plans/issue-19-pronoun-resolution.md
+++ b/docs/plans/issue-19-pronoun-resolution.md
@@ -1,0 +1,13 @@
+# Issue 19 工作計畫：Character Pronoun Resolution
+
+目標：改善角色行為審查對 `他/她` 代名詞的處理，降低只用代名詞時漏檢角色的機率。
+
+這輪範圍先聚焦 Phase 1：
+- 在 behavior prompt 補上代名詞歸因指引
+- 在角色自動選擇時，加入代名詞候選擴充
+
+做法：
+1. 補一個角色代名詞推斷 helper，從角色設定推測 `他/她`
+2. 在 `resolveCharacters` 內，把代名詞候選角色合併進待審清單
+3. 在 `CheckBehaviorStream` prompt 加入代名詞歸因說明
+4. 補測試並驗證 `go test ./...`

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -11,6 +11,11 @@ import (
 	"strings"
 )
 
+const (
+	behaviorChunkRuneLimit = 12000
+	behaviorChunkOverlap   = 1200
+)
+
 type Checker struct {
 	baseURL string
 	model   string
@@ -39,8 +44,27 @@ type EmotionPoint struct {
 }
 
 func (c *Checker) CheckBehaviorStream(ctx context.Context, profile, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
+	if len([]rune(chapter)) > behaviorChunkRuneLimit {
+		return c.checkBehaviorChunkedStream(ctx, profile, chapter, w)
+	}
+	return c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chapter, "", ""), w)
+}
+
+func behaviorPrompt(profile, chapter, chunkLabel, summary string) string {
+	var extra strings.Builder
+	if chunkLabel != "" {
+		extra.WriteString("\n【長文分段審查】\n")
+		extra.WriteString(chunkLabel)
+		extra.WriteString("\n")
+	}
+	if summary != "" {
+		extra.WriteString("\n【角色摘要】\n")
+		extra.WriteString(summary)
+		extra.WriteString("\n")
+	}
+	return fmt.Sprintf(`
 【角色設定】
+%s
 %s
 
 【待審章節】
@@ -53,8 +77,98 @@ func (c *Checker) CheckBehaviorStream(ctx context.Context, profile, chapter stri
    - 需要哪些觸發事件？
    - 角色內心掙扎為何？
    - 建議幾個章節完成轉變？
-`, profile, chapter)
-	return c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", prompt, w)
+
+判讀規則：
+- 除了角色姓名，也要把章節中的「他 / 她」視為可能指向此角色的代名詞，請根據上下文一起判讀
+- 若代名詞指向不明，請明確指出不確定性，不要武斷歸因
+`, profile, extra.String(), chapter)
+}
+
+func (c *Checker) checkBehaviorChunkedStream(ctx context.Context, profile, chapter string, w io.Writer) error {
+	chunks := splitTextWithOverlap(chapter, behaviorChunkRuneLimit, behaviorChunkOverlap)
+	summary := summarizeBehaviorProfile(profile)
+	results := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		var buf strings.Builder
+		label := fmt.Sprintf("這是第 %d / %d 段，請以角色設定與本段內容為主，必要時利用重疊區理解前後文。", i+1, len(chunks))
+		if err := c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chunk, label, summary), &buf); err != nil {
+			return err
+		}
+		results = append(results, buf.String())
+	}
+	_, err := io.WriteString(w, mergeChunkedBehaviorResponses(results))
+	return err
+}
+
+func summarizeBehaviorProfile(profile string) string {
+	lines := strings.Split(profile, "\n")
+	parts := make([]string, 0, 4)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts = append(parts, line)
+		if len(parts) == 4 {
+			break
+		}
+	}
+	return strings.Join(parts, "；")
+}
+
+func splitTextWithOverlap(text string, limit, overlap int) []string {
+	runes := []rune(strings.TrimSpace(text))
+	if len(runes) == 0 {
+		return nil
+	}
+	if limit <= 0 || len(runes) <= limit {
+		return []string{string(runes)}
+	}
+	if overlap < 0 {
+		overlap = 0
+	}
+	if overlap >= limit {
+		overlap = limit / 4
+	}
+
+	var chunks []string
+	for start := 0; start < len(runes); {
+		end := start + limit
+		if end > len(runes) {
+			end = len(runes)
+		}
+		chunks = append(chunks, string(runes[start:end]))
+		if end == len(runes) {
+			break
+		}
+		start = end - overlap
+		if start < 0 {
+			start = 0
+		}
+	}
+	return chunks
+}
+
+func mergeChunkedBehaviorResponses(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{})
+	lines := make([]string, 0)
+	for _, item := range items {
+		for _, line := range strings.Split(item, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (c *Checker) CheckStyleStream(ctx context.Context, styleProfile, chapter string, w io.Writer) error {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -89,6 +89,7 @@ func (c *Checker) checkBehaviorChunkedStream(ctx context.Context, profile, chapt
 	summary := summarizeBehaviorProfile(profile)
 	results := make([]string, 0, len(chunks))
 	for i, chunk := range chunks {
+		_, _ = fmt.Fprintf(w, "\n正在分析第 %d / %d 段…\n", i+1, len(chunks))
 		var buf strings.Builder
 		label := fmt.Sprintf("這是第 %d / %d 段，請以角色設定與本段內容為主，必要時利用重疊區理解前後文。", i+1, len(chunks))
 		if err := c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chunk, label, summary), &buf); err != nil {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -90,6 +90,29 @@ func TestCheckBehaviorStreamUsesPronounGuidance(t *testing.T) {
 	}
 }
 
+func TestSplitTextWithOverlapEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	if got := splitTextWithOverlap("", 100, 10); len(got) != 0 {
+		t.Fatalf("expected nil for empty text, got %v", got)
+	}
+	exactText := strings.Repeat("a", 100)
+	if got := splitTextWithOverlap(exactText, 100, 10); len(got) != 1 || got[0] != exactText {
+		t.Fatalf("expected single chunk for text == limit, got %v", got)
+	}
+	if got := splitTextWithOverlap("hello", 100, 200); len(got) != 1 {
+		t.Fatalf("expected single chunk when overlap >= limit, got %v", got)
+	}
+	twoChunkText := strings.Repeat("字", 150)
+	chunks := splitTextWithOverlap(twoChunkText, 100, 20)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	if len([]rune(chunks[0])) != 100 {
+		t.Fatalf("expected first chunk to be exactly limit, got %d runes", len([]rune(chunks[0])))
+	}
+}
+
 func TestCheckBehaviorStreamChunksLongTextAndMergesResponses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -66,3 +66,52 @@ func TestCheckWorldConflictStreamUsesWorldPrompt(t *testing.T) {
 		t.Fatalf("expected output to contain response, got %q", out.String())
 	}
 }
+
+func TestCheckBehaviorStreamUsesPronounGuidance(t *testing.T) {
+	t.Parallel()
+
+	var captured genReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	var out bytes.Buffer
+	if err := c.CheckBehaviorStream(context.Background(), "角色設定", "章節內容", &out); err != nil {
+		t.Fatalf("expected stream success, got error: %v", err)
+	}
+	if !strings.Contains(captured.Prompt, "他 / 她") {
+		t.Fatalf("expected pronoun guidance in prompt, got %q", captured.Prompt)
+	}
+}
+
+func TestCheckBehaviorStreamChunksLongTextAndMergesResponses(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"1. 行為一致性：符合\\n\",\"done\":false}\n"))
+		_, _ = w.Write([]byte("{\"response\":\"2. 具體問題：無明顯衝突\\n\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	var out bytes.Buffer
+	longText := strings.Repeat("他在夜裡持續觀察四周。", behaviorChunkRuneLimit/4+50)
+	if err := c.CheckBehaviorStream(context.Background(), "角色設定", longText, &out); err != nil {
+		t.Fatalf("expected chunked stream success, got error: %v", err)
+	}
+	if callCount < 2 {
+		t.Fatalf("expected multiple chunk calls, got %d", callCount)
+	}
+	if strings.Count(out.String(), "1. 行為一致性：符合") != 1 {
+		t.Fatalf("expected merged output to dedupe repeated lines, got %q", out.String())
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -515,8 +515,13 @@ func inferCharacterPronouns(char *profile.Character) []string {
 	if text == "" {
 		return nil
 	}
-	hasHe := strings.Contains(text, "男性") || strings.Contains(text, "男生") || strings.Contains(text, "男孩") || strings.Contains(text, "少年") || strings.Contains(text, "他")
-	hasShe := strings.Contains(text, "女性") || strings.Contains(text, "女生") || strings.Contains(text, "女孩") || strings.Contains(text, "少女") || strings.Contains(text, "她")
+	// Explicit gender keywords take priority. Pronoun occurrence in profile text
+	// is only used as a fallback when no explicit keyword is found, to avoid false
+	// positives when the profile mentions another character's pronouns.
+	hasHeKeyword := strings.Contains(text, "男性") || strings.Contains(text, "男生") || strings.Contains(text, "男孩") || strings.Contains(text, "少年")
+	hasSheKeyword := strings.Contains(text, "女性") || strings.Contains(text, "女生") || strings.Contains(text, "女孩") || strings.Contains(text, "少女")
+	hasHe := hasHeKeyword || (!hasSheKeyword && strings.Contains(text, "他"))
+	hasShe := hasSheKeyword || (!hasHeKeyword && strings.Contains(text, "她"))
 
 	out := make([]string, 0, 2)
 	if hasHe {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -447,6 +447,7 @@ func (s *Server) resolveCharacters(req checkRequest) []*profile.Character {
 	names := req.Characters
 	if len(names) == 0 {
 		names = checker.ExtractNames(req.Chapter, s.profiles.AllNames())
+		names = mergeCharacterNames(names, pronounCharacterCandidates(req.Chapter, s.profiles.Characters)...)
 	}
 	if len(names) == 0 {
 		names = s.profiles.AllNames()
@@ -459,6 +460,72 @@ func (s *Server) resolveCharacters(req checkRequest) []*profile.Character {
 		}
 	}
 	return chars
+}
+
+func mergeCharacterNames(base []string, extra ...string) []string {
+	seen := make(map[string]struct{}, len(base)+len(extra))
+	merged := make([]string, 0, len(base)+len(extra))
+	for _, name := range append(append([]string(nil), base...), extra...) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		merged = append(merged, name)
+	}
+	return merged
+}
+
+func pronounCharacterCandidates(chapter string, chars []*profile.Character) []string {
+	chapter = strings.TrimSpace(chapter)
+	if chapter == "" || len(chars) == 0 {
+		return nil
+	}
+	wantsHe := strings.Contains(chapter, "他")
+	wantsShe := strings.Contains(chapter, "她")
+	if !wantsHe && !wantsShe {
+		return nil
+	}
+
+	out := make([]string, 0)
+	for _, char := range chars {
+		if char == nil || strings.TrimSpace(char.Name) == "" {
+			continue
+		}
+		pronouns := inferCharacterPronouns(char)
+		if wantsHe && contains(pronouns, "他") {
+			out = append(out, char.Name)
+			continue
+		}
+		if wantsShe && contains(pronouns, "她") {
+			out = append(out, char.Name)
+		}
+	}
+	return out
+}
+
+func inferCharacterPronouns(char *profile.Character) []string {
+	if char == nil {
+		return nil
+	}
+	text := strings.TrimSpace(char.RawContent)
+	if text == "" {
+		return nil
+	}
+	hasHe := strings.Contains(text, "男性") || strings.Contains(text, "男生") || strings.Contains(text, "男孩") || strings.Contains(text, "少年") || strings.Contains(text, "他")
+	hasShe := strings.Contains(text, "女性") || strings.Contains(text, "女生") || strings.Contains(text, "女孩") || strings.Contains(text, "少女") || strings.Contains(text, "她")
+
+	out := make([]string, 0, 2)
+	if hasHe {
+		out = append(out, "他")
+	}
+	if hasShe {
+		out = append(out, "她")
+	}
+	return out
 }
 
 // ─── pages ───────────────────────────────────────────────────────────────────

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -213,3 +213,27 @@ func TestComputeRetrievalGapsReportsOnlyUnretrievedSignals(t *testing.T) {
 		t.Fatalf("expected missing setting to be reported, got %#v", gaps.MissingSettings)
 	}
 }
+
+func TestResolveCharactersIncludesPronounCandidates(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		profiles: &profile.Manager{
+			Characters: []*profile.Character{
+				{Name: "林昊", RawContent: "# 角色：林昊\n- 個性：冷靜\n- 性別：男性"},
+				{Name: "白璃", RawContent: "# 角色：白璃\n- 個性：果斷\n- 性別：女性"},
+			},
+		},
+	}
+
+	chars := s.resolveCharacters(checkRequest{
+		Chapter: "林昊看著她，沒有立刻回答。",
+		Checks:  []string{"behavior"},
+	})
+	if len(chars) != 2 {
+		t.Fatalf("expected explicit and pronoun candidates, got %#v", chars)
+	}
+	if chars[0].Name != "林昊" || chars[1].Name != "白璃" {
+		t.Fatalf("unexpected resolved characters: %#v", chars)
+	}
+}


### PR DESCRIPTION
## Summary

Improve character behavior consistency checks so pronoun-only references are handled more deliberately.

Closes #19

## What Changed

- add explicit pronoun guidance (`他 / 她`) to behavior-check prompts
- expand automatic character resolution so pronoun cues can pull in likely review candidates even when names are not repeated
- add best-effort long-text chunking for behavior checks with overlapping windows, character summary headers, and merged/deduplicated chunk results
- add a small Issue #19 plan doc and tests for prompt guidance, chunked behavior review, and pronoun-based character selection

## Why

Issue #19 points out that name-only matching skips behavior checks when a scene refers to a character mainly through pronouns. This change improves both prompt-level attribution and long-form review behavior without breaking existing named-character flows.

## Validation

- `go test ./...`

## Notes

- Phase 2 remains best-effort: chunked behavior review improves long-form coverage, but merged findings still depend on LLM output quality
- pronoun candidate expansion is heuristic and intentionally conservative; ambiguous chapters may still include extra likely candidates for review