### PR TITLE
feat: auto-pull Ollama models in docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ go run ./cmd
 ```
 
 Open `http://localhost:8080`.
+Before your first review request, make sure Ollama already has `llama3.2` and `nomic-embed-text` available, for example with `ollama pull llama3.2` and `ollama pull nomic-embed-text`.
 
 ### Environment Configuration
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,8 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for planned work.
 ### Requirements
 
 - Go `1.21+`
-- [Ollama](https://ollama.com/) running locally
-
-### Install Models
-
-```bash
-ollama pull llama3.2
-ollama pull nomic-embed-text
-```
+- [Ollama](https://ollama.com/) running locally for native `go run ./cmd`
+- Docker + Docker Compose for the container flow
 
 ### Run Locally
 
@@ -125,8 +119,10 @@ This starts:
 
 - `app`: the Go web server
 - `ollama`: a local Ollama container
+- `ollama-init`: a one-shot setup container that pulls required models if they are missing
 
 The compose file expects a local `.env` file and mounts `./data` for persistence.
+On the first startup, `ollama-init` waits for Ollama and then automatically pulls `llama3.2` and `nomic-embed-text`. Later runs skip the pull when those models already exist in the shared Ollama volume.
 
 ### Common Development Commands
 
@@ -228,7 +224,7 @@ Example files for onboarding and demos live in [examples/README.md](examples/REA
 - VSCode shows red errors but `go test` and `go build` pass:
   Open the `novel-assistant` folder directly in VSCode, not the outer `gopl.io` workspace.
 - Docker starts but review requests fail:
-  Make sure the Ollama container is healthy and the configured models have been pulled.
+  Make sure the Ollama container is healthy. On first startup, wait for `ollama-init` to finish pulling the required models.
 - `寫作風格` has no selectable items:
   Add `.md` files under `data/style/` and reindex.
 - Review requests fail immediately:

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -81,14 +81,8 @@ flowchart TD
 ### 環境需求
 
 - Go `1.21+`
-- 本地執行中的 [Ollama](https://ollama.com/)
-
-### 安裝模型
-
-```bash
-ollama pull llama3.2
-ollama pull nomic-embed-text
-```
+- 若要用 `go run ./cmd`，需要本地執行中的 [Ollama](https://ollama.com/)
+- 若要用容器流程，需安裝 Docker 與 Docker Compose
 
 ### 啟動專案
 
@@ -125,8 +119,10 @@ docker compose up --build
 
 - `app`：Go 網頁伺服器
 - `ollama`：本地 Ollama 容器
+- `ollama-init`：一次性初始化容器，會在缺少模型時自動 pull
 
 `docker-compose.yml` 會讀取本地 `.env`，並將 `./data` 掛載成持久化資料目錄。
+第一次啟動時，`ollama-init` 會先等待 Ollama 可用，再自動下載 `llama3.2` 與 `nomic-embed-text`。之後若共享的 Ollama volume 已經有這些模型，就會直接略過。
 
 ### 常用開發指令
 
@@ -228,7 +224,7 @@ data/
 - VSCode 顯示紅字，但 `go test` 和 `go build` 都正常：
   請直接用 VSCode 開 `novel-assistant` 資料夾，不要開外層 `gopl.io` workspace。
 - Docker 可以啟動，但審查送出失敗：
-  請確認 Ollama 容器已正常啟動，且所需模型已先 pull。
+  請確認 Ollama 容器已正常啟動；第一次啟動時也要等 `ollama-init` 完成必要模型下載。
 - `寫作風格` 沒有可選項目：
   請確認 `data/style/` 內已有 `.md` 檔案，並重新索引。
 - 審查一送出就失敗：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -92,6 +92,7 @@ go run ./cmd
 ```
 
 啟動後開啟 `http://localhost:8080`。
+第一次送出審查前，請先確認 Ollama 已有 `llama3.2` 與 `nomic-embed-text`，例如先執行 `ollama pull llama3.2` 和 `ollama pull nomic-embed-text`。
 
 ### 環境變數設定
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,38 @@ services:
     volumes:
       - ollama-data:/root/.ollama
 
+  ollama-init:
+    image: ollama/ollama:latest
+    container_name: novel-assistant-ollama-init
+    depends_on:
+      - ollama
+    environment:
+      OLLAMA_HOST: http://ollama:11434
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: "no"
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        echo "Waiting for Ollama to become ready..."
+        until ollama list >/dev/null 2>&1; do
+          sleep 2
+        done
+
+        ensure_model() {
+          model="$1"
+          if ollama list | awk 'NR > 1 { print $1 }' | grep -Fxq "$model"; then
+            echo "Model $model already exists, skipping pull."
+            return 0
+          fi
+          echo "Pulling model $model..."
+          ollama pull "$model"
+        }
+
+        ensure_model "llama3.2"
+        ensure_model "nomic-embed-text"
+
 volumes:
   ollama-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,13 +35,20 @@ services:
       - |
         set -eu
         echo "Waiting for Ollama to become ready..."
+        attempts=0
+        max_attempts=60
         until ollama list >/dev/null 2>&1; do
+          attempts=$((attempts + 1))
+          if [ "$attempts" -ge "$max_attempts" ]; then
+            echo "Ollama did not become ready in time."
+            exit 1
+          fi
           sleep 2
         done
 
         ensure_model() {
           model="$1"
-          if ollama list | awk 'NR > 1 { print $1 }' | grep -Fxq "$model"; then
+          if ollama list | awk 'NR > 1 { print $1 }' | grep -Fq "${model}:"; then
             echo "Model $model already exists, skipping pull."
             return 0
           fi

--- a/docs/plans/issue-20-ollama-init.md
+++ b/docs/plans/issue-20-ollama-init.md
@@ -1,0 +1,7 @@
+## Issue #20 Plan
+
+- Add an `ollama-init` service to `docker-compose.yml`.
+- Wait for Ollama to become reachable before any model pull attempt.
+- Pull `llama3.2` and `nomic-embed-text` only when they are missing.
+- Update English and Traditional Chinese README quick-start steps so Docker setup becomes `cp .env.example .env` then `docker compose up --build`.
+- Mention that the first startup may take longer because required models are downloaded automatically.


### PR DESCRIPTION
## Summary
- add an `ollama-init` service that waits for Ollama and only pulls required models when they are missing
- update English and Traditional Chinese Docker quick-start docs to reflect the auto-download flow
- add an Issue #20 plan doc for the implementation scope

## Why
Issue #20 aims to make the container setup work from a fresh clone with just:

```bash
cp .env.example .env
docker compose up --build
```

Without this change, users still have to manually pull `llama3.2` and `nomic-embed-text` before the app can review text.

## Impact
- first Docker startup may take longer while the required models are downloaded
- later `docker compose up` runs skip re-pulling when the shared Ollama volume already contains the models
- native `go run ./cmd` flow is unchanged

## Validation
- inspected the compose diff to ensure the init service waits for Ollama and skips existing models
- updated both READMEs so quick start and troubleshooting match the new compose behavior
- could not run `docker compose config` in this environment because the `docker` CLI is not installed locally

Closes #20