### PR TITLE
feat: wait for Ollama health in docker compose startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This starts:
 - `ollama-init`: a one-shot setup container that pulls required models if they are missing
 
 The compose file expects a local `.env` file and mounts `./data` for persistence.
+The `app` container waits for Ollama's health check to pass before starting, so your first reindex is less likely to fail on a cold boot.
 On the first startup, `ollama-init` waits for Ollama and then automatically pulls `llama3.2` and `nomic-embed-text`. Later runs skip the pull when those models already exist in the shared Ollama volume.
 
 ### Common Development Commands

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -123,6 +123,7 @@ docker compose up --build
 - `ollama-init`：一次性初始化容器，會在缺少模型時自動 pull
 
 `docker-compose.yml` 會讀取本地 `.env`，並將 `./data` 掛載成持久化資料目錄。
+`app` 會先等待 Ollama health check 通過才啟動，因此第一次冷啟動後直接重新索引時，比較不容易因為 Ollama 尚未就緒而失敗。
 第一次啟動時，`ollama-init` 會先等待 Ollama 可用，再自動下載 `llama3.2` 與 `nomic-embed-text`。之後若共享的 Ollama volume 已經有這些模型，就會直接略過。
 
 ### 常用開發指令

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,8 @@ services:
     volumes:
       - ./data:/app/data
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
 
   ollama:
     image: ollama/ollama:latest
@@ -18,12 +19,19 @@ services:
       - "11434:11434"
     volumes:
       - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
   ollama-init:
     image: ollama/ollama:latest
     container_name: novel-assistant-ollama-init
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
     environment:
       OLLAMA_HOST: http://ollama:11434
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     volumes:
       - ollama-data:/root/.ollama
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434"]
+      test: ["CMD", "ollama", "list"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docs/plans/issue-22-ollama-healthcheck.md
+++ b/docs/plans/issue-22-ollama-healthcheck.md
@@ -1,0 +1,6 @@
+## Issue #22 Plan
+
+- Add an Ollama HTTP health check to `docker-compose.yml`.
+- Update `app` so it waits for `ollama` to become healthy before starting.
+- Update `ollama-init` so model pull starts only after `ollama` is healthy.
+- Refresh English and Traditional Chinese Docker Compose docs to mention the readiness gate.


### PR DESCRIPTION
## Summary
- add an HTTP health check to the `ollama` service in `docker-compose.yml`
- make both `app` and `ollama-init` wait for Ollama to become healthy before starting
- document the readiness gate in the English and Traditional Chinese Docker Compose docs

## Why
Issue #22 fixes a startup race where the app container could boot before Ollama was actually ready to serve requests. That made the first reindex or review request fail on a cold boot even though the stack looked up.

## Impact
- `app` now starts only after Ollama responds to HTTP requests
- `ollama-init` model downloads also wait for the same health gate
- first-use Docker behavior should be more predictable after `docker compose up --build`

## Validation
- inspected the compose diff to confirm `depends_on.condition: service_healthy` is applied to both `app` and `ollama-init`
- updated both READMEs so the Docker startup notes match the new readiness flow
- could not run `docker compose config` in this environment because the `docker` CLI is not installed locally

Closes #22