### PR TITLE
docs: add missing .env step to Docker quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,11 @@ Supported variables:
 ### Docker Compose
 
 ```bash
+cp .env.example .env
 docker compose up --build
 ```
+
+The `.env` file controls the Ollama URL, default model names, and exposed app port for the compose setup.
 
 This starts:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -113,8 +113,11 @@ cp .env.example .env
 ### Docker Compose
 
 ```bash
+cp .env.example .env
 docker compose up --build
 ```
+
+`.env` 會控制 compose 流程使用的 Ollama URL、預設模型名稱與對外開放的連接埠。
 
 這會啟動：
 

--- a/docs/plans/issue-24-docker-env-step.md
+++ b/docs/plans/issue-24-docker-env-step.md
@@ -1,0 +1,6 @@
+## Issue #24 Plan
+
+- Update the Docker Compose quick-start in `README.md`.
+- Update the Docker Compose quick-start in `README.zh-TW.md`.
+- Add the explicit `cp .env.example .env` step before `docker compose up --build`.
+- Mention that `.env` controls the Ollama URL, model names, and port.


### PR DESCRIPTION
## Summary
- add `cp .env.example .env` to the Docker Compose quick-start in both READMEs
- explain that `.env` controls the Ollama URL, default model names, and exposed port
- add an Issue #24 plan doc for the documentation update

## Why
Issue #24 fixes a gap in the Docker quick-start docs. The previous instructions showed only `docker compose up --build`, which made it easy for users to skip `.env` creation and end up with silent defaults or confusing environment-dependent behavior.

## Impact
- Docker setup instructions now match the actual expected startup flow
- both English and Traditional Chinese docs stay aligned
- users get a clearer explanation of what `.env` controls before they launch the stack

## Validation
- confirmed both README Docker sections now start with `cp .env.example .env`
- confirmed both README sections mention the key values controlled by `.env`
- docs-only change; no runtime code paths were modified

Closes #24