### PR TITLE
feat: add chapter worldstate snapshots

### DIFF
--- a/docs/plans/issue-31-worldstate-snapshots.md
+++ b/docs/plans/issue-31-worldstate-snapshots.md
@@ -1,0 +1,8 @@
+## Issue #31 Plan
+
+- Add an `internal/worldstate` package for snapshot storage and latest-before lookup.
+- Load and save `worldstate.json` alongside the existing tracker JSON stores.
+- Add `POST /api/chapters/:name/snapshot` and `GET /api/worldstate`.
+- Use the latest snapshot before the current chapter as a high-priority system prefix in check and rewrite flows.
+- Surface snapshot generation and the latest snapshot summary inline on the chapter overview page.
+- Cover store boundary behavior, snapshot generation, and prompt injection with tests.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -45,10 +45,7 @@ type EmotionPoint struct {
 }
 
 func (c *Checker) CheckBehaviorStream(ctx context.Context, profile, chapter string, w io.Writer) error {
-	if len([]rune(chapter)) > behaviorChunkRuneLimit {
-		return c.checkBehaviorChunkedStream(ctx, profile, chapter, w)
-	}
-	return c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chapter, "", ""), w)
+	return c.CheckBehaviorWithSystemStream(ctx, "", profile, chapter, w)
 }
 
 func (c *Checker) CheckBehaviorWithSystemStream(ctx context.Context, systemPrefix, profile, chapter string, w io.Writer) error {
@@ -93,20 +90,7 @@ func behaviorPrompt(profile, chapter, chunkLabel, summary string) string {
 }
 
 func (c *Checker) checkBehaviorChunkedStream(ctx context.Context, profile, chapter string, w io.Writer) error {
-	chunks := splitTextWithOverlap(chapter, behaviorChunkRuneLimit, behaviorChunkOverlap)
-	summary := summarizeBehaviorProfile(profile)
-	results := make([]string, 0, len(chunks))
-	for i, chunk := range chunks {
-		_, _ = fmt.Fprintf(w, "\n正在分析第 %d / %d 段…\n", i+1, len(chunks))
-		var buf strings.Builder
-		label := fmt.Sprintf("這是第 %d / %d 段，請以角色設定與本段內容為主，必要時利用重疊區理解前後文。", i+1, len(chunks))
-		if err := c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chunk, label, summary), &buf); err != nil {
-			return err
-		}
-		results = append(results, buf.String())
-	}
-	_, err := io.WriteString(w, mergeChunkedBehaviorResponses(results))
-	return err
+	return c.checkBehaviorChunkedWithSystemStream(ctx, "", profile, chapter, w)
 }
 
 func summarizeBehaviorProfile(profile string) string {
@@ -181,19 +165,7 @@ func mergeChunkedBehaviorResponses(items []string) string {
 }
 
 func (c *Checker) CheckStyleStream(ctx context.Context, styleProfile, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【寫作風格設定】
-%s
-
-【待審章節】
-%s
-
-請依序分析：
-1. **風格一致性**：章節的寫作風格是否符合設定？（符合 / 不符合）
-2. **具體問題**：列出不符合風格設定的段落或句子，說明哪裡違和
-3. **修改建議**：針對問題段落，提供符合風格的改寫方向或範例
-`, styleProfile, chapter)
-	return c.stream(ctx, "你是專業文學編輯，專責分析文章寫作風格的一致性。請用繁體中文回答。", prompt, w)
+	return c.CheckStyleWithSystemStream(ctx, "", styleProfile, chapter, w)
 }
 
 func (c *Checker) checkBehaviorChunkedWithSystemStream(ctx context.Context, systemPrefix, profile, chapter string, w io.Writer) error {
@@ -214,87 +186,23 @@ func (c *Checker) checkBehaviorChunkedWithSystemStream(ctx context.Context, syst
 }
 
 func (c *Checker) CheckStyleWithSystemStream(ctx context.Context, systemPrefix, styleProfile, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【寫作風格設定】
-%s
-
-【待審章節】
-%s
-
-請依序分析：
-1. **風格一致性**：章節的寫作風格是否符合設定？（符合 / 不符合）
-2. **具體問題**：列出不符合風格設定的段落或句子，說明哪裡違和
-3. **修改建議**：針對問題段落，提供符合風格的改寫方向或範例
-`, styleProfile, chapter)
-	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，專責分析文章寫作風格的一致性。請用繁體中文回答。"), prompt, w)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，專責分析文章寫作風格的一致性。請用繁體中文回答。"), stylePrompt(styleProfile, chapter), w)
 }
 
 func (c *Checker) CheckWorldConflictStream(ctx context.Context, worldProfile, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【世界觀與規則設定】
-%s
-
-【待審章節】
-%s
-
-請依序分析：
-1. **世界觀一致性**：章節是否違反既有世界規則、時間線、地點設定、能力限制或勢力關係？（符合 / 不符合）
-2. **具體問題**：若有衝突，列出衝突段落並說明與哪條設定矛盾
-3. **修正建議**：提供最小修改方案，盡量保留原場景張力
-`, worldProfile, chapter)
-	return c.stream(ctx, "你是專責小說世界觀審核的編輯，擅長抓出規則、時間線、地點與能力設定的矛盾。請用繁體中文回答。", prompt, w)
+	return c.CheckWorldConflictWithSystemStream(ctx, "", worldProfile, chapter, w)
 }
 
 func (c *Checker) CheckWorldConflictWithSystemStream(ctx context.Context, systemPrefix, worldProfile, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【世界觀與規則設定】
-%s
-
-【待審章節】
-%s
-
-請依序分析：
-1. **世界觀一致性**：章節是否違反既有世界規則、時間線、地點設定、能力限制或勢力關係？（符合 / 不符合）
-2. **具體問題**：若有衝突，列出衝突段落並說明與哪條設定矛盾
-3. **修正建議**：提供最小修改方案，盡量保留原場景張力
-`, worldProfile, chapter)
-	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專責小說世界觀審核的編輯，擅長抓出規則、時間線、地點與能力設定的矛盾。請用繁體中文回答。"), prompt, w)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專責小說世界觀審核的編輯，擅長抓出規則、時間線、地點與能力設定的矛盾。請用繁體中文回答。"), worldConflictPrompt(worldProfile, chapter), w)
 }
 
 func (c *Checker) CheckDialogueStream(ctx context.Context, name, personality, speechStyle, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【角色說話風格】
-姓名：%s
-個性：%s
-說話風格：%s
-
-【待審章節對白】
-%s
-
-請分析：
-1. **語氣一致性**：對白是否符合角色風格？
-2. **具體問題**：列出不符合風格的對白行
-3. **修改建議**：提供符合角色風格的改寫版本
-`, name, personality, speechStyle, chapter)
-	return c.stream(ctx, "你是專業對白編輯，分析角色說話風格一致性。請用繁體中文回答。", prompt, w)
+	return c.CheckDialogueWithSystemStream(ctx, "", name, personality, speechStyle, chapter, w)
 }
 
 func (c *Checker) CheckDialogueWithSystemStream(ctx context.Context, systemPrefix, name, personality, speechStyle, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【角色說話風格】
-姓名：%s
-個性：%s
-說話風格：%s
-
-【待審章節對白】
-%s
-
-請分析：
-1. **語氣一致性**：對白是否符合角色風格？
-2. **具體問題**：列出不符合風格的對白行
-3. **修改建議**：提供符合角色風格的改寫版本
-`, name, personality, speechStyle, chapter)
-	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業對白編輯，分析角色說話風格一致性。請用繁體中文回答。"), prompt, w)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業對白編輯，分析角色說話風格一致性。請用繁體中文回答。"), dialoguePrompt(name, personality, speechStyle, chapter), w)
 }
 
 func (c *Checker) RewriteChapterStream(ctx context.Context, prompt string, w io.Writer) error {
@@ -306,73 +214,19 @@ func (c *Checker) RewriteChapterWithSystemStream(ctx context.Context, systemPref
 }
 
 func (c *Checker) EnhanceSensoryStream(ctx context.Context, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【待強化章節】
-%s
-
-請針對以下面向強化此章節的感官描寫：
-1. **視覺**：光線、色彩、空間感、動態細節
-2. **聽覺**：環境音、聲音質感、靜默對比
-3. **嗅覺**：場景氣味、記憶聯想
-4. **觸覺**：材質、溫度、身體感受
-5. **味覺**（如適用）
-
-規則：不改變情節與對白；感官描寫須符合場景氛圍；直接輸出修訂後的完整章節內容。
-`, chapter)
-	return c.stream(ctx, "你是專業文學編輯，擅長將平淡場景改寫為富有感官層次的文學散文。請用繁體中文回答。", prompt, w)
+	return c.EnhanceSensoryWithSystemStream(ctx, "", chapter, w)
 }
 
 func (c *Checker) EnhanceSensoryWithSystemStream(ctx context.Context, systemPrefix, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【待強化章節】
-%s
-
-請針對以下面向強化此章節的感官描寫：
-1. **視覺**：光線、色彩、空間感、動態細節
-2. **聽覺**：環境音、聲音質感、靜默對比
-3. **嗅覺**：場景氣味、記憶聯想
-4. **觸覺**：材質、溫度、身體感受
-5. **味覺**（如適用）
-
-規則：不改變情節與對白；感官描寫須符合場景氛圍；直接輸出修訂後的完整章節內容。
-`, chapter)
-	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，擅長將平淡場景改寫為富有感官層次的文學散文。請用繁體中文回答。"), prompt, w)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，擅長將平淡場景改寫為富有感官層次的文學散文。請用繁體中文回答。"), sensoryPrompt(chapter), w)
 }
 
 func (c *Checker) DiagnoseOpeningStream(ctx context.Context, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【待診斷章節】
-%s
-
-請模擬普通網路讀者（非文學評論家）閱讀此章節的體驗，從以下五個維度評分並給出建議：
-
-1. **懸念鉤子（Hook）**（1-10分）：開頭是否有讓讀者想繼續讀的疑問或張力？
-2. **主角魅力**（1-10分）：主角是否在短時間內展現出鮮明特質或讓人代入的處境？
-3. **世界觀吸引力**（1-10分）：設定是否讓讀者感到新奇或有探索欲？
-4. **節奏感**（1-10分）：前幾段的閱讀節奏是否流暢、不拖沓？
-5. **留存意願**（1-10分）：讀完此章後，讀者會想看下一章嗎？
-
-輸出格式：每項給出分數＋一到兩句說明；最後給出「總體建議」2-3條可立即執行的修改方向。
-`, chapter)
-	return c.stream(ctx, "你是資深網文平台編輯，擅長從普通讀者視角評估小說開頭的吸引力。請用繁體中文回答。", prompt, w)
+	return c.DiagnoseOpeningWithSystemStream(ctx, "", chapter, w)
 }
 
 func (c *Checker) DiagnoseOpeningWithSystemStream(ctx context.Context, systemPrefix, chapter string, w io.Writer) error {
-	prompt := fmt.Sprintf(`
-【待診斷章節】
-%s
-
-請模擬普通網路讀者（非文學評論家）閱讀此章節的體驗，從以下五個維度評分並給出建議：
-
-1. **懸念鉤子（Hook）**（1-10分）：開頭是否有讓讀者想繼續讀的疑問或張力？
-2. **主角魅力**（1-10分）：主角是否在短時間內展現出鮮明特質或讓人代入的處境？
-3. **世界觀吸引力**（1-10分）：設定是否讓讀者感到新奇或有探索欲？
-4. **節奏感**（1-10分）：前幾段的閱讀節奏是否流暢、不拖沓？
-5. **留存意願**（1-10分）：讀完此章後，讀者會想看下一章嗎？
-
-輸出格式：每項給出分數＋一到兩句說明；最後給出「總體建議」2-3條可立即執行的修改方向。
-`, chapter)
-	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是資深網文平台編輯，擅長從普通讀者視角評估小說開頭的吸引力。請用繁體中文回答。"), prompt, w)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是資深網文平台編輯，擅長從普通讀者視角評估小說開頭的吸引力。請用繁體中文回答。"), openingPrompt(chapter), w)
 }
 
 func (c *Checker) AnalyzeEmotionCurve(ctx context.Context, chapter string) ([]EmotionPoint, error) {
@@ -464,6 +318,86 @@ func withSystemPrefix(prefix, base string) string {
 		return base
 	}
 	return prefix + "\n\n" + base
+}
+
+func stylePrompt(styleProfile, chapter string) string {
+	return fmt.Sprintf(`
+【寫作風格設定】
+%s
+
+【待審章節】
+%s
+
+請依序分析：
+1. **風格一致性**：章節的寫作風格是否符合設定？（符合 / 不符合）
+2. **具體問題**：列出不符合風格設定的段落或句子，說明哪裡違和
+3. **修改建議**：針對問題段落，提供符合風格的改寫方向或範例
+`, styleProfile, chapter)
+}
+
+func worldConflictPrompt(worldProfile, chapter string) string {
+	return fmt.Sprintf(`
+【世界觀與規則設定】
+%s
+
+【待審章節】
+%s
+
+請依序分析：
+1. **世界觀一致性**：章節是否違反既有世界規則、時間線、地點設定、能力限制或勢力關係？（符合 / 不符合）
+2. **具體問題**：若有衝突，列出衝突段落並說明與哪條設定矛盾
+3. **修正建議**：提供最小修改方案，盡量保留原場景張力
+`, worldProfile, chapter)
+}
+
+func dialoguePrompt(name, personality, speechStyle, chapter string) string {
+	return fmt.Sprintf(`
+【角色說話風格】
+姓名：%s
+個性：%s
+說話風格：%s
+
+【待審章節對白】
+%s
+
+請分析：
+1. **語氣一致性**：對白是否符合角色風格？
+2. **具體問題**：列出不符合風格的對白行
+3. **修改建議**：提供符合角色風格的改寫版本
+`, name, personality, speechStyle, chapter)
+}
+
+func sensoryPrompt(chapter string) string {
+	return fmt.Sprintf(`
+【待強化章節】
+%s
+
+請針對以下面向強化此章節的感官描寫：
+1. **視覺**：光線、色彩、空間感、動態細節
+2. **聽覺**：環境音、聲音質感、靜默對比
+3. **嗅覺**：場景氣味、記憶聯想
+4. **觸覺**：材質、溫度、身體感受
+5. **味覺**（如適用）
+
+規則：不改變情節與對白；感官描寫須符合場景氛圍；直接輸出修訂後的完整章節內容。
+`, chapter)
+}
+
+func openingPrompt(chapter string) string {
+	return fmt.Sprintf(`
+【待診斷章節】
+%s
+
+請模擬普通網路讀者（非文學評論家）閱讀此章節的體驗，從以下五個維度評分並給出建議：
+
+1. **懸念鉤子（Hook）**（1-10分）：開頭是否有讓讀者想繼續讀的疑問或張力？
+2. **主角魅力**（1-10分）：主角是否在短時間內展現出鮮明特質或讓人代入的處境？
+3. **世界觀吸引力**（1-10分）：設定是否讓讀者感到新奇或有探索欲？
+4. **節奏感**（1-10分）：前幾段的閱讀節奏是否流暢、不拖沓？
+5. **留存意願**（1-10分）：讀完此章後，讀者會想看下一章嗎？
+
+輸出格式：每項給出分數＋一到兩句說明；最後給出「總體建議」2-3條可立即執行的修改方向。
+`, chapter)
 }
 
 func (c *Checker) stream(ctx context.Context, system, prompt string, w io.Writer) error {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"novel-assistant/internal/worldstate"
 	"strings"
 )
 
@@ -48,6 +49,13 @@ func (c *Checker) CheckBehaviorStream(ctx context.Context, profile, chapter stri
 		return c.checkBehaviorChunkedStream(ctx, profile, chapter, w)
 	}
 	return c.stream(ctx, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。", behaviorPrompt(profile, chapter, "", ""), w)
+}
+
+func (c *Checker) CheckBehaviorWithSystemStream(ctx context.Context, systemPrefix, profile, chapter string, w io.Writer) error {
+	if len([]rune(chapter)) > behaviorChunkRuneLimit {
+		return c.checkBehaviorChunkedWithSystemStream(ctx, systemPrefix, profile, chapter, w)
+	}
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。"), behaviorPrompt(profile, chapter, "", ""), w)
 }
 
 func behaviorPrompt(profile, chapter, chunkLabel, summary string) string {
@@ -188,6 +196,39 @@ func (c *Checker) CheckStyleStream(ctx context.Context, styleProfile, chapter st
 	return c.stream(ctx, "你是專業文學編輯，專責分析文章寫作風格的一致性。請用繁體中文回答。", prompt, w)
 }
 
+func (c *Checker) checkBehaviorChunkedWithSystemStream(ctx context.Context, systemPrefix, profile, chapter string, w io.Writer) error {
+	chunks := splitTextWithOverlap(chapter, behaviorChunkRuneLimit, behaviorChunkOverlap)
+	summary := summarizeBehaviorProfile(profile)
+	results := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		_, _ = fmt.Fprintf(w, "\n正在分析第 %d / %d 段…\n", i+1, len(chunks))
+		var buf strings.Builder
+		label := fmt.Sprintf("這是第 %d / %d 段，請以角色設定與本段內容為主，必要時利用重疊區理解前後文。", i+1, len(chunks))
+		if err := c.stream(ctx, withSystemPrefix(systemPrefix, "你是嚴謹的小說編輯，專責角色一致性審查。請用繁體中文回答。"), behaviorPrompt(profile, chunk, label, summary), &buf); err != nil {
+			return err
+		}
+		results = append(results, buf.String())
+	}
+	_, err := io.WriteString(w, mergeChunkedBehaviorResponses(results))
+	return err
+}
+
+func (c *Checker) CheckStyleWithSystemStream(ctx context.Context, systemPrefix, styleProfile, chapter string, w io.Writer) error {
+	prompt := fmt.Sprintf(`
+【寫作風格設定】
+%s
+
+【待審章節】
+%s
+
+請依序分析：
+1. **風格一致性**：章節的寫作風格是否符合設定？（符合 / 不符合）
+2. **具體問題**：列出不符合風格設定的段落或句子，說明哪裡違和
+3. **修改建議**：針對問題段落，提供符合風格的改寫方向或範例
+`, styleProfile, chapter)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，專責分析文章寫作風格的一致性。請用繁體中文回答。"), prompt, w)
+}
+
 func (c *Checker) CheckWorldConflictStream(ctx context.Context, worldProfile, chapter string, w io.Writer) error {
 	prompt := fmt.Sprintf(`
 【世界觀與規則設定】
@@ -202,6 +243,22 @@ func (c *Checker) CheckWorldConflictStream(ctx context.Context, worldProfile, ch
 3. **修正建議**：提供最小修改方案，盡量保留原場景張力
 `, worldProfile, chapter)
 	return c.stream(ctx, "你是專責小說世界觀審核的編輯，擅長抓出規則、時間線、地點與能力設定的矛盾。請用繁體中文回答。", prompt, w)
+}
+
+func (c *Checker) CheckWorldConflictWithSystemStream(ctx context.Context, systemPrefix, worldProfile, chapter string, w io.Writer) error {
+	prompt := fmt.Sprintf(`
+【世界觀與規則設定】
+%s
+
+【待審章節】
+%s
+
+請依序分析：
+1. **世界觀一致性**：章節是否違反既有世界規則、時間線、地點設定、能力限制或勢力關係？（符合 / 不符合）
+2. **具體問題**：若有衝突，列出衝突段落並說明與哪條設定矛盾
+3. **修正建議**：提供最小修改方案，盡量保留原場景張力
+`, worldProfile, chapter)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專責小說世界觀審核的編輯，擅長抓出規則、時間線、地點與能力設定的矛盾。請用繁體中文回答。"), prompt, w)
 }
 
 func (c *Checker) CheckDialogueStream(ctx context.Context, name, personality, speechStyle, chapter string, w io.Writer) error {
@@ -222,8 +279,30 @@ func (c *Checker) CheckDialogueStream(ctx context.Context, name, personality, sp
 	return c.stream(ctx, "你是專業對白編輯，分析角色說話風格一致性。請用繁體中文回答。", prompt, w)
 }
 
+func (c *Checker) CheckDialogueWithSystemStream(ctx context.Context, systemPrefix, name, personality, speechStyle, chapter string, w io.Writer) error {
+	prompt := fmt.Sprintf(`
+【角色說話風格】
+姓名：%s
+個性：%s
+說話風格：%s
+
+【待審章節對白】
+%s
+
+請分析：
+1. **語氣一致性**：對白是否符合角色風格？
+2. **具體問題**：列出不符合風格的對白行
+3. **修改建議**：提供符合角色風格的改寫版本
+`, name, personality, speechStyle, chapter)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業對白編輯，分析角色說話風格一致性。請用繁體中文回答。"), prompt, w)
+}
+
 func (c *Checker) RewriteChapterStream(ctx context.Context, prompt string, w io.Writer) error {
 	return c.stream(ctx, "你是專業小說編輯，專責修稿。請直接輸出修訂後的章節內容，必要時可在最前面補一小段修訂說明。請用繁體中文回答。", prompt, w)
+}
+
+func (c *Checker) RewriteChapterWithSystemStream(ctx context.Context, systemPrefix, prompt string, w io.Writer) error {
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業小說編輯，專責修稿。請直接輸出修訂後的章節內容，必要時可在最前面補一小段修訂說明。請用繁體中文回答。"), prompt, w)
 }
 
 func (c *Checker) EnhanceSensoryStream(ctx context.Context, chapter string, w io.Writer) error {
@@ -243,6 +322,23 @@ func (c *Checker) EnhanceSensoryStream(ctx context.Context, chapter string, w io
 	return c.stream(ctx, "你是專業文學編輯，擅長將平淡場景改寫為富有感官層次的文學散文。請用繁體中文回答。", prompt, w)
 }
 
+func (c *Checker) EnhanceSensoryWithSystemStream(ctx context.Context, systemPrefix, chapter string, w io.Writer) error {
+	prompt := fmt.Sprintf(`
+【待強化章節】
+%s
+
+請針對以下面向強化此章節的感官描寫：
+1. **視覺**：光線、色彩、空間感、動態細節
+2. **聽覺**：環境音、聲音質感、靜默對比
+3. **嗅覺**：場景氣味、記憶聯想
+4. **觸覺**：材質、溫度、身體感受
+5. **味覺**（如適用）
+
+規則：不改變情節與對白；感官描寫須符合場景氛圍；直接輸出修訂後的完整章節內容。
+`, chapter)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是專業文學編輯，擅長將平淡場景改寫為富有感官層次的文學散文。請用繁體中文回答。"), prompt, w)
+}
+
 func (c *Checker) DiagnoseOpeningStream(ctx context.Context, chapter string, w io.Writer) error {
 	prompt := fmt.Sprintf(`
 【待診斷章節】
@@ -259,6 +355,24 @@ func (c *Checker) DiagnoseOpeningStream(ctx context.Context, chapter string, w i
 輸出格式：每項給出分數＋一到兩句說明；最後給出「總體建議」2-3條可立即執行的修改方向。
 `, chapter)
 	return c.stream(ctx, "你是資深網文平台編輯，擅長從普通讀者視角評估小說開頭的吸引力。請用繁體中文回答。", prompt, w)
+}
+
+func (c *Checker) DiagnoseOpeningWithSystemStream(ctx context.Context, systemPrefix, chapter string, w io.Writer) error {
+	prompt := fmt.Sprintf(`
+【待診斷章節】
+%s
+
+請模擬普通網路讀者（非文學評論家）閱讀此章節的體驗，從以下五個維度評分並給出建議：
+
+1. **懸念鉤子（Hook）**（1-10分）：開頭是否有讓讀者想繼續讀的疑問或張力？
+2. **主角魅力**（1-10分）：主角是否在短時間內展現出鮮明特質或讓人代入的處境？
+3. **世界觀吸引力**（1-10分）：設定是否讓讀者感到新奇或有探索欲？
+4. **節奏感**（1-10分）：前幾段的閱讀節奏是否流暢、不拖沓？
+5. **留存意願**（1-10分）：讀完此章後，讀者會想看下一章嗎？
+
+輸出格式：每項給出分數＋一到兩句說明；最後給出「總體建議」2-3條可立即執行的修改方向。
+`, chapter)
+	return c.stream(ctx, withSystemPrefix(systemPrefix, "你是資深網文平台編輯，擅長從普通讀者視角評估小說開頭的吸引力。請用繁體中文回答。"), prompt, w)
 }
 
 func (c *Checker) AnalyzeEmotionCurve(ctx context.Context, chapter string) ([]EmotionPoint, error) {
@@ -312,6 +426,44 @@ func (c *Checker) ChatWithCharacterStream(ctx context.Context, characterProfile,
 規則：只說角色會說的話；保持設定中的語氣與個性；不要使用角色沒有的知識；請用繁體中文回答。`, characterProfile)
 
 	return c.stream(ctx, system, prompt, w)
+}
+
+func (c *Checker) GenerateWorldStateChanges(ctx context.Context, chapter string) ([]worldstate.Change, error) {
+	prompt := fmt.Sprintf(`
+分析以下章節內容，列出本章造成的「世界狀態變更」。
+只列出客觀事實變更（角色死亡、獲得/失去道具、地點移動、關係改變、狀態改變），不要列劇情摘要。
+輸出嚴格 JSON 陣列，不要有任何額外說明文字：
+[
+  {"entity":"...","change_type":"...","description":"..."}
+]
+
+章節內容：
+%s
+`, chapter)
+
+	var buf strings.Builder
+	if err := c.stream(ctx, "你是小說世界狀態分析器，只輸出 JSON，不輸出任何額外文字。請用繁體中文描述 description。", prompt, &buf); err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(buf.String())
+	start := strings.Index(raw, "[")
+	end := strings.LastIndex(raw, "]")
+	if start < 0 || end <= start {
+		return nil, fmt.Errorf("無法解析世界狀態快照回應")
+	}
+	var changes []worldstate.Change
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &changes); err != nil {
+		return nil, fmt.Errorf("JSON 解析失敗：%w", err)
+	}
+	return changes, nil
+}
+
+func withSystemPrefix(prefix, base string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return base
+	}
+	return prefix + "\n\n" + base
 }
 
 func (c *Checker) stream(ctx context.Context, system, prompt string, w io.Writer) error {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -90,6 +90,48 @@ func TestCheckBehaviorStreamUsesPronounGuidance(t *testing.T) {
 	}
 }
 
+func TestCheckBehaviorWithSystemStreamPrependsWorldState(t *testing.T) {
+	t.Parallel()
+
+	var captured genReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	var out bytes.Buffer
+	if err := c.CheckBehaviorWithSystemStream(context.Background(), "【當前世界狀態】\n- 林昊：已失去傳家寶劍", "角色設定", "章節內容", &out); err != nil {
+		t.Fatalf("expected stream success, got error: %v", err)
+	}
+	if !strings.Contains(captured.System, "【當前世界狀態】") {
+		t.Fatalf("expected system prefix in request, got %q", captured.System)
+	}
+}
+
+func TestGenerateWorldStateChangesParsesJSONArray(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"[{\\\"entity\\\":\\\"林昊\\\",\\\"change_type\\\":\\\"status\\\",\\\"description\\\":\\\"已失去傳家寶劍\\\"}]\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	changes, err := c.GenerateWorldStateChanges(context.Background(), "章節內容")
+	if err != nil {
+		t.Fatalf("expected parse success, got error: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Entity != "林昊" {
+		t.Fatalf("unexpected changes: %#v", changes)
+	}
+}
+
 func TestSplitTextWithOverlapEdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/chapters_page.go
+++ b/internal/server/chapters_page.go
@@ -26,6 +26,8 @@ type chapterOverview struct {
 	TimelineCount   int
 	Signals         extractor.Signals
 	SceneCards      []sceneBoardCard
+	SnapshotAt      time.Time
+	SnapshotLines   []string
 }
 
 type sceneBoardCard struct {
@@ -155,6 +157,14 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 				RewriteCount: rewriteCount,
 			})
 		}
+		var snapshotAt time.Time
+		var snapshotLines []string
+		if s.worldstate != nil {
+			if snapshot := s.worldstate.GetByChapterFile(file.Name); snapshot != nil {
+				snapshotAt = snapshot.GeneratedAt
+				snapshotLines = summarizeSnapshot(snapshot)
+			}
+		}
 		overviews = append(overviews, chapterOverview{
 			Name:            file.Name,
 			Title:           file.Title,
@@ -167,6 +177,8 @@ func (s *Server) buildChapterOverviews() ([]chapterOverview, error) {
 			TimelineCount:   timelineCounts[chapterNo],
 			Signals:         signals,
 			SceneCards:      sceneCards,
+			SnapshotAt:      snapshotAt,
+			SnapshotLines:   snapshotLines,
 		})
 	}
 

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	"novel-assistant/internal/checker"
@@ -22,6 +23,7 @@ import (
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
+	"novel-assistant/internal/worldstate"
 
 	"github.com/gin-gonic/gin"
 )
@@ -146,6 +148,108 @@ func TestCheckStreamMarksGapsAsUnindexedWhenStoreIsEmpty(t *testing.T) {
 	}
 	if !strings.Contains(string(checkResp.Body), "\"index_ready\":false") {
 		t.Fatalf("expected unindexed gap payload in stream, got %s", string(checkResp.Body))
+	}
+}
+
+func TestCreateWorldstateSnapshotAndList(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"[{\\\"entity\\\":\\\"林昊\\\",\\\"change_type\\\":\\\"status\\\",\\\"description\\\":\\\"已失去傳家寶劍\\\"}]\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第02章.md"), "林昊把傳家寶劍賣了出去。")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	snapshotResp := performRequest(t, app.URL, "POST", "/api/chapters/%E7%AC%AC02%E7%AB%A0.md/snapshot", nil)
+	if snapshotResp.StatusCode != http.StatusOK || !strings.Contains(string(snapshotResp.Body), "已產生章節狀態快照") {
+		t.Fatalf("snapshot endpoint failed: %s", string(snapshotResp.Body))
+	}
+
+	listResp := performRequest(t, app.URL, "GET", "/api/worldstate", nil)
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("worldstate list failed: %s", string(listResp.Body))
+	}
+	if !strings.Contains(string(listResp.Body), "\"chapter_file\":\"第02章.md\"") || !strings.Contains(string(listResp.Body), "已失去傳家寶劍") {
+		t.Fatalf("expected snapshot in list payload, got %s", string(listResp.Body))
+	}
+}
+
+func TestCheckAndRewriteUseLatestWorldstateInSystemPrompt(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu      sync.Mutex
+		systems []string
+	)
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			var req struct {
+				System string `json:"system"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode generate request: %v", err)
+			}
+			mu.Lock()
+			systems = append(systems, req.System)
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	s.worldstate.Upsert(&worldstate.Snapshot{
+		ChapterFile:  "第01章.md",
+		ChapterIndex: 1,
+		Changes: []worldstate.Change{
+			{Entity: "林昊", ChangeType: "status", Description: "已失去傳家寶劍"},
+		},
+	})
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	checkResp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":      "林昊走進夜港塔下。",
+		"checks":       []string{"behavior"},
+		"chapter_file": "第02章.md",
+	})
+	if checkResp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(checkResp.Body))
+	}
+
+	rewriteResp := performJSONRequest(t, app.URL, "POST", "/rewrite/stream", map[string]any{
+		"chapter":      "林昊走進夜港塔下。",
+		"mode":         "conservative",
+		"chapter_file": "第02章.md",
+	})
+	if rewriteResp.StatusCode != http.StatusOK {
+		t.Fatalf("rewrite stream failed: %s", string(rewriteResp.Body))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	joined := strings.Join(systems, "\n---\n")
+	if !strings.Contains(joined, "【當前世界狀態（截至第 1 章）】") || !strings.Contains(joined, "已失去傳家寶劍") {
+		t.Fatalf("expected world state in generate system prompts, got %s", joined)
 	}
 }
 
@@ -329,6 +433,7 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 		relationships: tracker.NewRelationshipTracker(filepath.Join(dataDir, "relationships.json")),
 		timeline:      tracker.NewTimelineTracker(filepath.Join(dataDir, "timeline.json")),
 		foreshadow:    tracker.NewForeshadowTracker(filepath.Join(dataDir, "foreshadow.json")),
+		worldstate:    worldstate.New(filepath.Join(dataDir, "worldstate.json")),
 	}
 	if err := s.profiles.Load(); err != nil {
 		t.Fatalf("load profiles: %v", err)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -768,6 +768,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		defer close(msgChan)
 
 		cw := &chanWriter{ch: msgChan, transcript: &transcript}
+		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
 		charsToCheck := s.resolveCharacters(req)
 		needsCharacters := len(req.Checks) == 0 || contains(req.Checks, "behavior") || contains(req.Checks, "dialogue")
 		if needsCharacters && len(charsToCheck) == 0 {
@@ -861,7 +862,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 				transcript.WriteString("\n\n## 世界觀衝突審查\n\n")
 				msgChan <- streamEvent{Event: "chunk", Text: "\n\n## 世界觀衝突審查\n\n"}
 				worldPrompt := worldText + "\n\n【審查偏好】\n" + reviewBias
-				if err := s.checker.CheckWorldConflictStream(ctx, worldPrompt, req.Chapter, cw); err != nil {
+				if err := s.checker.CheckWorldConflictWithSystemStream(ctx, worldStatePrefix, worldPrompt, req.Chapter, cw); err != nil {
 					if ctx.Err() == nil {
 						text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
 						transcript.WriteString(text)
@@ -876,7 +877,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			text := "\n\n## 黃金三章診斷\n\n"
 			transcript.WriteString(text)
 			msgChan <- streamEvent{Event: "chunk", Text: text}
-			if err := s.checker.DiagnoseOpeningStream(ctx, req.Chapter, cw); err != nil {
+			if err := s.checker.DiagnoseOpeningWithSystemStream(ctx, worldStatePrefix, req.Chapter, cw); err != nil {
 				if ctx.Err() == nil {
 					log.Printf("opening diagnosis: %v", err)
 					text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
@@ -899,7 +900,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 				if behaviorRefText != "" {
 					profileText += "\n\n【補充參考資料】\n" + behaviorRefText
 				}
-				if err := s.checker.CheckBehaviorStream(ctx, profileText, req.Chapter, cw); err != nil {
+				if err := s.checker.CheckBehaviorWithSystemStream(ctx, worldStatePrefix, profileText, req.Chapter, cw); err != nil {
 					if ctx.Err() == nil {
 						text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
 						transcript.WriteString(text)
@@ -920,7 +921,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 				if dialogueRefText != "" {
 					dialogueStyle += "\n\n【補充參考資料】\n" + dialogueRefText
 				}
-				if err := s.checker.CheckDialogueStream(ctx, char.Name, char.Personality, dialogueStyle, req.Chapter, cw); err != nil {
+				if err := s.checker.CheckDialogueWithSystemStream(ctx, worldStatePrefix, char.Name, char.Personality, dialogueStyle, req.Chapter, cw); err != nil {
 					if ctx.Err() == nil {
 						text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
 						transcript.WriteString(text)
@@ -944,7 +945,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			transcript.WriteString(text)
 			msgChan <- streamEvent{Event: "chunk", Text: text}
 			stylePrompt := sg.RawContent + "\n\n【審查偏好】\n" + reviewBias
-			if err := s.checker.CheckStyleStream(ctx, stylePrompt, req.Chapter, cw); err != nil {
+			if err := s.checker.CheckStyleWithSystemStream(ctx, worldStatePrefix, stylePrompt, req.Chapter, cw); err != nil {
 				if ctx.Err() == nil {
 					text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
 					transcript.WriteString(text)
@@ -1083,6 +1084,7 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer cancel()
 		defer close(msgChan)
 
+		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
 		activeRetrieval := summarizeRetrieval("rewrite", mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval))
 		traceStarted := time.Now()
 		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, retrievalOptions{
@@ -1119,9 +1121,9 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 
 		var rewriteErr error
 		if req.Mode == "sensory" {
-			rewriteErr = s.checker.EnhanceSensoryStream(ctx, strings.Join(promptParts, "\n\n"), cw)
+			rewriteErr = s.checker.EnhanceSensoryWithSystemStream(ctx, worldStatePrefix, strings.Join(promptParts, "\n\n"), cw)
 		} else {
-			rewriteErr = s.checker.RewriteChapterStream(ctx, strings.Join(promptParts, "\n\n"), cw)
+			rewriteErr = s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, strings.Join(promptParts, "\n\n"), cw)
 		}
 		if rewriteErr != nil {
 			if ctx.Err() == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
 	"novel-assistant/internal/workspace"
+	"novel-assistant/internal/worldstate"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,7 @@ type projectState struct {
 	relationships *tracker.RelationshipTracker
 	timeline      *tracker.TimelineTracker
 	foreshadow    *tracker.ForeshadowTracker
+	worldstate    *worldstate.Store
 }
 
 type Server struct {
@@ -54,6 +56,7 @@ type Server struct {
 	relationships  *tracker.RelationshipTracker
 	timeline       *tracker.TimelineTracker
 	foreshadow     *tracker.ForeshadowTracker
+	worldstate     *worldstate.Store
 	chapterOrderMu sync.RWMutex
 	scenePlansMu   sync.RWMutex
 }
@@ -154,9 +157,11 @@ func (s *Server) setupRoutes() {
 	protected.GET("/api/chapters", s.handleListChapters)
 	protected.GET("/api/chapters/:name", s.handleGetChapter)
 	protected.GET("/api/settings", s.handleGetSettings)
+	protected.GET("/api/worldstate", s.handleListWorldstate)
 
 	protected.POST("/ingest", s.handleIngest)
 	protected.POST("/api/chapters", s.handleSaveChapter)
+	protected.POST("/api/chapters/:name/snapshot", s.handleCreateWorldstateSnapshot)
 	protected.POST("/api/chapters/order", s.handleSaveChapterOrder)
 	protected.POST("/api/chapters/:name/scenes/plan", s.handleSaveScenePlan)
 	protected.POST("/api/chapters/:name/scenes/order", s.handleSaveSceneOrder)
@@ -233,6 +238,11 @@ func (s *Server) loadProjectState(name string) (*projectState, error) {
 		log.Printf("foreshadow load: %v", err)
 	}
 
+	st.worldstate = worldstate.New(filepath.Join(dataDir, "worldstate.json"))
+	if err := st.worldstate.Load(); err != nil {
+		log.Printf("worldstate load: %v", err)
+	}
+
 	return st, nil
 }
 
@@ -244,7 +254,7 @@ func (s *Server) currentState() *projectState {
 		return st
 	}
 	if s.profiles == nil && s.store == nil && s.project == nil && s.rules == nil && s.history == nil &&
-		s.relationships == nil && s.timeline == nil && s.foreshadow == nil {
+		s.relationships == nil && s.timeline == nil && s.foreshadow == nil && s.worldstate == nil {
 		return nil
 	}
 	dataDir := s.cfg.DataDir
@@ -261,6 +271,7 @@ func (s *Server) currentState() *projectState {
 		relationships: s.relationships,
 		timeline:      s.timeline,
 		foreshadow:    s.foreshadow,
+		worldstate:    s.worldstate,
 	}
 }
 
@@ -276,6 +287,7 @@ func (s *Server) setProjectState(st *projectState) {
 	s.relationships = st.relationships
 	s.timeline = st.timeline
 	s.foreshadow = st.foreshadow
+	s.worldstate = st.worldstate
 	s.cfg.DataDir = st.dataDir
 }
 

--- a/internal/server/worldstate.go
+++ b/internal/server/worldstate.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (s *Server) handleCreateWorldstateSnapshot(c *gin.Context) {
+	if s.worldstate == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "世界狀態快照功能尚未初始化"})
+		return
+	}
 	file, err := s.loadChapterFile(c.Param("name"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -32,6 +36,10 @@ func (s *Server) handleCreateWorldstateSnapshot(c *gin.Context) {
 		ChapterIndex: chapterNumberFromName(file.Name),
 		Changes:      changes,
 	}
+	if snapshot.ChapterIndex <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "無法從章節檔名解析章節順序"})
+		return
+	}
 	s.worldstate.Upsert(snapshot)
 	if err := s.worldstate.Save(); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -47,6 +55,10 @@ func (s *Server) handleCreateWorldstateSnapshot(c *gin.Context) {
 }
 
 func (s *Server) handleListWorldstate(c *gin.Context) {
+	if s.worldstate == nil {
+		c.JSON(http.StatusOK, gin.H{"items": []*worldstate.Snapshot{}})
+		return
+	}
 	c.JSON(http.StatusOK, gin.H{"items": s.worldstate.GetAll()})
 }
 
@@ -66,15 +78,8 @@ func (s *Server) worldStateSystemPrefix(chapterFile string) string {
 
 	lines := make([]string, 0, len(snapshot.Changes))
 	for _, change := range snapshot.Changes {
-		description := strings.TrimSpace(change.Description)
-		entity := strings.TrimSpace(change.Entity)
-		switch {
-		case entity != "" && description != "":
-			lines = append(lines, fmt.Sprintf("- %s：%s", entity, description))
-		case description != "":
-			lines = append(lines, "- "+description)
-		case entity != "":
-			lines = append(lines, "- "+entity)
+		if line := formatChangeLine(change, "- "); line != "" {
+			lines = append(lines, line)
 		}
 	}
 	if len(lines) == 0 {
@@ -90,16 +95,24 @@ func summarizeSnapshot(snapshot *worldstate.Snapshot) []string {
 	}
 	lines := make([]string, 0, len(snapshot.Changes))
 	for _, change := range snapshot.Changes {
-		description := strings.TrimSpace(change.Description)
-		entity := strings.TrimSpace(change.Entity)
-		switch {
-		case entity != "" && description != "":
-			lines = append(lines, fmt.Sprintf("%s：%s", entity, description))
-		case description != "":
-			lines = append(lines, description)
-		case entity != "":
-			lines = append(lines, entity)
+		if line := formatChangeLine(change, ""); line != "" {
+			lines = append(lines, line)
 		}
 	}
 	return lines
+}
+
+func formatChangeLine(change worldstate.Change, prefix string) string {
+	description := strings.TrimSpace(change.Description)
+	entity := strings.TrimSpace(change.Entity)
+	switch {
+	case entity != "" && description != "":
+		return fmt.Sprintf("%s%s：%s", prefix, entity, description)
+	case description != "":
+		return prefix + description
+	case entity != "":
+		return prefix + entity
+	default:
+		return ""
+	}
 }

--- a/internal/server/worldstate.go
+++ b/internal/server/worldstate.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"novel-assistant/internal/worldstate"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) handleCreateWorldstateSnapshot(c *gin.Context) {
+	file, err := s.loadChapterFile(c.Param("name"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(file.Content) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可為空"})
+		return
+	}
+
+	changes, err := s.checker.GenerateWorldStateChanges(c.Request.Context(), file.Content)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	snapshot := &worldstate.Snapshot{
+		ChapterFile:  file.Name,
+		ChapterIndex: chapterNumberFromName(file.Name),
+		Changes:      changes,
+	}
+	s.worldstate.Upsert(snapshot)
+	if err := s.worldstate.Save(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	latest := s.worldstate.GetByChapterFile(file.Name)
+	c.JSON(http.StatusOK, gin.H{
+		"ok":       true,
+		"message":  "已產生章節狀態快照",
+		"snapshot": latest,
+	})
+}
+
+func (s *Server) handleListWorldstate(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"items": s.worldstate.GetAll()})
+}
+
+func (s *Server) worldStateSystemPrefix(chapterFile string) string {
+	chapterFile = strings.TrimSpace(chapterFile)
+	if chapterFile == "" || s.worldstate == nil {
+		return ""
+	}
+	chapterIndex := chapterNumberFromName(chapterFile)
+	if chapterIndex <= 0 {
+		return ""
+	}
+	snapshot := s.worldstate.GetLatestBefore(chapterIndex)
+	if snapshot == nil || len(snapshot.Changes) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(snapshot.Changes))
+	for _, change := range snapshot.Changes {
+		description := strings.TrimSpace(change.Description)
+		entity := strings.TrimSpace(change.Entity)
+		switch {
+		case entity != "" && description != "":
+			lines = append(lines, fmt.Sprintf("- %s：%s", entity, description))
+		case description != "":
+			lines = append(lines, "- "+description)
+		case entity != "":
+			lines = append(lines, "- "+entity)
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("【當前世界狀態（截至第 %d 章）】\n%s", snapshot.ChapterIndex, strings.Join(lines, "\n"))
+}
+
+func summarizeSnapshot(snapshot *worldstate.Snapshot) []string {
+	if snapshot == nil {
+		return nil
+	}
+	lines := make([]string, 0, len(snapshot.Changes))
+	for _, change := range snapshot.Changes {
+		description := strings.TrimSpace(change.Description)
+		entity := strings.TrimSpace(change.Entity)
+		switch {
+		case entity != "" && description != "":
+			lines = append(lines, fmt.Sprintf("%s：%s", entity, description))
+		case description != "":
+			lines = append(lines, description)
+		case entity != "":
+			lines = append(lines, entity)
+		}
+	}
+	return lines
+}

--- a/internal/worldstate/store.go
+++ b/internal/worldstate/store.go
@@ -1,0 +1,142 @@
+package worldstate
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+type Change struct {
+	Entity      string `json:"entity"`
+	ChangeType  string `json:"change_type"`
+	Description string `json:"description"`
+}
+
+type Snapshot struct {
+	ChapterFile  string    `json:"chapter_file"`
+	ChapterIndex int       `json:"chapter_index"`
+	GeneratedAt  time.Time `json:"generated_at"`
+	Changes      []Change  `json:"changes"`
+}
+
+type Store struct {
+	mu    sync.RWMutex
+	path  string
+	Items []*Snapshot `json:"items"`
+}
+
+func New(path string) *Store {
+	return &Store{path: path}
+}
+
+func (s *Store) Load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &s.Items); err != nil {
+		return err
+	}
+	s.sortLocked()
+	return nil
+}
+
+func (s *Store) Save() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	data, _ := json.MarshalIndent(s.Items, "", "  ")
+	return os.WriteFile(s.path, data, 0644)
+}
+
+func (s *Store) Upsert(snapshot *Snapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copied := cloneSnapshot(snapshot)
+	copied.GeneratedAt = time.Now()
+	replaced := false
+	for i, item := range s.Items {
+		if item.ChapterFile == copied.ChapterFile {
+			s.Items[i] = copied
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		s.Items = append(s.Items, copied)
+	}
+	s.sortLocked()
+}
+
+func (s *Store) GetLatestBefore(chapterIndex int) *Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var latest *Snapshot
+	for _, item := range s.Items {
+		if item == nil || item.ChapterIndex >= chapterIndex {
+			continue
+		}
+		if latest == nil || item.ChapterIndex > latest.ChapterIndex || (item.ChapterIndex == latest.ChapterIndex && item.GeneratedAt.After(latest.GeneratedAt)) {
+			latest = item
+		}
+	}
+	return cloneSnapshot(latest)
+}
+
+func (s *Store) GetByChapterFile(chapterFile string) *Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, item := range s.Items {
+		if item != nil && item.ChapterFile == chapterFile {
+			return cloneSnapshot(item)
+		}
+	}
+	return nil
+}
+
+func (s *Store) GetAll() []*Snapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	items := make([]*Snapshot, 0, len(s.Items))
+	for _, item := range s.Items {
+		items = append(items, cloneSnapshot(item))
+	}
+	return items
+}
+
+func (s *Store) sortLocked() {
+	sort.Slice(s.Items, func(i, j int) bool {
+		left := s.Items[i]
+		right := s.Items[j]
+		if left == nil || right == nil {
+			return left != nil
+		}
+		if left.ChapterIndex != right.ChapterIndex {
+			return left.ChapterIndex < right.ChapterIndex
+		}
+		if left.ChapterFile != right.ChapterFile {
+			return left.ChapterFile < right.ChapterFile
+		}
+		return left.GeneratedAt.Before(right.GeneratedAt)
+	})
+}
+
+func cloneSnapshot(item *Snapshot) *Snapshot {
+	if item == nil {
+		return nil
+	}
+	changes := make([]Change, len(item.Changes))
+	copy(changes, item.Changes)
+	return &Snapshot{
+		ChapterFile:  item.ChapterFile,
+		ChapterIndex: item.ChapterIndex,
+		GeneratedAt:  item.GeneratedAt,
+		Changes:      changes,
+	}
+}

--- a/internal/worldstate/store_test.go
+++ b/internal/worldstate/store_test.go
@@ -3,7 +3,6 @@ package worldstate
 import (
 	"path/filepath"
 	"testing"
-	"time"
 )
 
 func TestStoreGetLatestBefore(t *testing.T) {
@@ -15,7 +14,6 @@ func TestStoreGetLatestBefore(t *testing.T) {
 		ChapterIndex: 1,
 		Changes:      []Change{{Entity: "林昊", ChangeType: "status", Description: "開始追查夜港塔"}},
 	})
-	time.Sleep(time.Millisecond)
 	store.Upsert(&Snapshot{
 		ChapterFile:  "第03章.md",
 		ChapterIndex: 3,

--- a/internal/worldstate/store_test.go
+++ b/internal/worldstate/store_test.go
@@ -1,0 +1,62 @@
+package worldstate
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreGetLatestBefore(t *testing.T) {
+	t.Parallel()
+
+	store := New(filepath.Join(t.TempDir(), "worldstate.json"))
+	store.Upsert(&Snapshot{
+		ChapterFile:  "第01章.md",
+		ChapterIndex: 1,
+		Changes:      []Change{{Entity: "林昊", ChangeType: "status", Description: "開始追查夜港塔"}},
+	})
+	time.Sleep(time.Millisecond)
+	store.Upsert(&Snapshot{
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		Changes:      []Change{{Entity: "傳家寶劍", ChangeType: "lost", Description: "已賣出"}},
+	})
+
+	if got := store.GetLatestBefore(1); got != nil {
+		t.Fatalf("expected no snapshot before chapter 1, got %#v", got)
+	}
+
+	got := store.GetLatestBefore(3)
+	if got == nil || got.ChapterFile != "第01章.md" {
+		t.Fatalf("expected chapter 1 snapshot before chapter 3, got %#v", got)
+	}
+
+	got = store.GetLatestBefore(4)
+	if got == nil || got.ChapterFile != "第03章.md" {
+		t.Fatalf("expected chapter 3 snapshot before chapter 4, got %#v", got)
+	}
+}
+
+func TestStoreUpsertReplacesExistingChapterSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store := New(filepath.Join(t.TempDir(), "worldstate.json"))
+	store.Upsert(&Snapshot{
+		ChapterFile:  "第02章.md",
+		ChapterIndex: 2,
+		Changes:      []Change{{Entity: "夜港塔", ChangeType: "moved", Description: "抵達塔頂"}},
+	})
+	store.Upsert(&Snapshot{
+		ChapterFile:  "第02章.md",
+		ChapterIndex: 2,
+		Changes:      []Change{{Entity: "林昊", ChangeType: "status", Description: "受傷"}},
+	})
+
+	items := store.GetAll()
+	if len(items) != 1 {
+		t.Fatalf("expected single snapshot after upsert, got %d", len(items))
+	}
+	if len(items[0].Changes) != 1 || items[0].Changes[0].Description != "受傷" {
+		t.Fatalf("expected replacement snapshot, got %#v", items[0])
+	}
+}

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -89,6 +89,7 @@
           </div>
           <div class="history-actions">
             <button class="btn btn-ghost btn-sm" type="button" onclick="exportChapterBundle('{{.Name}}')">匯出完整報告</button>
+            <button class="btn btn-ghost btn-sm" type="button" onclick="createWorldstateSnapshot('{{.Name}}')">產生狀態快照</button>
             <a class="btn btn-ghost btn-sm" href="/check?chapter={{.Name}}">載入到審查頁</a>
           </div>
         </div>
@@ -109,6 +110,18 @@
         </div>
 
         <div class="chapter-signal-grid">
+          <div class="writeback-card">
+            <h3>章節狀態快照</h3>
+            {{if .SnapshotLines}}
+              <div class="helper-text" style="margin-bottom:8px">最近更新 {{.SnapshotAt.Format "2006-01-02 15:04:05"}}</div>
+              {{range .SnapshotLines}}
+              <div class="candidate-row"><span>{{.}}</span></div>
+              {{end}}
+            {{else}}
+              <div class="empty-state">尚未建立狀態快照。可手動產生，讓後續審查與修稿優先參考前章節的最新世界狀態。</div>
+            {{end}}
+          </div>
+
           <div class="writeback-card">
             <h3>角色候選</h3>
             {{if .Signals.CharacterCandidates}}
@@ -251,6 +264,20 @@ async function exportChapterBundle(name) {
     URL.revokeObjectURL(url);
   } catch (e) {
     alert('匯出失敗：' + e.message);
+  }
+}
+
+async function createWorldstateSnapshot(name) {
+  try {
+    const resp = await fetch('/api/chapters/' + encodeURIComponent(name) + '/snapshot', {
+      method: 'POST'
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '產生狀態快照失敗');
+    alert(data.message);
+    window.location.reload();
+  } catch (e) {
+    alert('產生狀態快照失敗：' + e.message);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a new `internal/worldstate` store for per-chapter world-state snapshots with latest-before lookup
- add `POST /api/chapters/:name/snapshot` and `GET /api/worldstate`
- inject the latest prior world-state snapshot into check/rewrite system prompts
- add chapter overview actions to generate a snapshot and view the latest summary inline
- add store, checker, and e2e coverage for snapshot generation and prompt injection

## Why
Issue #31 addresses a common long-form fiction problem: retrieval can surface facts from older chapters without knowing that later chapters changed the world state. By storing manual chapter snapshots and pushing the latest known state into the system prompt, review and rewrite flows can prioritize the current canon over stale references.

## Impact
- users can manually generate a structured world-state snapshot for each chapter
- review and rewrite requests now receive the latest prior snapshot as high-priority context
- chapter overview surfaces the latest snapshot summary without adding a separate page
- snapshot data is persisted in `worldstate.json` alongside existing project state

## Validation
- `gofmt -w` on the touched Go files
- `go test ./...`
- added tests for `GetLatestBefore` boundary behavior
- added tests for snapshot generation, worldstate listing, and prompt injection into Ollama system prompts

Closes #31