### PR TITLE
chore: add large-pr label exemption to pr-size CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q 'large-pr'; then
+            echo "large-pr label present, skipping size check."
+            exit 0
+          fi
           lines=$(gh pr diff ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} | grep -cE '^[+-]' || true)
           echo "Changed lines: $lines"
           if [ "$lines" -gt 700 ]; then
-            echo "PR too large ($lines lines, limit 700). Split into smaller PRs."
+            echo "PR too large ($lines lines, limit 700). Add 'large-pr' label to exempt, or split into smaller PRs."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- PR size check skips when the `large-pr` label is present
- Error message updated to mention the exemption as an alternative to splitting

## Why
Some features (e.g., new packages with store + handler + tests + e2e) cannot be meaningfully split without breaking CI on each sub-PR. The label provides an explicit opt-out that requires conscious action.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>