### PR TITLE
feat: add pre-generation consistency conflict warnings

### DIFF
--- a/docs/plans/issue-32-conflict-precheck.md
+++ b/docs/plans/issue-32-conflict-precheck.md
@@ -1,0 +1,7 @@
+## Issue #32 Plan
+
+- Add an `internal/consistency` package that sends one preflight LLM call and parses JSON conflicts.
+- Run the consistency precheck after RAG references are assembled but before the main check/rewrite generation starts.
+- Emit a new SSE `conflict` event without blocking the downstream generation flow.
+- Show conflict warnings in the review UI before the streamed result content.
+- Cover JSON parsing and SSE ordering with tests.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -312,6 +312,10 @@ func (c *Checker) GenerateWorldStateChanges(ctx context.Context, chapter string)
 	return changes, nil
 }
 
+func (c *Checker) RawStream(ctx context.Context, system, prompt string, w io.Writer) error {
+	return c.stream(ctx, system, prompt, w)
+}
+
 func withSystemPrefix(prefix, base string) string {
 	prefix = strings.TrimSpace(prefix)
 	if prefix == "" {

--- a/internal/consistency/check.go
+++ b/internal/consistency/check.go
@@ -1,13 +1,10 @@
 package consistency
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
+	"novel-assistant/internal/checker"
 	"strings"
 )
 
@@ -18,33 +15,22 @@ type Conflict struct {
 }
 
 type Checker struct {
-	baseURL string
-	model   string
+	checker *checker.Checker
 }
 
-func New(baseURL, model string) *Checker {
-	return &Checker{baseURL: baseURL, model: model}
-}
-
-type genReq struct {
-	Model  string `json:"model"`
-	System string `json:"system"`
-	Prompt string `json:"prompt"`
-	Stream bool   `json:"stream"`
-}
-
-type genChunk struct {
-	Response string `json:"response"`
-	Done     bool   `json:"done"`
+func New(c *checker.Checker) *Checker {
+	return &Checker{checker: c}
 }
 
 func (c *Checker) Check(ctx context.Context, prompt, worldContext string) ([]Conflict, error) {
-	reqBody := genReq{
-		Model:  c.model,
-		System: "你是小說邏輯審查員，只輸出 JSON，不輸出任何額外文字。請用繁體中文撰寫衝突說明。",
-		Prompt: fmt.Sprintf(`
-你是小說邏輯審查員。以下是目前世界設定與追蹤器：
-
+	if c == nil || c.checker == nil {
+		return nil, fmt.Errorf("一致性檢查器尚未初始化")
+	}
+	var raw strings.Builder
+	if err := c.checker.RawStream(
+		ctx,
+		"你是小說邏輯審查員，只輸出 JSON，不輸出任何額外文字。請用繁體中文撰寫衝突說明。",
+		fmt.Sprintf(`
 【世界設定與追蹤器】
 %s
 
@@ -56,43 +42,8 @@ func (c *Checker) Check(ctx context.Context, prompt, worldContext string) ([]Con
 [{"severity":"warning|error","description":"衝突說明","reference":"依據來源"}]
 若無衝突，回傳：[]
 `, strings.TrimSpace(worldContext), strings.TrimSpace(prompt)),
-		Stream: true,
-	}
-
-	body, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshal consistency request: %w", err)
-	}
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/generate", bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("ollama unavailable: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, fmt.Errorf("ollama generate failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
-	}
-
-	var raw strings.Builder
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-	for scanner.Scan() {
-		var chunk genChunk
-		if err := json.Unmarshal(scanner.Bytes(), &chunk); err != nil {
-			continue
-		}
-		raw.WriteString(chunk.Response)
-		if chunk.Done {
-			break
-		}
-	}
-	if err := scanner.Err(); err != nil {
+		&raw,
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/consistency/check.go
+++ b/internal/consistency/check.go
@@ -1,0 +1,110 @@
+package consistency
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Conflict struct {
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Reference   string `json:"reference"`
+}
+
+type Checker struct {
+	baseURL string
+	model   string
+}
+
+func New(baseURL, model string) *Checker {
+	return &Checker{baseURL: baseURL, model: model}
+}
+
+type genReq struct {
+	Model  string `json:"model"`
+	System string `json:"system"`
+	Prompt string `json:"prompt"`
+	Stream bool   `json:"stream"`
+}
+
+type genChunk struct {
+	Response string `json:"response"`
+	Done     bool   `json:"done"`
+}
+
+func (c *Checker) Check(ctx context.Context, prompt, worldContext string) ([]Conflict, error) {
+	reqBody := genReq{
+		Model:  c.model,
+		System: "你是小說邏輯審查員，只輸出 JSON，不輸出任何額外文字。請用繁體中文撰寫衝突說明。",
+		Prompt: fmt.Sprintf(`
+你是小說邏輯審查員。以下是目前世界設定與追蹤器：
+
+【世界設定與追蹤器】
+%s
+
+【使用者即將生成的場景描述】
+%s
+
+請判斷場景描述是否與世界設定產生邏輯矛盾。
+只回傳 JSON 陣列，格式：
+[{"severity":"warning|error","description":"衝突說明","reference":"依據來源"}]
+若無衝突，回傳：[]
+`, strings.TrimSpace(worldContext), strings.TrimSpace(prompt)),
+		Stream: true,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal consistency request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/generate", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ollama unavailable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("ollama generate failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var raw strings.Builder
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var chunk genChunk
+		if err := json.Unmarshal(scanner.Bytes(), &chunk); err != nil {
+			continue
+		}
+		raw.WriteString(chunk.Response)
+		if chunk.Done {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	text := strings.TrimSpace(raw.String())
+	start := strings.Index(text, "[")
+	end := strings.LastIndex(text, "]")
+	if start < 0 || end <= start {
+		return nil, fmt.Errorf("無法解析一致性預檢回應")
+	}
+	var conflicts []Conflict
+	if err := json.Unmarshal([]byte(text[start:end+1]), &conflicts); err != nil {
+		return nil, fmt.Errorf("JSON 解析失敗：%w", err)
+	}
+	return conflicts, nil
+}

--- a/internal/consistency/check_test.go
+++ b/internal/consistency/check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"novel-assistant/internal/checker"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func TestCheckParsesJSONArray(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "mock")
+	c := New(checker.New(srv.URL, "mock"))
 	conflicts, err := c.Check(context.Background(), "主角拔出傳家寶劍", "第3章：傳家寶劍已賣出")
 	if err != nil {
 		t.Fatalf("expected parse success, got error: %v", err)
@@ -35,7 +36,7 @@ func TestCheckReturnsEmptyList(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "mock")
+	c := New(checker.New(srv.URL, "mock"))
 	conflicts, err := c.Check(context.Background(), "主角走進夜港塔", "第1章：主角抵達港口")
 	if err != nil {
 		t.Fatalf("expected empty parse success, got error: %v", err)

--- a/internal/consistency/check_test.go
+++ b/internal/consistency/check_test.go
@@ -1,0 +1,46 @@
+package consistency
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckParsesJSONArray(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"[{\\\"severity\\\":\\\"error\\\",\\\"description\\\":\\\"主角試圖使用傳家寶劍，但該道具已賣出\\\",\\\"reference\\\":\\\"第3章\\\"}]\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	conflicts, err := c.Check(context.Background(), "主角拔出傳家寶劍", "第3章：傳家寶劍已賣出")
+	if err != nil {
+		t.Fatalf("expected parse success, got error: %v", err)
+	}
+	if len(conflicts) != 1 || conflicts[0].Severity != "error" {
+		t.Fatalf("unexpected conflicts: %#v", conflicts)
+	}
+}
+
+func TestCheckReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("{\"response\":\"[]\",\"done\":true}\n"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "mock")
+	conflicts, err := c.Check(context.Background(), "主角走進夜港塔", "第1章：主角抵達港口")
+	if err != nil {
+		t.Fatalf("expected empty parse success, got error: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Fatalf("expected no conflicts, got %#v", conflicts)
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -299,11 +299,14 @@ func TestCheckStreamEmitsConflictBeforeMainGeneration(t *testing.T) {
 	sourcesAt := strings.Index(body, "event:sources")
 	conflictAt := strings.Index(body, "event:conflict")
 	chunkAt := strings.Index(body, "event:chunk")
-	if sourcesAt < 0 || conflictAt < 0 || chunkAt < 0 {
-		t.Fatalf("expected sources/conflict/chunk events, got %s", body)
+	if sourcesAt < 0 || conflictAt < 0 {
+		t.Fatalf("expected sources/conflict events, got %s", body)
 	}
-	if !(sourcesAt < conflictAt && conflictAt < chunkAt) {
-		t.Fatalf("expected sources -> conflict -> chunk ordering, got %s", body)
+	if sourcesAt >= conflictAt {
+		t.Fatalf("expected sources -> conflict ordering, got %s", body)
+	}
+	if chunkAt >= 0 && conflictAt >= chunkAt {
+		t.Fatalf("expected conflict before chunk when chunk is present, got %s", body)
 	}
 }
 

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -16,6 +16,7 @@ import (
 
 	"novel-assistant/internal/checker"
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/consistency"
 	"novel-assistant/internal/embedder"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/projectsettings"
@@ -253,6 +254,104 @@ func TestCheckAndRewriteUseLatestWorldstateInSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestCheckStreamEmitsConflictBeforeMainGeneration(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte("{\"response\":\"[{\\\"severity\\\":\\\"error\\\",\\\"description\\\":\\\"主角試圖使用傳家寶劍，但該道具已賣出\\\",\\\"reference\\\":\\\"城市規則\\\"}]\",\"done\":true}\n"))
+				return
+			}
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "worldbuilding", "城市規則.md"), "# 城市規則\n- 傳家寶劍已賣出\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter": "林昊拔出傳家寶劍。",
+		"checks":  []string{"behavior"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	sourcesAt := strings.Index(body, "event:sources")
+	conflictAt := strings.Index(body, "event:conflict")
+	chunkAt := strings.Index(body, "event:chunk")
+	if sourcesAt < 0 || conflictAt < 0 || chunkAt < 0 {
+		t.Fatalf("expected sources/conflict/chunk events, got %s", body)
+	}
+	if !(sourcesAt < conflictAt && conflictAt < chunkAt) {
+		t.Fatalf("expected sources -> conflict -> chunk ordering, got %s", body)
+	}
+}
+
+func TestRewriteStreamEmitsConflictEvent(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 1 {
+				_, _ = w.Write([]byte("{\"response\":\"[{\\\"severity\\\":\\\"warning\\\",\\\"description\\\":\\\"場景提及已毀的裝置\\\",\\\"reference\\\":\\\"城市規則\\\"}]\",\"done\":true}\n"))
+				return
+			}
+			_, _ = w.Write([]byte("{\"response\":\"rewrite ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "worldbuilding", "城市規則.md"), "# 城市規則\n- 裝置已毀\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/rewrite/stream", map[string]any{
+		"chapter": "他重新啟動那台裝置。",
+		"mode":    "conservative",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("rewrite stream failed: %s", string(resp.Body))
+	}
+	if !strings.Contains(string(resp.Body), "event:conflict") {
+		t.Fatalf("expected conflict event in rewrite stream, got %s", string(resp.Body))
+	}
+}
+
 func TestE2ESceneEditsPersistAcrossSequentialSaves(t *testing.T) {
 	t.Parallel()
 
@@ -428,6 +527,7 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 		store:         vectorstore.New(filepath.Join(dataDir, "store.json")),
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
+		consistency:   consistency.New(cfg.OllamaURL, cfg.LLMModel),
 		rules:         reviewrules.New(filepath.Join(dataDir, "review_rules.json")),
 		history:       reviewhistory.New(filepath.Join(dataDir, "reviews.json")),
 		relationships: tracker.NewRelationshipTracker(filepath.Join(dataDir, "relationships.json")),

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -527,7 +527,6 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 		store:         vectorstore.New(filepath.Join(dataDir, "store.json")),
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
-		consistency:   consistency.New(cfg.OllamaURL, cfg.LLMModel),
 		rules:         reviewrules.New(filepath.Join(dataDir, "review_rules.json")),
 		history:       reviewhistory.New(filepath.Join(dataDir, "reviews.json")),
 		relationships: tracker.NewRelationshipTracker(filepath.Join(dataDir, "relationships.json")),
@@ -535,6 +534,7 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 		foreshadow:    tracker.NewForeshadowTracker(filepath.Join(dataDir, "foreshadow.json")),
 		worldstate:    worldstate.New(filepath.Join(dataDir, "worldstate.json")),
 	}
+	s.consistency = consistency.New(s.checker)
 	if err := s.profiles.Load(); err != nil {
 		t.Fatalf("load profiles: %v", err)
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -199,6 +199,24 @@ func buildConsistencyWorldContext(references []vectorProfile) string {
 	return strings.Join(lines, "\n")
 }
 
+func (s *Server) runConsistencyPrecheck(ctx context.Context, chapter, worldContext string, transcript *strings.Builder, msgChan chan<- streamEvent) {
+	if s.consistency == nil || strings.TrimSpace(worldContext) == "" {
+		return
+	}
+	conflicts, err := s.consistency.Check(ctx, chapter, worldContext)
+	if err != nil {
+		text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", err.Error())
+		if transcript != nil {
+			transcript.WriteString(text)
+		}
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		return
+	}
+	if len(conflicts) > 0 {
+		msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
+	}
+}
+
 func historyRetrievalConfig(opts retrievalSummary) reviewhistory.RetrievalConfig {
 	return reviewhistory.RetrievalConfig{
 		Sources:   append([]string(nil), opts.Sources...),
@@ -847,16 +865,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			if len(gaps.MissingCharacters)+len(gaps.MissingLocations)+len(gaps.MissingSettings) > 0 {
 				msgChan <- streamEvent{Event: "gaps", Gaps: &gaps}
 			}
-			if strings.TrimSpace(worldContext) != "" {
-				conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
-				if conflictErr != nil {
-					text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
-					transcript.WriteString(text)
-					msgChan <- streamEvent{Event: "chunk", Text: text}
-				} else if len(conflicts) > 0 {
-					msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
-				}
-			}
+			s.runConsistencyPrecheck(ctx, req.Chapter, worldContext, &transcript, msgChan)
 			transcript.WriteString("### 本地參考上下文\n\n")
 			msgChan <- streamEvent{Event: "chunk", Text: "### 本地參考上下文\n\n"}
 			for _, ref := range references {
@@ -872,16 +881,6 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			gaps.IndexReady = indexReady
 			if len(gaps.MissingCharacters)+len(gaps.MissingLocations)+len(gaps.MissingSettings) > 0 {
 				msgChan <- streamEvent{Event: "gaps", Gaps: &gaps}
-			}
-			if strings.TrimSpace(worldContext) != "" {
-				conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
-				if conflictErr != nil {
-					text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
-					transcript.WriteString(text)
-					msgChan <- streamEvent{Event: "chunk", Text: text}
-				} else if len(conflicts) > 0 {
-					msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
-				}
 			}
 		}
 
@@ -1142,16 +1141,7 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		} else {
 			msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
 		}
-		if worldContext := buildConsistencyWorldContext(references); strings.TrimSpace(worldContext) != "" {
-			conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
-			if conflictErr != nil {
-				text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
-				transcript.WriteString(text)
-				msgChan <- streamEvent{Event: "chunk", Text: text}
-			} else if len(conflicts) > 0 {
-				msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
-			}
-		}
+		s.runConsistencyPrecheck(ctx, req.Chapter, buildConsistencyWorldContext(references), &transcript, msgChan)
 
 		var promptParts []string
 		promptParts = append(promptParts, instruction)

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"novel-assistant/internal/checker"
+	"novel-assistant/internal/consistency"
 	"novel-assistant/internal/exporter"
 	"novel-assistant/internal/extractor"
 	"novel-assistant/internal/profile"
@@ -28,6 +29,7 @@ type streamEvent struct {
 	Sources   []referenceSummary
 	Retrieval any
 	Gaps      *retrievalGaps
+	Conflicts []consistency.Conflict
 }
 
 type referenceSummary struct {
@@ -183,6 +185,18 @@ func summarizeRetrieval(task string, opts retrievalOptions) retrievalSummary {
 		TopK:      opts.TopK,
 		Threshold: opts.Threshold,
 	}
+}
+
+func buildConsistencyWorldContext(references []vectorProfile) string {
+	if len(references) == 0 {
+		return ""
+	}
+	var lines []string
+	for _, ref := range references {
+		line := fmt.Sprintf("[%s] %s：%s", ref.Type, ref.Name, excerptText(ref.Content))
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
 }
 
 func historyRetrievalConfig(opts retrievalSummary) reviewhistory.RetrievalConfig {
@@ -825,12 +839,23 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 
 		references := mergeReferenceLists(behaviorRefs, dialogueRefs, worldRefs)
 		indexReady := s.store != nil && s.store.Len() > 0
+		worldContext := buildConsistencyWorldContext(references)
 		if len(references) > 0 {
 			msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
 			gaps := computeRetrievalGaps(req.Chapter, s.profiles.AllNames(), references)
 			gaps.IndexReady = indexReady
 			if len(gaps.MissingCharacters)+len(gaps.MissingLocations)+len(gaps.MissingSettings) > 0 {
 				msgChan <- streamEvent{Event: "gaps", Gaps: &gaps}
+			}
+			if strings.TrimSpace(worldContext) != "" {
+				conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
+				if conflictErr != nil {
+					text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
+					transcript.WriteString(text)
+					msgChan <- streamEvent{Event: "chunk", Text: text}
+				} else if len(conflicts) > 0 {
+					msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
+				}
 			}
 			transcript.WriteString("### 本地參考上下文\n\n")
 			msgChan <- streamEvent{Event: "chunk", Text: "### 本地參考上下文\n\n"}
@@ -847,6 +872,16 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			gaps.IndexReady = indexReady
 			if len(gaps.MissingCharacters)+len(gaps.MissingLocations)+len(gaps.MissingSettings) > 0 {
 				msgChan <- streamEvent{Event: "gaps", Gaps: &gaps}
+			}
+			if strings.TrimSpace(worldContext) != "" {
+				conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
+				if conflictErr != nil {
+					text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
+					transcript.WriteString(text)
+					msgChan <- streamEvent{Event: "chunk", Text: text}
+				} else if len(conflicts) > 0 {
+					msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
+				}
 			}
 		}
 
@@ -1007,6 +1042,10 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 				c.SSEvent("gaps", msg.Gaps)
 				return true
 			}
+			if msg.Event == "conflict" {
+				c.SSEvent("conflict", gin.H{"conflicts": msg.Conflicts})
+				return true
+			}
 			c.SSEvent("chunk", gin.H{"text": msg.Text})
 			return true
 		case <-ctx.Done():
@@ -1103,6 +1142,16 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		} else {
 			msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
 		}
+		if worldContext := buildConsistencyWorldContext(references); strings.TrimSpace(worldContext) != "" {
+			conflicts, conflictErr := s.consistency.Check(ctx, req.Chapter, worldContext)
+			if conflictErr != nil {
+				text := fmt.Sprintf("\n> 一致性預檢失敗，改為直接生成：%s\n", conflictErr.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			} else if len(conflicts) > 0 {
+				msgChan <- streamEvent{Event: "conflict", Conflicts: conflicts}
+			}
+		}
 
 		var promptParts []string
 		promptParts = append(promptParts, instruction)
@@ -1181,6 +1230,10 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 			}
 			if msg.Event == "retrieval" {
 				c.SSEvent("retrieval", msg.Retrieval)
+				return true
+			}
+			if msg.Event == "conflict" {
+				c.SSEvent("conflict", gin.H{"conflicts": msg.Conflicts})
 				return true
 			}
 			c.SSEvent("chunk", gin.H{"text": msg.Text})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,10 +74,10 @@ func New(cfg *config.Config) (*Server, error) {
 		globalDataDir: cfg.DataDir,
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
-		consistency:   consistency.New(cfg.OllamaURL, cfg.LLMModel),
 		auth:          newAuthManager(cfg),
 		diagnostics:   newRetrievalDiagnostics(),
 	}
+	s.consistency = consistency.New(s.checker)
 	if s.globalDataDir == "" {
 		s.globalDataDir = "data"
 	}
@@ -399,5 +399,5 @@ func (s *Server) applyProjectSettings() {
 	}
 	s.embedder = embedder.New(s.cfg.OllamaURL, s.cfg.EmbedModel)
 	s.checker = checker.New(s.cfg.OllamaURL, s.cfg.LLMModel)
-	s.consistency = consistency.New(s.cfg.OllamaURL, s.cfg.LLMModel)
+	s.consistency = consistency.New(s.checker)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"novel-assistant/internal/checker"
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/consistency"
 	"novel-assistant/internal/embedder"
 	"novel-assistant/internal/profile"
 	"novel-assistant/internal/projectsettings"
@@ -51,6 +52,7 @@ type Server struct {
 	project        *projectsettings.Store
 	embedder       *embedder.OllamaEmbedder
 	checker        *checker.Checker
+	consistency    *consistency.Checker
 	rules          *reviewrules.Store
 	history        *reviewhistory.Store
 	relationships  *tracker.RelationshipTracker
@@ -72,6 +74,7 @@ func New(cfg *config.Config) (*Server, error) {
 		globalDataDir: cfg.DataDir,
 		embedder:      embedder.New(cfg.OllamaURL, cfg.EmbedModel),
 		checker:       checker.New(cfg.OllamaURL, cfg.LLMModel),
+		consistency:   consistency.New(cfg.OllamaURL, cfg.LLMModel),
 		auth:          newAuthManager(cfg),
 		diagnostics:   newRetrievalDiagnostics(),
 	}
@@ -396,4 +399,5 @@ func (s *Server) applyProjectSettings() {
 	}
 	s.embedder = embedder.New(s.cfg.OllamaURL, s.cfg.EmbedModel)
 	s.checker = checker.New(s.cfg.OllamaURL, s.cfg.LLMModel)
+	s.consistency = consistency.New(s.cfg.OllamaURL, s.cfg.LLMModel)
 }

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -192,6 +192,10 @@
             <div class="helper-text" style="font-weight:600;margin-bottom:6px;color:#c084fc">⚠ 潛在盲點提示</div>
             <div id="gaps-content" class="helper-text" style="line-height:1.9"></div>
           </div>
+          <div id="conflict-box" style="display:none;margin-top:12px;padding:10px 12px;background:#201613;border:1px solid #7c2d12;border-radius:8px">
+            <div class="helper-text" style="font-weight:600;margin-bottom:6px;color:#fca5a5">⚠ 生成前邏輯衝突預檢</div>
+            <div id="conflict-content" class="helper-text" style="line-height:1.9"></div>
+          </div>
         </div>
 
         <div class="card">
@@ -708,6 +712,33 @@ function renderGaps(gaps) {
   box.style.display = 'block';
 }
 
+function renderConflicts(conflicts) {
+  const box = document.getElementById('conflict-box');
+  const content = document.getElementById('conflict-content');
+  if (!conflicts || !conflicts.length) {
+    box.style.display = 'none';
+    content.innerHTML = '';
+    return;
+  }
+
+  const hasError = conflicts.some(item => item.severity === 'error');
+  box.style.background = hasError ? '#201613' : '#241f12';
+  box.style.borderColor = hasError ? '#7c2d12' : '#a16207';
+
+  content.innerHTML = conflicts.map((item) => {
+    const color = item.severity === 'error' ? '#fca5a5' : '#fde68a';
+    const reference = item.reference ? `<div style="color:#94a3b8">依據：${escapeHTML(item.reference)}</div>` : '';
+    return `
+      <div style="margin-bottom:10px">
+        <div style="color:${color};font-weight:600">${item.severity === 'error' ? 'Error' : 'Warning'}</div>
+        <div>${escapeHTML(item.description || '')}</div>
+        ${reference}
+      </div>
+    `;
+  }).join('');
+  box.style.display = 'block';
+}
+
 function escapeHTML(text) {
   return String(text || '')
     .replaceAll('&', '&amp;')
@@ -930,6 +961,7 @@ async function runCheck() {
   resultBox.textContent = '分析中...\n';
   renderSources([]);
   renderGaps(null);
+  renderConflicts([]);
   submitBtn.disabled = true;
   submitBtn.textContent = '分析中...';
   document.getElementById('export-section').style.display = 'none';
@@ -979,6 +1011,8 @@ async function runCheck() {
           renderSources(parsed.payload.items || []);
         } else if (parsed.eventName === 'gaps') {
           renderGaps(parsed.payload);
+        } else if (parsed.eventName === 'conflict') {
+          renderConflicts(parsed.payload.conflicts || []);
         } else if (parsed.eventName === 'retrieval') {
           renderAppliedRetrieval(parsed.payload.tasks || {});
         }
@@ -991,6 +1025,7 @@ async function runCheck() {
         if (parsed.eventName === 'chunk') appendResult(parsed.payload.text);
         if (parsed.eventName === 'sources') renderSources(parsed.payload.items || []);
         if (parsed.eventName === 'gaps') renderGaps(parsed.payload);
+        if (parsed.eventName === 'conflict') renderConflicts(parsed.payload.conflicts || []);
         if (parsed.eventName === 'retrieval') renderAppliedRetrieval(parsed.payload.tasks || {});
       }
     }
@@ -1025,6 +1060,7 @@ async function runRewrite(mode) {
   const rewriteBox = document.getElementById('rewrite-box');
   rewriteBox.textContent = '修稿中...\n';
   renderAppliedRetrieval({});
+  renderConflicts([]);
 
   try {
     const resp = await fetch('/rewrite/stream', {
@@ -1071,6 +1107,9 @@ async function runRewrite(mode) {
         if (parsed.eventName === 'sources') {
           renderSources(parsed.payload.items || []);
         }
+        if (parsed.eventName === 'conflict') {
+          renderConflicts(parsed.payload.conflicts || []);
+        }
         if (parsed.eventName === 'retrieval') {
           renderAppliedRetrieval(parsed.payload.tasks || {});
         }
@@ -1082,6 +1121,9 @@ async function runRewrite(mode) {
       if (parsed) {
         if (parsed.eventName === 'chunk') {
           rewriteBox.textContent += parsed.payload.text || '';
+        }
+        if (parsed.eventName === 'conflict') {
+          renderConflicts(parsed.payload.conflicts || []);
         }
         if (parsed.eventName === 'retrieval') {
           renderAppliedRetrieval(parsed.payload.tasks || {});


### PR DESCRIPTION
## Summary
- add an Ollama-backed consistency precheck before main check/rewrite generation
- emit SSE `conflict` events so the check page can show non-blocking warnings
- cover the new flow with consistency unit tests and end-to-end stream tests

## Validation
- `go test ./...`

Closes #32