### PR TITLE
feat: add scene-level chunk rag

### DIFF
--- a/docs/specs/2026-04-20-scene-level-chunk-rag-design.md
+++ b/docs/specs/2026-04-20-scene-level-chunk-rag-design.md
@@ -1,0 +1,161 @@
+# Scene-level Chunk RAG Design
+
+## Summary
+
+Issue #35 changes chapter retrieval granularity from whole-chapter embeddings to chunk-level embeddings. Chapter documents will be split into scene chunks when explicit `## Scene N` markers exist, and into paragraph chunks when they do not. Each chunk is embedded and stored independently so retrieval returns focused excerpts instead of entire chapters.
+
+## Goals
+
+- Replace whole-chapter vectorization with scene/paragraph chunk vectorization for chapter files only.
+- Attach chunk metadata to chapter documents so the backend and frontend can describe exactly where a retrieved excerpt came from.
+- Keep character, world, and style embeddings unchanged.
+- Preserve current cosine-similarity retrieval flow while improving context precision.
+
+## Non-Goals
+
+- No reranking layer.
+- No incremental indexing.
+- No vectorstore storage migration script.
+- No chunking changes for character, world, or style documents.
+
+## Data Model
+
+`internal/vectorstore.Document` will gain these optional metadata fields:
+
+- `chapter_file`
+- `chapter_index`
+- `scene_index`
+- `chunk_type`
+
+Semantics:
+
+- `chapter_file`: original chapter filename, for example `第03章.md`
+- `chapter_index`: chapter number parsed from filename, for example `第03章.md -> 3`
+- `scene_index`: 1-based chunk order within the chapter
+- `chunk_type`: `scene` or `paragraph`
+
+Fallback rule:
+
+- If the filename does not contain a parseable chapter number, `chapter_index = 0`
+- This includes names such as `prologue.md`, `番外.md`, or `test.md`
+
+## Chunking Strategy
+
+Add `chunkChapter(name string, content string) []vectorstore.Document`.
+
+Behavior:
+
+1. Trim the input content.
+2. If the chapter is empty, return an empty slice.
+3. Call existing `parseScenes(content)`.
+4. If scenes exist:
+   - one scene becomes one chunk
+   - `chunk_type = "scene"`
+   - `scene_index` is the scene order already derived from `parseScenes`
+   - `content` is the scene body only
+5. If no scenes exist:
+   - split by `\n\n`
+   - trim each paragraph
+   - skip empty paragraphs
+   - each paragraph becomes one chunk
+   - `chunk_type = "paragraph"`
+   - `scene_index` is the 1-based paragraph order
+
+Document IDs:
+
+- scene chunks: `chapter_<name>_scene_<i>`
+- paragraph chunks: `chapter_<name>_para_<i>`
+
+## Ingest Flow
+
+`Server.Ingest()` keeps the current high-level structure:
+
+- clear store
+- index characters
+- index worlds
+- index styles
+- index chapters
+
+The chapter portion changes:
+
+- read chapter file
+- call `chunkChapter(file.Name(), string(content))`
+- for each returned chunk:
+  - embed the chunk content
+  - store one `vectorstore.Document`
+
+Expected effect:
+
+- chapter document count becomes greater than chapter file count after ingest
+- ingest becomes slower because each chapter may now issue multiple embed calls
+
+## Retrieval Flow
+
+Retrieval algorithm stays unchanged:
+
+- same vector query generation
+- same filtered cosine search
+- same top-k and threshold logic
+
+Only the retrieved chapter document payload becomes more precise because `doc.Content` is now a scene or paragraph chunk instead of the whole chapter.
+
+## Metadata Propagation
+
+Chunk metadata must flow through these layers:
+
+1. `vectorstore.Document`
+2. `vectorProfile`
+3. `referenceSummary`
+4. `sources` SSE event payload
+5. frontend source card rendering
+
+`referenceSummary` will expose:
+
+- `chapter_file`
+- `chapter_index`
+- `scene_index`
+- `chunk_type`
+
+## Frontend Display
+
+`web/templates/check.html` source cards will show chapter location text derived from metadata:
+
+- scene chunk: `第 3 章・Scene 2`
+- paragraph chunk: `第 3 章・段落 4`
+- unknown chapter number fallback: `章節檔案 prologue.md・Scene 1` or `章節檔案 prologue.md・段落 2`
+
+The rest of the source rendering remains unchanged.
+
+## Error Handling
+
+- Empty chapter content produces zero chunks and therefore zero stored chapter documents.
+- Nonstandard chapter filenames do not fail ingest; they use `chapter_index = 0`.
+- Existing `store.Clear()` behavior remains sufficient, so old whole-chapter entries are replaced automatically on the next ingest.
+
+## Testing
+
+### Unit Tests
+
+Add tests for `chunkChapter()` covering:
+
+- scene-based chunking
+- paragraph-based chunking
+- empty chapter returns empty slice
+- filename chapter number parsing
+- fallback filename parsing returns `chapter_index = 0`
+
+### Integration / E2E Tests
+
+Add tests covering:
+
+- ingest stores more chapter documents than chapter file count when a chapter has multiple scenes or paragraphs
+- `sources` SSE payload includes `chapter_index`, `scene_index`, and `chunk_type`
+
+### Frontend / Template Tests
+
+Add tests covering:
+
+- source rendering includes `第 N 章・Scene M`
+- source rendering includes paragraph labels when `chunk_type = "paragraph"`
+- source rendering falls back to filename-based labels when `chapter_index = 0`
+

--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -3,9 +3,11 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"novel-assistant/internal/vectorstore"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +24,7 @@ type Scene struct {
 
 // sceneHeaderRe matches lines of the form "## Scene 1" or "## Scene 2: The Rain".
 var sceneHeaderRe = regexp.MustCompile(`(?m)^(## Scene \d+(?::\s*.+)?)$`)
+var chapterIndexRe = regexp.MustCompile(`第\s*(\d+)\s*章`)
 
 // parseScenes splits chapter content into scenes when scene markers are present.
 // Returns nil when no markers are found (caller treats content as a single implicit scene).
@@ -48,6 +51,65 @@ func parseScenes(content string) []Scene {
 		})
 	}
 	return scenes
+}
+
+func extractChapterIndex(name string) int {
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	matches := chapterIndexRe.FindStringSubmatch(base)
+	if len(matches) != 2 {
+		return 0
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func chunkChapter(name string, content string) []vectorstore.Document {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+
+	chapterIndex := extractChapterIndex(name)
+	scenes := parseScenes(content)
+	if len(scenes) > 0 {
+		chunks := make([]vectorstore.Document, 0, len(scenes))
+		for _, scene := range scenes {
+			chunks = append(chunks, vectorstore.Document{
+				ID:           fmt.Sprintf("chapter_%s_scene_%d", name, scene.Index),
+				Type:         "chapter",
+				Content:      scene.Content,
+				ChapterFile:  name,
+				ChapterIndex: chapterIndex,
+				SceneIndex:   scene.Index,
+				ChunkType:    "scene",
+			})
+		}
+		return chunks
+	}
+
+	parts := strings.Split(content, "\n\n")
+	chunks := make([]vectorstore.Document, 0, len(parts))
+	paragraphIndex := 0
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		paragraphIndex++
+		chunks = append(chunks, vectorstore.Document{
+			ID:           fmt.Sprintf("chapter_%s_para_%d", name, paragraphIndex),
+			Type:         "chapter",
+			Content:      part,
+			ChapterFile:  name,
+			ChapterIndex: chapterIndex,
+			SceneIndex:   paragraphIndex,
+			ChunkType:    "paragraph",
+		})
+	}
+	return chunks
 }
 
 // sceneByTitle returns the first scene whose Title matches, or nil.

--- a/internal/server/chapters_test.go
+++ b/internal/server/chapters_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/vectorstore"
 	"testing"
 )
 
@@ -143,5 +144,91 @@ func TestSaveAndLoadChapterFile(t *testing.T) {
 	}
 	if loaded.Content != "林昊推門而入。" {
 		t.Fatalf("unexpected loaded content: %s", loaded.Content)
+	}
+}
+
+func TestChunkChapterUsesSceneMarkers(t *testing.T) {
+	t.Parallel()
+
+	content := "## Scene 1: Opening\nLin Hao stepped in.\n\n## Scene 2: Rain\nZhang Lei waited."
+	chunks := chunkChapter("第03章.md", content)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	assertChunk(t, chunks[0], vectorstore.Document{
+		ID:           "chapter_第03章.md_scene_1",
+		Type:         "chapter",
+		Content:      "Lin Hao stepped in.",
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   1,
+		ChunkType:    "scene",
+	})
+	assertChunk(t, chunks[1], vectorstore.Document{
+		ID:           "chapter_第03章.md_scene_2",
+		Type:         "chapter",
+		Content:      "Zhang Lei waited.",
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   2,
+		ChunkType:    "scene",
+	})
+}
+
+func TestChunkChapterFallsBackToParagraphs(t *testing.T) {
+	t.Parallel()
+
+	content := "第一段。\n\n第二段。\n\n\n\n第三段。"
+	chunks := chunkChapter("第08章.md", content)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 paragraph chunks, got %d", len(chunks))
+	}
+	assertChunk(t, chunks[0], vectorstore.Document{
+		ID:           "chapter_第08章.md_para_1",
+		Type:         "chapter",
+		Content:      "第一段。",
+		ChapterFile:  "第08章.md",
+		ChapterIndex: 8,
+		SceneIndex:   1,
+		ChunkType:    "paragraph",
+	})
+	assertChunk(t, chunks[2], vectorstore.Document{
+		ID:           "chapter_第08章.md_para_3",
+		Type:         "chapter",
+		Content:      "第三段。",
+		ChapterFile:  "第08章.md",
+		ChapterIndex: 8,
+		SceneIndex:   3,
+		ChunkType:    "paragraph",
+	})
+}
+
+func TestChunkChapterReturnsEmptySliceForBlankContent(t *testing.T) {
+	t.Parallel()
+
+	chunks := chunkChapter("第01章.md", " \n\t ")
+	if len(chunks) != 0 {
+		t.Fatalf("expected no chunks, got %#v", chunks)
+	}
+}
+
+func TestExtractChapterIndexFromFilename(t *testing.T) {
+	t.Parallel()
+
+	if got := extractChapterIndex("第03章.md"); got != 3 {
+		t.Fatalf("expected 3, got %d", got)
+	}
+	if got := extractChapterIndex("prologue.md"); got != 0 {
+		t.Fatalf("expected fallback 0, got %d", got)
+	}
+	if got := extractChapterIndex("番外.md"); got != 0 {
+		t.Fatalf("expected fallback 0, got %d", got)
+	}
+}
+
+func assertChunk(t *testing.T, got, want vectorstore.Document) {
+	t.Helper()
+	if got.ID != want.ID || got.Type != want.Type || got.Content != want.Content || got.ChapterFile != want.ChapterFile || got.ChapterIndex != want.ChapterIndex || got.SceneIndex != want.SceneIndex || got.ChunkType != want.ChunkType {
+		t.Fatalf("unexpected chunk: got %#v want %#v", got, want)
 	}
 }

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -181,12 +181,19 @@ func TestCheckStreamSourcesExposeChunkMetadata(t *testing.T) {
 		t.Fatalf("check stream failed: %s", string(resp.Body))
 	}
 
-	body := string(resp.Body)
-	if !strings.Contains(body, "\"chapter_file\":\"第02章.md\"") ||
-		!strings.Contains(body, "\"chapter_index\":2") ||
-		!strings.Contains(body, "\"scene_index\":1") ||
-		!strings.Contains(body, "\"chunk_type\":\"scene\"") {
-		t.Fatalf("expected chunk metadata in sources payload, got %s", body)
+	items := decodeSSEItems(t, string(resp.Body))
+	if len(items) == 0 {
+		t.Fatalf("expected sources payload in stream, got %s", string(resp.Body))
+	}
+	found := false
+	for _, item := range items {
+		if item.ChapterFile == "第02章.md" && item.ChapterIndex == 2 && item.SceneIndex == 1 && item.ChunkType == "scene" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected chunk metadata in sources payload, got %#v", items)
 	}
 }
 
@@ -256,8 +263,26 @@ func TestCreateWorldstateSnapshotAndList(t *testing.T) {
 	if listResp.StatusCode != http.StatusOK {
 		t.Fatalf("worldstate list failed: %s", string(listResp.Body))
 	}
-	if !strings.Contains(string(listResp.Body), "\"chapter_file\":\"第02章.md\"") || !strings.Contains(string(listResp.Body), "已失去傳家寶劍") {
-		t.Fatalf("expected snapshot in list payload, got %s", string(listResp.Body))
+
+	var payload struct {
+		Items []struct {
+			ChapterFile string `json:"chapter_file"`
+			Changes     []struct {
+				Description string `json:"description"`
+			} `json:"changes"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(listResp.Body, &payload); err != nil {
+		t.Fatalf("decode worldstate list: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("expected 1 snapshot in list payload, got %#v", payload.Items)
+	}
+	if payload.Items[0].ChapterFile != "第02章.md" {
+		t.Fatalf("expected chapter_file 第02章.md, got %#v", payload.Items[0])
+	}
+	if len(payload.Items[0].Changes) != 1 || payload.Items[0].Changes[0].Description != "已失去傳家寶劍" {
+		t.Fatalf("expected snapshot change in list payload, got %#v", payload.Items[0].Changes)
 	}
 }
 
@@ -737,6 +762,13 @@ type httpResult struct {
 	Body       []byte
 }
 
+type sourceEventItem struct {
+	ChapterFile  string `json:"chapter_file"`
+	ChapterIndex int    `json:"chapter_index"`
+	SceneIndex   int    `json:"scene_index"`
+	ChunkType    string `json:"chunk_type"`
+}
+
 func performJSONRequest(t *testing.T, baseURL, method, path string, payload any) httpResult {
 	t.Helper()
 
@@ -781,6 +813,39 @@ func mustWriteFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func decodeSSEItems(t *testing.T, body string) []sourceEventItem {
+	t.Helper()
+
+	type sourceEvent struct {
+		Items []sourceEventItem `json:"items"`
+	}
+
+	blocks := strings.Split(body, "\n\n")
+	for _, block := range blocks {
+		lines := strings.Split(block, "\n")
+		if len(lines) < 2 || strings.TrimSpace(lines[0]) != "event:sources" {
+			continue
+		}
+		var payloadLines []string
+		for _, line := range lines[1:] {
+			if strings.HasPrefix(line, "data:") {
+				payloadLines = append(payloadLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if len(payloadLines) == 0 {
+			continue
+		}
+
+		var payload sourceEvent
+		if err := json.Unmarshal([]byte(strings.Join(payloadLines, "\n")), &payload); err != nil {
+			t.Fatalf("decode SSE sources payload: %v body=%s", err, body)
+		}
+		return payload.Items
+	}
+
+	return nil
 }
 
 func reconstructChapterForSceneEdit(t *testing.T, fullContent string, scenes []Scene, sceneTitle, editedContent string) string {

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -116,6 +116,80 @@ func TestE2EChapterReviewRewriteWritebackAndHistoryExport(t *testing.T) {
 	}
 }
 
+func TestIngestStoresMultipleChapterChunks(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第01章.md"), "## Scene 1: Opening\nA\n\n## Scene 2: Rain\nB")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "store.json"))
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	if strings.Count(string(raw), "\"type\": \"chapter\"") <= 1 {
+		t.Fatalf("expected multiple chapter documents in store.json, got %s", string(raw))
+	}
+}
+
+func TestCheckStreamSourcesExposeChunkMetadata(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第02章.md"), "## Scene 1: Rain Dock\n林昊在雨夜碼頭停下腳步。")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter": "林昊再次想起雨夜碼頭的腳步聲。",
+		"checks":  []string{"behavior"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	if !strings.Contains(body, "\"chapter_file\":\"第02章.md\"") ||
+		!strings.Contains(body, "\"chapter_index\":2") ||
+		!strings.Contains(body, "\"scene_index\":1") ||
+		!strings.Contains(body, "\"chunk_type\":\"scene\"") {
+		t.Fatalf("expected chunk metadata in sources payload, got %s", body)
+	}
+}
+
 func TestCheckStreamMarksGapsAsUnindexedWhenStoreIsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -43,6 +43,10 @@ type referenceSummary struct {
 	Score        float64 `json:"score"`
 	MatchReason  string  `json:"match_reason"`
 	ChapterMatch string  `json:"chapter_match"`
+	ChapterFile  string  `json:"chapter_file,omitempty"`
+	ChapterIndex int     `json:"chapter_index,omitempty"`
+	SceneIndex   int     `json:"scene_index,omitempty"`
+	ChunkType    string  `json:"chunk_type,omitempty"`
 }
 
 type retrievalSummary struct {
@@ -169,6 +173,10 @@ type vectorProfile struct {
 	Score        float64
 	MatchReason  string
 	ChapterMatch string
+	ChapterFile  string
+	ChapterIndex int
+	SceneIndex   int
+	ChunkType    string
 }
 
 func excerptText(content string) string {
@@ -264,6 +272,10 @@ func summarizeReferences(items []vectorProfile) []referenceSummary {
 			Score:        item.Score,
 			MatchReason:  item.MatchReason,
 			ChapterMatch: item.ChapterMatch,
+			ChapterFile:  item.ChapterFile,
+			ChapterIndex: item.ChapterIndex,
+			SceneIndex:   item.SceneIndex,
+			ChunkType:    item.ChunkType,
 		})
 	}
 	return summaries
@@ -399,7 +411,7 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 	docs := s.store.QueryFilteredScored(queryVec, topK, sources, threshold)
 	results := make([]vectorProfile, 0, len(docs))
 	for _, doc := range docs {
-		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ID == "chapter_"+chapterFile {
+		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ChapterFile == chapterFile {
 			continue
 		}
 		name := strings.TrimPrefix(doc.ID, "char_")
@@ -414,6 +426,10 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 			Score:        doc.Score,
 			MatchReason:  reason,
 			ChapterMatch: snippet,
+			ChapterFile:  doc.ChapterFile,
+			ChapterIndex: doc.ChapterIndex,
+			SceneIndex:   doc.SceneIndex,
+			ChunkType:    doc.ChunkType,
 		})
 	}
 	return results, nil

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -327,3 +327,30 @@ func TestResolveCharactersIncludesPronounCandidates(t *testing.T) {
 		t.Fatalf("unexpected resolved characters: %#v", chars)
 	}
 }
+
+func TestSummarizeReferencesIncludesChunkMetadata(t *testing.T) {
+	t.Parallel()
+
+	items := []vectorProfile{
+		{
+			Name:         "第02章_scene_1",
+			Type:         "chapter",
+			Content:      "林昊推門走進雨夜碼頭。",
+			Score:        0.91,
+			MatchReason:  "章節直接提到此參考名稱",
+			ChapterMatch: "…雨夜碼頭…",
+			ChapterFile:  "第02章.md",
+			ChapterIndex: 2,
+			SceneIndex:   1,
+			ChunkType:    "scene",
+		},
+	}
+
+	got := summarizeReferences(items)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 summary, got %#v", got)
+	}
+	if got[0].ChapterFile != "第02章.md" || got[0].ChapterIndex != 2 || got[0].SceneIndex != 1 || got[0].ChunkType != "scene" {
+		t.Fatalf("expected chunk metadata in summary, got %#v", got[0])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -367,17 +367,15 @@ func (s *Server) Ingest(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("read chapter %s: %w", file.Name(), err)
 		}
-		vec, err := s.embedder.Embed(ctx, string(content))
-		if err != nil {
-			return fmt.Errorf("embed chapter %s: %w", file.Name(), err)
+		for _, chunk := range chunkChapter(file.Name(), string(content)) {
+			vec, err := s.embedder.Embed(ctx, chunk.Content)
+			if err != nil {
+				return fmt.Errorf("embed chapter chunk %s: %w", chunk.ID, err)
+			}
+			chunk.Embedding = vec
+			st.store.Upsert(chunk)
+			log.Printf("indexed chapter chunk: %s", chunk.ID)
 		}
-		st.store.Upsert(vectorstore.Document{
-			ID:        "chapter_" + file.Name(),
-			Type:      "chapter",
-			Content:   string(content),
-			Embedding: vec,
-		})
-		log.Printf("indexed chapter: %s", file.Name())
 	}
 
 	return st.store.Save()

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -41,3 +41,25 @@ func TestStylesTemplateRenderStyleAnalysisAvoidsInnerHTMLInterpolation(t *testin
 		t.Fatal("expected style analysis rendering to use textContent")
 	}
 }
+
+func TestCheckTemplateRendersSourceLocationLabel(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../web/templates/check.html")
+	if err != nil {
+		t.Fatalf("read check template: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "function formatSourceLocation(item)") {
+		t.Fatal("expected check template to define source location formatter")
+	}
+	if !strings.Contains(text, "第 ' + item.chapter_index + ' 章") {
+		t.Fatal("expected source formatter to mention chapter index labels")
+	}
+	if !strings.Contains(text, "Scene ' + item.scene_index") {
+		t.Fatal("expected source formatter to mention scene labels")
+	}
+	if !strings.Contains(text, "段落 ' + item.scene_index") {
+		t.Fatal("expected source formatter to mention paragraph labels")
+	}
+}

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -9,10 +9,14 @@ import (
 )
 
 type Document struct {
-	ID        string    `json:"id"`
-	Type      string    `json:"type"` // "character" | "world" | "style" | "chapter"
-	Content   string    `json:"content"`
-	Embedding []float64 `json:"embedding"`
+	ID           string    `json:"id"`
+	Type         string    `json:"type"` // "character" | "world" | "style" | "chapter"
+	Content      string    `json:"content"`
+	Embedding    []float64 `json:"embedding"`
+	ChapterFile  string    `json:"chapter_file,omitempty"`
+	ChapterIndex int       `json:"chapter_index,omitempty"`
+	SceneIndex   int       `json:"scene_index,omitempty"`
+	ChunkType    string    `json:"chunk_type,omitempty"`
 }
 
 type Store struct {

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -1,6 +1,9 @@
 package vectorstore
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestQueryFilteredScoredSupportsThresholdAndTypeFilters(t *testing.T) {
 	t.Parallel()
@@ -52,5 +55,37 @@ func TestQueryFilteredScoredRespectsTopK(t *testing.T) {
 	}
 	if results[0].Score < results[1].Score {
 		t.Fatalf("expected scores sorted descending, got %#v", results)
+	}
+}
+
+func TestDocumentMetadataSurvivesSaveLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "store.json")
+	store := New(path)
+	store.Upsert(Document{
+		ID:           "chapter_第03章.md_scene_1",
+		Type:         "chapter",
+		Content:      "雨落下來。",
+		Embedding:    []float64{0.1, 0.2},
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   1,
+		ChunkType:    "scene",
+	})
+	if err := store.Save(); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+
+	loaded := New(path)
+	if err := loaded.Load(); err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	items := loaded.QueryFilteredScored([]float64{0.1, 0.2}, 1, []string{"chapter"}, 0)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(items))
+	}
+	if items[0].ChapterFile != "第03章.md" || items[0].ChapterIndex != 3 || items[0].SceneIndex != 1 || items[0].ChunkType != "scene" {
+		t.Fatalf("unexpected metadata after reload: %#v", items[0].Document)
 	}
 }

--- a/plans/2026-04-20-issue-35-scene-level-chunk-rag.md
+++ b/plans/2026-04-20-issue-35-scene-level-chunk-rag.md
@@ -1,0 +1,91 @@
+# Scene-level Chunk RAG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change chapter retrieval from whole-chapter vectors to scene or paragraph chunks so review and rewrite flows receive precise excerpts with chapter/scene metadata.
+
+**Architecture:** Keep the existing vectorstore query algorithm and retrieval flow, but replace chapter ingest with a chunk builder that emits scene or paragraph `vectorstore.Document` entries. Propagate chunk metadata through `vectorProfile`, `referenceSummary`, SSE `sources`, and the `check.html` source card renderer so the UI can label each result as `第 N 章・Scene M` or `第 N 章・段落 M`.
+
+**Tech Stack:** Go, Gin, html/template, vanilla JavaScript, Go tests
+
+---
+
+### Task 1: Expand vector document metadata
+
+**Files:**
+- Modify: `internal/vectorstore/store.go`
+- Test: `internal/vectorstore/store_test.go`
+
+- [ ] **Step 1: Write the failing metadata persistence test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 2: Add chapter chunk builder and chapter index parsing
+
+**Files:**
+- Modify: `internal/server/chapters.go`
+- Test: `internal/server/chapters_test.go`
+
+- [ ] **Step 1: Write the failing chunking tests**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 3: Switch ingest from whole chapters to chapter chunks
+
+**Files:**
+- Modify: `internal/server/server.go`
+- Test: `internal/server/e2e_test.go`
+
+- [ ] **Step 1: Write the failing ingest test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 4: Propagate chunk metadata through retrieval summaries
+
+**Files:**
+- Modify: `internal/server/handlers.go`
+- Test: `internal/server/handlers_test.go`
+- Test: `internal/server/e2e_test.go`
+
+- [ ] **Step 1: Write the failing metadata propagation tests**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 5: Render chunk location labels in the source cards
+
+**Files:**
+- Modify: `web/templates/check.html`
+- Test: `internal/server/templates_test.go`
+
+- [ ] **Step 1: Write the failing template test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 6: Final formatting and verification
+
+**Files:**
+- Modify: `internal/vectorstore/store.go`
+- Modify: `internal/vectorstore/store_test.go`
+- Modify: `internal/server/chapters.go`
+- Modify: `internal/server/chapters_test.go`
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/handlers.go`
+- Modify: `internal/server/handlers_test.go`
+- Modify: `internal/server/e2e_test.go`
+- Modify: `internal/server/templates_test.go`
+- Modify: `web/templates/check.html`
+
+- [ ] **Step 1: Run gofmt on modified Go files**
+- [ ] **Step 2: Run the full test suite**
+- [ ] **Step 3: Verify formatting is clean**
+- [ ] **Step 4: Commit**

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -692,18 +692,21 @@ function renderSources(items) {
     return item.chapter_file || '';
   }
 
-  box.innerHTML = items.map(item => `
-    <div class="source-card">
-      <div class="source-meta">
-        <span class="source-type">${escapeHTML(item.type)}</span>
-        <strong>${escapeHTML(item.name)}</strong>
+  box.innerHTML = items.map(item => {
+    const location = formatSourceLocation(item);
+    return `
+      <div class="source-card">
+        <div class="source-meta">
+          <span class="source-type">${escapeHTML(item.type)}</span>
+          <strong>${escapeHTML(item.name)}</strong>
+        </div>
+        <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
+        ${location ? `<div class="helper-text">${escapeHTML(location)}</div>` : ''}
+        ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
+        <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
       </div>
-      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
-      ${formatSourceLocation(item) ? `<div class="helper-text">${escapeHTML(formatSourceLocation(item))}</div>` : ''}
-      ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
-      <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
-    </div>
-  `).join('');
+    `;
+  }).join('');
 }
 
 function renderGaps(gaps) {

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -678,15 +678,30 @@ function renderSources(items) {
     return;
   }
 
+  function formatSourceLocation(item) {
+    if (!item || item.type !== 'chapter') return '';
+    if (Number(item.chapter_index || 0) > 0) {
+      if (item.chunk_type === 'scene' && Number(item.scene_index || 0) > 0) {
+        return '第 ' + item.chapter_index + ' 章・Scene ' + item.scene_index;
+      }
+      if (item.chunk_type === 'paragraph' && Number(item.scene_index || 0) > 0) {
+        return '第 ' + item.chapter_index + ' 章・段落 ' + item.scene_index;
+      }
+      return '第 ' + item.chapter_index + ' 章';
+    }
+    return item.chapter_file || '';
+  }
+
   box.innerHTML = items.map(item => `
     <div class="source-card">
       <div class="source-meta">
-        <span class="source-type">${item.type}</span>
-        <strong>${item.name}</strong>
+        <span class="source-type">${escapeHTML(item.type)}</span>
+        <strong>${escapeHTML(item.name)}</strong>
       </div>
-      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${item.match_reason || '由向量相似度命中'}</div>
-      ${item.chapter_match ? `<div class="source-match">章節片段：${item.chapter_match}</div>` : ''}
-      <div class="source-excerpt">${item.excerpt || ''}</div>
+      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
+      ${formatSourceLocation(item) ? `<div class="helper-text">${escapeHTML(formatSourceLocation(item))}</div>` : ''}
+      ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
+      <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
     </div>
   `).join('');
 }


### PR DESCRIPTION
## Summary
- chunk chapter ingestion at scene level first, then paragraph fallback when no scene markers exist
- carry chapter chunk metadata through vectorstore, retrieval summaries, and check/rewrite source payloads
- render chapter source locations in the check UI and add spec/plan plus unit/e2e coverage

## Test Plan
- go test ./... -count=1

closes #35