### PR TITLE
feat: scene-aware RAG timeline-bounded retrieval (#44)

### DIFF
--- a/docs/specs/2026-04-20-multi-layer-review-pipeline-design.md
+++ b/docs/specs/2026-04-20-multi-layer-review-pipeline-design.md
@@ -1,0 +1,308 @@
+# Issue #36 Spec: Multi-Layer Review Pipeline
+
+Date: 2026-04-20
+Issue: #36
+
+## Summary
+
+將目前單一路徑的章節審查流程擴充為雙模式：
+
+- `single`：維持既有 `handleCheckStream` 行為，不做語義改動
+- `pipeline`：依序執行四個獨立審稿層，讓結構、角色、世界觀、語言四個面向分段輸出
+
+本設計只新增多層審稿 pipeline，不移除既有單層模式、不加入評分系統、不提供使用者自訂 prompt、不做並行執行。
+
+## Goals
+
+- 保留現有 `single` 模式，確保 backward compatible
+- 新增 `pipeline` 模式，固定依序執行四層 review
+- 每層使用獨立 prompt 與獨立標題分段輸出
+- 後端透過 SSE 發送 `layer_start` / `layer_end`
+- 前端在結果區正確插入層標題與層間分隔
+- 補齊 regression、pipeline、failure path 測試
+
+## Non-Goals
+
+- 不移除既有 `checks` 機制
+- 不做 layer score / rating
+- 不允許使用者編輯 layer prompt 模板
+- 不支援並行跑多層
+- 不新增 `layer_error` SSE event
+- 不在第一版前端提供 layer 勾選 UI
+
+## Request Model
+
+`checkRequest` 擴充以下欄位：
+
+```go
+type checkRequest struct {
+    Chapter   string   `json:"chapter"`
+    Scene     string   `json:"scene,omitempty"`
+    LayerMode string   `json:"layer_mode"` // "single" | "pipeline"
+    Layers    []string `json:"layers,omitempty"`
+}
+```
+
+實際語義如下：
+
+- `layer_mode == ""` 視為 `single`
+- `layer_mode == "single"`：完全沿用目前邏輯
+- `layer_mode == "pipeline"`：忽略 `checks`
+- `layers` 欄位先保留於 request schema，但第一版前後端都不提供部分啟用能力
+- `pipeline` 模式下，空 `layers` 代表固定跑四層全開
+
+其他既有欄位如 `characters`、`styles`、`chapter_file`、`chapter_title`、`scene_title` 仍保留原意。
+
+## Architecture
+
+### New File
+
+新增 `internal/server/review_layers.go`，集中管理：
+
+- `reviewLayer` struct
+- `defaultReviewLayers() []reviewLayer`
+- `resolveReviewLayers(req checkRequest) []reviewLayer`
+- `runPipelineReview(...)`
+
+避免把 layer prompt 與 pipeline control flow 寫進 `handlers.go`。
+
+### reviewLayer
+
+```go
+type reviewLayer struct {
+    Name    string `json:"name"`
+    Label   string `json:"label"`
+    Prompt  string `json:"prompt"`
+    Enabled bool   `json:"enabled"`
+}
+```
+
+說明：
+
+- `Name`：穩定 key，供後端與 SSE payload 使用
+- `Label`：人類可讀名稱，由後端定義並直接發給前端
+- `Prompt`：該層的 prompt 模板
+- `Enabled`：保留結構一致性；第一版 `pipeline` 固定四層皆為 `true`
+
+### Layer Definitions
+
+`defaultReviewLayers()` 固定回傳四層，順序不可變：
+
+1. `structure` / `結構層`
+2. `character` / `角色層`
+3. `world_logic` / `世界觀層`
+4. `language` / `語言層`
+
+這個順序同時作為：
+
+- pipeline 執行順序
+- SSE 顯示順序
+- 測試驗收基準
+
+## Prompt Ownership
+
+所有 layer prompt 模板皆由 `internal/server/review_layers.go` 管理，不放在 handler 中。
+
+四層提示語意如下：
+
+- `structure`
+  - 只分析敘事節奏、開場鉤子、張力起伏、段落長短
+  - 不評論角色或語言風格
+- `character`
+  - 只分析角色行為是否符合人設、對白語氣是否一致
+  - 可結合角色資料與對話相關 reference
+  - 不評論結構或語言
+- `world_logic`
+  - 只分析設定自洽、時間線、道具與地點邏輯
+  - 可結合世界觀、追蹤器、章節 reference
+  - 不評論其他層面
+- `language`
+  - 只分析句式多樣性、重複用語、描寫密度、語言流暢度
+  - 可結合 style reference
+  - 不評論劇情或角色
+
+## Data Sources Per Layer
+
+### structure
+
+- 只吃章節內容
+- 不依賴角色、世界觀、style reference
+
+### character
+
+- 吃章節內容
+- 吃角色資料
+- 吃現有 character/dialogue retrieval context
+- 角色選擇沿用現有 request 語義：
+  - 若 request 指定 `characters`，只使用指定角色
+  - 若未指定，走既有 `resolveCharacters(req)` 自動辨識與 fallback 邏輯
+
+### world_logic
+
+- 吃章節內容
+- 吃世界觀資料與相關 retrieval context
+- 若有 tracker/worldstate/context，可沿用既有 world review 可取得的資料
+
+### language
+
+- 吃章節內容
+- 可吃 style reference 與必要 context
+- prompt 必須明確限制只評論語言層面
+
+## Server Flow
+
+### Single Mode
+
+`layer_mode == ""` 或 `"single"` 時：
+
+- 完全走現有 `handleCheckStream` 流程
+- 不發送 `layer_start` / `layer_end`
+- 現有 `checks`、`sources`、`retrieval`、`gaps`、`conflict` 行為維持不變
+
+這是強制 regression 邊界，不能順手重構造成語義偏差。
+
+### Pipeline Mode
+
+`layer_mode == "pipeline"` 時：
+
+- 忽略 `checks`
+- 解析固定四層 review layers
+- 先建立一次共用 retrieval/reference context
+- 依固定順序逐層執行
+- 每層開始前送 `layer_start`
+- 該層 token 仍沿用既有 `chunk` SSE 事件
+- 每層完成後送 `layer_end`
+
+`sources`、`retrieval`、`gaps`、`conflict` 等事件維持既有 schema，不新增 layer-specific schema。第一版僅在整體 review 流程前段發送一次，不在每層重送。
+
+## SSE Contract
+
+新增兩種事件：
+
+### `layer_start`
+
+```json
+{"layer":"structure","label":"結構層"}
+```
+
+### `layer_end`
+
+```json
+{"layer":"structure"}
+```
+
+說明：
+
+- `layer` 是穩定 key
+- `label` 由後端定義，前端不自行做 key-to-label mapping
+- 若未來要做多語系，只需要改後端 layer 定義
+
+其餘 `chunk`、`sources`、`retrieval`、`gaps`、`conflict` 事件格式維持現狀。
+
+## Error Handling
+
+pipeline 模式下採「失敗即中止」：
+
+- 某一層失敗時，中止整個 pipeline
+- 不繼續執行後續 layer
+- 沿用目前 `chunk` 錯誤訊息輸出方式回報失敗
+- 不新增 `layer_error` event
+- 失敗層不發送 `layer_end`
+
+這可保持與現有 `handleCheckStream` 的失敗語義一致，避免向使用者交付半套且可信度不明的審稿結果。
+
+## Frontend Design
+
+目標檔案：`web/templates/check.html`
+
+### Review Mode Toggle
+
+新增「審稿模式」切換：
+
+- `single`：預設
+- `pipeline`
+
+### UI Behavior
+
+#### single
+
+- 顯示目前既有 `checks` UI
+- 行為完全維持現狀
+
+#### pipeline
+
+- 隱藏既有 `checks` 區塊
+- 不提供 layer 勾選 UI
+- 顯示 helper text：
+  - `將固定依序執行：結構層、角色層、世界觀層、語言層`
+
+### SSE Rendering
+
+前端收到 `layer_start` 時：
+
+- 在結果區 append 一個分隔標題
+- 格式：`── 結構層 ──`
+
+前端收到 `layer_end` 時：
+
+- append 一個空行作為層間間距
+
+前端收到 `chunk` 時：
+
+- 沿用目前串流 append 行為
+
+single 模式下，即使前端已有 `layer_start` / `layer_end` handler，也不應收到此事件。
+
+## Testing Strategy
+
+### 1. Backend Unit Tests
+
+- `defaultReviewLayers()` 固定回傳四層，順序為 structure -> character -> world_logic -> language
+- `resolveReviewLayers()` 在 `pipeline` 模式下回傳四層全開
+- `single` 模式不走 pipeline runner
+
+### 2. Handler / E2E Tests
+
+- regression test：
+  - `layer_mode: "single"` 行為與目前相同
+  - stream 中不出現 `layer_start` / `layer_end`
+- pipeline test：
+  - `layer_mode: "pipeline"` 時，依序輸出四層
+  - 事件順序必須符合：
+    - `layer_start structure`
+    - `chunk`
+    - `layer_end structure`
+    - `layer_start character`
+    - `...`
+- failure path：
+  - 模擬某一層 LLM 失敗
+  - stream 應輸出錯誤 `chunk`
+  - pipeline 停在該層
+  - 失敗層後續的 layer event 不可出現
+
+### 3. Template / Frontend Tests
+
+- `check.html` 存在審稿模式切換 UI
+- pipeline 模式會隱藏 `checks` 區塊
+- 前端 SSE 處理存在 `layer_start` / `layer_end` 分支
+- `layer_start` 會插入對應標題文字，如 `── 結構層 ──`
+
+## Acceptance Criteria
+
+- `layer_mode: "single"` 行為與現在完全相同
+- `layer_mode: "pipeline"` 依序輸出四層 review
+- 每層有明確 `layer_start` / `layer_end` 分隔
+- 前端在 pipeline 模式可正確顯示四層標題與層間分隔
+- `go test ./...` 全通過
+- `gofmt -l` 無輸出
+
+## Scope Notes
+
+本票刻意限制在：
+
+- 後端新增 pipeline review path
+- review layer 定義集中化
+- 前端新增模式切換與分段顯示
+- 對應測試
+
+不把 prompt template 系統化、layer score、partial layer selection、parallel execution 混進本票。

--- a/docs/specs/2026-04-20-scene-level-chunk-rag-design.md
+++ b/docs/specs/2026-04-20-scene-level-chunk-rag-design.md
@@ -1,0 +1,161 @@
+# Scene-level Chunk RAG Design
+
+## Summary
+
+Issue #35 changes chapter retrieval granularity from whole-chapter embeddings to chunk-level embeddings. Chapter documents will be split into scene chunks when explicit `## Scene N` markers exist, and into paragraph chunks when they do not. Each chunk is embedded and stored independently so retrieval returns focused excerpts instead of entire chapters.
+
+## Goals
+
+- Replace whole-chapter vectorization with scene/paragraph chunk vectorization for chapter files only.
+- Attach chunk metadata to chapter documents so the backend and frontend can describe exactly where a retrieved excerpt came from.
+- Keep character, world, and style embeddings unchanged.
+- Preserve current cosine-similarity retrieval flow while improving context precision.
+
+## Non-Goals
+
+- No reranking layer.
+- No incremental indexing.
+- No vectorstore storage migration script.
+- No chunking changes for character, world, or style documents.
+
+## Data Model
+
+`internal/vectorstore.Document` will gain these optional metadata fields:
+
+- `chapter_file`
+- `chapter_index`
+- `scene_index`
+- `chunk_type`
+
+Semantics:
+
+- `chapter_file`: original chapter filename, for example `第03章.md`
+- `chapter_index`: chapter number parsed from filename, for example `第03章.md -> 3`
+- `scene_index`: 1-based chunk order within the chapter
+- `chunk_type`: `scene` or `paragraph`
+
+Fallback rule:
+
+- If the filename does not contain a parseable chapter number, `chapter_index = 0`
+- This includes names such as `prologue.md`, `番外.md`, or `test.md`
+
+## Chunking Strategy
+
+Add `chunkChapter(name string, content string) []vectorstore.Document`.
+
+Behavior:
+
+1. Trim the input content.
+2. If the chapter is empty, return an empty slice.
+3. Call existing `parseScenes(content)`.
+4. If scenes exist:
+   - one scene becomes one chunk
+   - `chunk_type = "scene"`
+   - `scene_index` is the scene order already derived from `parseScenes`
+   - `content` is the scene body only
+5. If no scenes exist:
+   - split by `\n\n`
+   - trim each paragraph
+   - skip empty paragraphs
+   - each paragraph becomes one chunk
+   - `chunk_type = "paragraph"`
+   - `scene_index` is the 1-based paragraph order
+
+Document IDs:
+
+- scene chunks: `chapter_<name>_scene_<i>`
+- paragraph chunks: `chapter_<name>_para_<i>`
+
+## Ingest Flow
+
+`Server.Ingest()` keeps the current high-level structure:
+
+- clear store
+- index characters
+- index worlds
+- index styles
+- index chapters
+
+The chapter portion changes:
+
+- read chapter file
+- call `chunkChapter(file.Name(), string(content))`
+- for each returned chunk:
+  - embed the chunk content
+  - store one `vectorstore.Document`
+
+Expected effect:
+
+- chapter document count becomes greater than chapter file count after ingest
+- ingest becomes slower because each chapter may now issue multiple embed calls
+
+## Retrieval Flow
+
+Retrieval algorithm stays unchanged:
+
+- same vector query generation
+- same filtered cosine search
+- same top-k and threshold logic
+
+Only the retrieved chapter document payload becomes more precise because `doc.Content` is now a scene or paragraph chunk instead of the whole chapter.
+
+## Metadata Propagation
+
+Chunk metadata must flow through these layers:
+
+1. `vectorstore.Document`
+2. `vectorProfile`
+3. `referenceSummary`
+4. `sources` SSE event payload
+5. frontend source card rendering
+
+`referenceSummary` will expose:
+
+- `chapter_file`
+- `chapter_index`
+- `scene_index`
+- `chunk_type`
+
+## Frontend Display
+
+`web/templates/check.html` source cards will show chapter location text derived from metadata:
+
+- scene chunk: `第 3 章・Scene 2`
+- paragraph chunk: `第 3 章・段落 4`
+- unknown chapter number fallback: `章節檔案 prologue.md・Scene 1` or `章節檔案 prologue.md・段落 2`
+
+The rest of the source rendering remains unchanged.
+
+## Error Handling
+
+- Empty chapter content produces zero chunks and therefore zero stored chapter documents.
+- Nonstandard chapter filenames do not fail ingest; they use `chapter_index = 0`.
+- Existing `store.Clear()` behavior remains sufficient, so old whole-chapter entries are replaced automatically on the next ingest.
+
+## Testing
+
+### Unit Tests
+
+Add tests for `chunkChapter()` covering:
+
+- scene-based chunking
+- paragraph-based chunking
+- empty chapter returns empty slice
+- filename chapter number parsing
+- fallback filename parsing returns `chapter_index = 0`
+
+### Integration / E2E Tests
+
+Add tests covering:
+
+- ingest stores more chapter documents than chapter file count when a chapter has multiple scenes or paragraphs
+- `sources` SSE payload includes `chapter_index`, `scene_index`, and `chunk_type`
+
+### Frontend / Template Tests
+
+Add tests covering:
+
+- source rendering includes `第 N 章・Scene M`
+- source rendering includes paragraph labels when `chunk_type = "paragraph"`
+- source rendering falls back to filename-based labels when `chapter_index = 0`
+

--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -3,9 +3,11 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"novel-assistant/internal/vectorstore"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +24,7 @@ type Scene struct {
 
 // sceneHeaderRe matches lines of the form "## Scene 1" or "## Scene 2: The Rain".
 var sceneHeaderRe = regexp.MustCompile(`(?m)^(## Scene \d+(?::\s*.+)?)$`)
+var chapterIndexRe = regexp.MustCompile(`第\s*(\d+)\s*章`)
 
 // parseScenes splits chapter content into scenes when scene markers are present.
 // Returns nil when no markers are found (caller treats content as a single implicit scene).
@@ -48,6 +51,65 @@ func parseScenes(content string) []Scene {
 		})
 	}
 	return scenes
+}
+
+func extractChapterIndex(name string) int {
+	base := strings.TrimSuffix(name, filepath.Ext(name))
+	matches := chapterIndexRe.FindStringSubmatch(base)
+	if len(matches) != 2 {
+		return 0
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func chunkChapter(name string, content string) []vectorstore.Document {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return nil
+	}
+
+	chapterIndex := extractChapterIndex(name)
+	scenes := parseScenes(content)
+	if len(scenes) > 0 {
+		chunks := make([]vectorstore.Document, 0, len(scenes))
+		for _, scene := range scenes {
+			chunks = append(chunks, vectorstore.Document{
+				ID:           fmt.Sprintf("chapter_%s_scene_%d", name, scene.Index),
+				Type:         "chapter",
+				Content:      scene.Content,
+				ChapterFile:  name,
+				ChapterIndex: chapterIndex,
+				SceneIndex:   scene.Index,
+				ChunkType:    "scene",
+			})
+		}
+		return chunks
+	}
+
+	parts := strings.Split(content, "\n\n")
+	chunks := make([]vectorstore.Document, 0, len(parts))
+	paragraphIndex := 0
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		paragraphIndex++
+		chunks = append(chunks, vectorstore.Document{
+			ID:           fmt.Sprintf("chapter_%s_para_%d", name, paragraphIndex),
+			Type:         "chapter",
+			Content:      part,
+			ChapterFile:  name,
+			ChapterIndex: chapterIndex,
+			SceneIndex:   paragraphIndex,
+			ChunkType:    "paragraph",
+		})
+	}
+	return chunks
 }
 
 // sceneByTitle returns the first scene whose Title matches, or nil.

--- a/internal/server/chapters_test.go
+++ b/internal/server/chapters_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"novel-assistant/internal/config"
+	"novel-assistant/internal/vectorstore"
 	"testing"
 )
 
@@ -143,5 +144,91 @@ func TestSaveAndLoadChapterFile(t *testing.T) {
 	}
 	if loaded.Content != "林昊推門而入。" {
 		t.Fatalf("unexpected loaded content: %s", loaded.Content)
+	}
+}
+
+func TestChunkChapterUsesSceneMarkers(t *testing.T) {
+	t.Parallel()
+
+	content := "## Scene 1: Opening\nLin Hao stepped in.\n\n## Scene 2: Rain\nZhang Lei waited."
+	chunks := chunkChapter("第03章.md", content)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(chunks))
+	}
+	assertChunk(t, chunks[0], vectorstore.Document{
+		ID:           "chapter_第03章.md_scene_1",
+		Type:         "chapter",
+		Content:      "Lin Hao stepped in.",
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   1,
+		ChunkType:    "scene",
+	})
+	assertChunk(t, chunks[1], vectorstore.Document{
+		ID:           "chapter_第03章.md_scene_2",
+		Type:         "chapter",
+		Content:      "Zhang Lei waited.",
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   2,
+		ChunkType:    "scene",
+	})
+}
+
+func TestChunkChapterFallsBackToParagraphs(t *testing.T) {
+	t.Parallel()
+
+	content := "第一段。\n\n第二段。\n\n\n\n第三段。"
+	chunks := chunkChapter("第08章.md", content)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 paragraph chunks, got %d", len(chunks))
+	}
+	assertChunk(t, chunks[0], vectorstore.Document{
+		ID:           "chapter_第08章.md_para_1",
+		Type:         "chapter",
+		Content:      "第一段。",
+		ChapterFile:  "第08章.md",
+		ChapterIndex: 8,
+		SceneIndex:   1,
+		ChunkType:    "paragraph",
+	})
+	assertChunk(t, chunks[2], vectorstore.Document{
+		ID:           "chapter_第08章.md_para_3",
+		Type:         "chapter",
+		Content:      "第三段。",
+		ChapterFile:  "第08章.md",
+		ChapterIndex: 8,
+		SceneIndex:   3,
+		ChunkType:    "paragraph",
+	})
+}
+
+func TestChunkChapterReturnsEmptySliceForBlankContent(t *testing.T) {
+	t.Parallel()
+
+	chunks := chunkChapter("第01章.md", " \n\t ")
+	if len(chunks) != 0 {
+		t.Fatalf("expected no chunks, got %#v", chunks)
+	}
+}
+
+func TestExtractChapterIndexFromFilename(t *testing.T) {
+	t.Parallel()
+
+	if got := extractChapterIndex("第03章.md"); got != 3 {
+		t.Fatalf("expected 3, got %d", got)
+	}
+	if got := extractChapterIndex("prologue.md"); got != 0 {
+		t.Fatalf("expected fallback 0, got %d", got)
+	}
+	if got := extractChapterIndex("番外.md"); got != 0 {
+		t.Fatalf("expected fallback 0, got %d", got)
+	}
+}
+
+func assertChunk(t *testing.T, got, want vectorstore.Document) {
+	t.Helper()
+	if got.ID != want.ID || got.Type != want.Type || got.Content != want.Content || got.ChapterFile != want.ChapterFile || got.ChapterIndex != want.ChapterIndex || got.SceneIndex != want.SceneIndex || got.ChunkType != want.ChunkType {
+		t.Fatalf("unexpected chunk: got %#v want %#v", got, want)
 	}
 }

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -181,12 +181,19 @@ func TestCheckStreamSourcesExposeChunkMetadata(t *testing.T) {
 		t.Fatalf("check stream failed: %s", string(resp.Body))
 	}
 
-	body := string(resp.Body)
-	if !strings.Contains(body, "\"chapter_file\":\"第02章.md\"") ||
-		!strings.Contains(body, "\"chapter_index\":2") ||
-		!strings.Contains(body, "\"scene_index\":1") ||
-		!strings.Contains(body, "\"chunk_type\":\"scene\"") {
-		t.Fatalf("expected chunk metadata in sources payload, got %s", body)
+	items := decodeSSEItems(t, string(resp.Body))
+	if len(items) == 0 {
+		t.Fatalf("expected sources payload in stream, got %s", string(resp.Body))
+	}
+	found := false
+	for _, item := range items {
+		if item.ChapterFile == "第02章.md" && item.ChapterIndex == 2 && item.SceneIndex == 1 && item.ChunkType == "scene" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected chunk metadata in sources payload, got %#v", items)
 	}
 }
 
@@ -256,8 +263,26 @@ func TestCreateWorldstateSnapshotAndList(t *testing.T) {
 	if listResp.StatusCode != http.StatusOK {
 		t.Fatalf("worldstate list failed: %s", string(listResp.Body))
 	}
-	if !strings.Contains(string(listResp.Body), "\"chapter_file\":\"第02章.md\"") || !strings.Contains(string(listResp.Body), "已失去傳家寶劍") {
-		t.Fatalf("expected snapshot in list payload, got %s", string(listResp.Body))
+
+	var payload struct {
+		Items []struct {
+			ChapterFile string `json:"chapter_file"`
+			Changes     []struct {
+				Description string `json:"description"`
+			} `json:"changes"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(listResp.Body, &payload); err != nil {
+		t.Fatalf("decode worldstate list: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("expected 1 snapshot in list payload, got %#v", payload.Items)
+	}
+	if payload.Items[0].ChapterFile != "第02章.md" {
+		t.Fatalf("expected chapter_file 第02章.md, got %#v", payload.Items[0])
+	}
+	if len(payload.Items[0].Changes) != 1 || payload.Items[0].Changes[0].Description != "已失去傳家寶劍" {
+		t.Fatalf("expected snapshot change in list payload, got %#v", payload.Items[0].Changes)
 	}
 }
 
@@ -737,6 +762,13 @@ type httpResult struct {
 	Body       []byte
 }
 
+type sourceEventItem struct {
+	ChapterFile  string `json:"chapter_file"`
+	ChapterIndex int    `json:"chapter_index"`
+	SceneIndex   int    `json:"scene_index"`
+	ChunkType    string `json:"chunk_type"`
+}
+
 func performJSONRequest(t *testing.T, baseURL, method, path string, payload any) httpResult {
 	t.Helper()
 
@@ -781,6 +813,39 @@ func mustWriteFile(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func decodeSSEItems(t *testing.T, body string) []sourceEventItem {
+	t.Helper()
+
+	type sourceEvent struct {
+		Items []sourceEventItem `json:"items"`
+	}
+
+	blocks := strings.Split(body, "\n\n")
+	for _, block := range blocks {
+		lines := strings.Split(block, "\n")
+		if len(lines) < 2 || strings.TrimSpace(lines[0]) != "event:sources" {
+			continue
+		}
+		var payloadLines []string
+		for _, line := range lines[1:] {
+			if strings.HasPrefix(line, "data:") {
+				payloadLines = append(payloadLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if len(payloadLines) == 0 {
+			continue
+		}
+
+		var payload sourceEvent
+		if err := json.Unmarshal([]byte(strings.Join(payloadLines, "\n")), &payload); err != nil {
+			t.Fatalf("decode SSE sources payload: %v body=%s", err, body)
+		}
+		return payload.Items
+	}
+
+	return nil
 }
 
 func reconstructChapterForSceneEdit(t *testing.T, fullContent string, scenes []Scene, sceneTitle, editedContent string) string {

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1038,3 +1038,54 @@ func reconstructChapterForSceneEdit(t *testing.T, fullContent string, scenes []S
 
 	return strings.Join(parts, "\n\n")
 }
+
+func TestBuildReferenceContextExcludesFutureChapters(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{1, 0, 0}})
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	// Past chapter: index 2 — should be included when reviewing chapter 3
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第02章.md"), "# 第02章\n林昊初次見到城主。")
+	// Future chapter: index 5 — must be excluded when reviewing chapter 3
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第05章.md"), "# 第05章\n林昊離開了城市。")
+	// Character — not filtered by chapter index
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":      "林昊在第三章站著。",
+		"chapter_file": "第03章.md",
+		"checks":       []string{"behavior"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+
+	// Sources event should include chapter 第02章.md but not 第05章.md
+	if strings.Contains(body, "第05章") {
+		t.Fatalf("future chapter 第05章 must not appear in retrieval sources, got: %s", body)
+	}
+	if !strings.Contains(body, "第02章") {
+		t.Fatalf("past chapter 第02章 should appear in retrieval sources, got: %s", body)
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -116,6 +116,80 @@ func TestE2EChapterReviewRewriteWritebackAndHistoryExport(t *testing.T) {
 	}
 }
 
+func TestIngestStoresMultipleChapterChunks(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第01章.md"), "## Scene 1: Opening\nA\n\n## Scene 2: Rain\nB")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "store.json"))
+	if err != nil {
+		t.Fatalf("read store: %v", err)
+	}
+	if strings.Count(string(raw), "\"type\": \"chapter\"") <= 1 {
+		t.Fatalf("expected multiple chapter documents in store.json, got %s", string(raw))
+	}
+}
+
+func TestCheckStreamSourcesExposeChunkMetadata(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第02章.md"), "## Scene 1: Rain Dock\n林昊在雨夜碼頭停下腳步。")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter": "林昊再次想起雨夜碼頭的腳步聲。",
+		"checks":  []string{"behavior"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	if !strings.Contains(body, "\"chapter_file\":\"第02章.md\"") ||
+		!strings.Contains(body, "\"chapter_index\":2") ||
+		!strings.Contains(body, "\"scene_index\":1") ||
+		!strings.Contains(body, "\"chunk_type\":\"scene\"") {
+		t.Fatalf("expected chunk metadata in sources payload, got %s", body)
+	}
+}
+
 func TestCheckStreamMarksGapsAsUnindexedWhenStoreIsEmpty(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -233,6 +233,167 @@ func TestCheckStreamMarksGapsAsUnindexedWhenStoreIsEmpty(t *testing.T) {
 	}
 }
 
+func TestCheckStreamPipelineEmitsOrderedLayerEvents(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "worldbuilding", "城市規則.md"), "# 城市規則\n- 夜晚才會顯影\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"layer_mode": "pipeline",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pipeline stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	order := []string{
+		"event:layer_start\ndata:{\"label\":\"結構層\",\"layer\":\"structure\"}",
+		"event:layer_end\ndata:{\"layer\":\"structure\"}",
+		"event:layer_start\ndata:{\"label\":\"角色層\",\"layer\":\"character\"}",
+		"event:layer_end\ndata:{\"layer\":\"character\"}",
+		"event:layer_start\ndata:{\"label\":\"世界觀層\",\"layer\":\"world_logic\"}",
+		"event:layer_end\ndata:{\"layer\":\"world_logic\"}",
+		"event:layer_start\ndata:{\"label\":\"語言層\",\"layer\":\"language\"}",
+		"event:layer_end\ndata:{\"layer\":\"language\"}",
+	}
+
+	last := -1
+	for _, marker := range order {
+		idx := strings.Index(body, marker)
+		if idx < 0 {
+			t.Fatalf("expected marker %q in stream, got %s", marker, body)
+		}
+		if idx <= last {
+			t.Fatalf("expected ordered markers, got %s", body)
+		}
+		last = idx
+	}
+	if callCount != 4 {
+		t.Fatalf("expected 4 generate calls, got %d", callCount)
+	}
+}
+
+func TestCheckStreamPipelineAbortsOnFirstLayerFailure(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			callCount++
+			if callCount == 1 {
+				// First layer (structure) fails: return 500 to trigger layer error.
+				http.Error(w, "model overloaded", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n")
+	mustWriteFile(t, filepath.Join(dir, "worldbuilding", "城市規則.md"), "# 城市規則\n- 夜晚才會顯影\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"layer_mode": "pipeline",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pipeline stream failed with status %d", resp.StatusCode)
+	}
+
+	body := string(resp.Body)
+
+	// structure layer_start must appear (pipeline started)
+	if !strings.Contains(body, "event:layer_start\ndata:{\"label\":\"結構層\",\"layer\":\"structure\"}") {
+		t.Fatalf("expected structure layer_start in stream, got %s", body)
+	}
+	// failed layer must NOT have layer_end
+	if strings.Contains(body, "event:layer_end\ndata:{\"layer\":\"structure\"}") {
+		t.Fatalf("failed layer must not emit layer_end, got %s", body)
+	}
+	// subsequent layers must not appear
+	if strings.Contains(body, "event:layer_start\ndata:{\"label\":\"角色層\",\"layer\":\"character\"}") {
+		t.Fatalf("pipeline should abort after first failure, got character layer in %s", body)
+	}
+	// only one generate call (structure layer)
+	if callCount != 1 {
+		t.Fatalf("expected exactly 1 generate call before abort, got %d", callCount)
+	}
+}
+
+func TestCheckStreamSingleDoesNotEmitLayerEvents(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"checks":     []string{"behavior"},
+		"layer_mode": "single",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("single stream failed: %s", string(resp.Body))
+	}
+	if strings.Contains(string(resp.Body), "event:layer_start") || strings.Contains(string(resp.Body), "event:layer_end") {
+		t.Fatalf("single mode should not emit layer events, got %s", string(resp.Body))
+	}
+}
+
 func TestCreateWorldstateSnapshotAndList(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -30,6 +30,8 @@ import (
 type streamEvent struct {
 	Event     string
 	Text      string
+	Layer     string
+	Label     string
 	Sources   []referenceSummary
 	Retrieval any
 	Gaps      *retrievalGaps
@@ -104,6 +106,14 @@ func parsePositiveChapter(raw string) (int, error) {
 		return 0, fmt.Errorf("章節必須是大於 0 的整數")
 	}
 	return chapter, nil
+}
+
+func normalizedLayerMode(raw string) string {
+	mode := strings.TrimSpace(raw)
+	if mode == "" {
+		return "single"
+	}
+	return mode
 }
 
 func saveOrAbort(c *gin.Context, err error, action string) bool {
@@ -860,6 +870,8 @@ type checkRequest struct {
 	ChapterFile        string                      `json:"chapter_file"`
 	ChapterTitle       string                      `json:"chapter_title"`
 	SceneTitle         string                      `json:"scene_title,omitempty"` // empty = full chapter
+	LayerMode          string                      `json:"layer_mode"`
+	Layers             []string                    `json:"layers,omitempty"`
 }
 
 type retrievalOptions struct {
@@ -900,8 +912,41 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		defer cancel()
 		defer close(msgChan)
 
-		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
+		if normalizedLayerMode(req.LayerMode) == "pipeline" {
+			if err := s.runPipelineReview(ctx, req, msgChan, &transcript, worldStatePrefix); err != nil {
+				return
+			}
+
+			completion := "\n\n---\n審查完成\n"
+			msgChan <- streamEvent{Event: "chunk", Text: completion}
+			transcript.WriteString(completion)
+
+			chapterFile := strings.TrimSpace(req.ChapterFile)
+			chapterTitle := strings.TrimSpace(req.ChapterTitle)
+			if chapterTitle == "" && chapterFile != "" {
+				chapterTitle = strings.TrimSuffix(chapterFile, ".md")
+			}
+			if chapterTitle == "" {
+				chapterTitle = "未命名章節"
+			}
+			s.history.Add(&reviewhistory.Entry{
+				Kind:         "review",
+				ChapterTitle: chapterTitle,
+				ChapterFile:  chapterFile,
+				SceneTitle:   strings.TrimSpace(req.SceneTitle),
+				InputContent: req.Chapter,
+				Checks:       append([]string(nil), req.Checks...),
+				Styles:       append([]string(nil), req.Styles...),
+				Result:       transcript.String(),
+			})
+			if err := s.history.Save(); err != nil {
+				log.Printf("save review history: %v", err)
+			}
+			return
+		}
+
+		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		charsToCheck := s.resolveCharacters(req)
 		needsCharacters := len(req.Checks) == 0 || contains(req.Checks, "behavior") || contains(req.Checks, "dialogue")
 		if needsCharacters && len(charsToCheck) == 0 {
@@ -1140,6 +1185,14 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 			}
 			if msg.Event == "gaps" {
 				c.SSEvent("gaps", msg.Gaps)
+				return true
+			}
+			if msg.Event == "layer_start" {
+				c.SSEvent("layer_start", gin.H{"layer": msg.Layer, "label": msg.Label})
+				return true
+			}
+			if msg.Event == "layer_end" {
+				c.SSEvent("layer_end", gin.H{"layer": msg.Layer})
 				return true
 			}
 			if msg.Event == "conflict" {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -52,10 +52,11 @@ type referenceSummary struct {
 }
 
 type retrievalSummary struct {
-	Task      string   `json:"task"`
-	Sources   []string `json:"sources"`
-	TopK      int      `json:"top_k"`
-	Threshold float64  `json:"threshold"`
+	Task          string   `json:"task"`
+	Sources       []string `json:"sources"`
+	TopK          int      `json:"top_k"`
+	Threshold     float64  `json:"threshold"`
+	BeforeChapter int      `json:"before_chapter,omitempty"`
 }
 
 type retrievalGaps struct {
@@ -212,15 +213,19 @@ func mergeRetrieval(preset reviewrules.RetrievalPreset, override retrievalOption
 	if override.ThresholdSet {
 		result.Threshold = override.Threshold
 	}
+	if override.BeforeChapter > 0 {
+		result.BeforeChapter = override.BeforeChapter
+	}
 	return result
 }
 
-func summarizeRetrieval(task string, opts retrievalOptions) retrievalSummary {
+func summarizeRetrieval(task string, opts retrievalOptions, beforeChapter int) retrievalSummary {
 	return retrievalSummary{
-		Task:      task,
-		Sources:   append([]string(nil), opts.Sources...),
-		TopK:      opts.TopK,
-		Threshold: opts.Threshold,
+		Task:          task,
+		Sources:       append([]string(nil), opts.Sources...),
+		TopK:          opts.TopK,
+		Threshold:     opts.Threshold,
+		BeforeChapter: beforeChapter,
 	}
 }
 
@@ -394,6 +399,16 @@ func (s *Server) resolveStyles(req checkRequest) ([]*profile.StyleGuide, error) 
 	return styles, nil
 }
 
+// resolveBeforeChapter returns the chapter index upper bound for timeline-bounded retrieval.
+// If opts.BeforeChapter is set explicitly it takes precedence; otherwise the index is derived
+// from chapterFile so that only chapters written before the current one are retrieved.
+func resolveBeforeChapter(chapterFile string, opts retrievalOptions) int {
+	if opts.BeforeChapter > 0 {
+		return opts.BeforeChapter
+	}
+	return extractChapterIndex(chapterFile)
+}
+
 func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile string, opts retrievalOptions) ([]vectorProfile, error) {
 	if s.store.Len() == 0 {
 		return nil, nil
@@ -418,7 +433,8 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 		threshold = rules.RetrievalThreshold
 	}
 
-	docs := s.store.QueryFilteredScored(queryVec, topK, sources, threshold)
+	beforeChapter := resolveBeforeChapter(chapterFile, opts)
+	docs := s.store.QueryFilteredBeforeChapter(queryVec, topK, sources, threshold, beforeChapter)
 	results := make([]vectorProfile, 0, len(docs))
 	for _, doc := range docs {
 		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ChapterFile == chapterFile {
@@ -875,10 +891,11 @@ type checkRequest struct {
 }
 
 type retrievalOptions struct {
-	Sources      []string `json:"sources"`
-	TopK         int      `json:"top_k"`
-	Threshold    float64  `json:"threshold"`
-	ThresholdSet bool     `json:"threshold_set,omitempty"`
+	Sources       []string `json:"sources"`
+	TopK          int      `json:"top_k"`
+	Threshold     float64  `json:"threshold"`
+	ThresholdSet  bool     `json:"threshold_set,omitempty"`
+	BeforeChapter int      `json:"before_chapter,omitempty"`
 }
 
 func (r checkRequest) retrievalOverrideFor(task string) retrievalOptions {
@@ -964,7 +981,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 
 		if len(req.Checks) == 0 || contains(req.Checks, "behavior") {
 			behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
-			activeRetrieval["behavior"] = summarizeRetrieval("behavior", behaviorOpts)
+			activeRetrieval["behavior"] = summarizeRetrieval("behavior", behaviorOpts, resolveBeforeChapter(req.ChapterFile, behaviorOpts))
 			traceStarted := time.Now()
 			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["behavior"], req.ChapterTitle, req.ChapterFile, behaviorRefs, err, time.Since(traceStarted))
@@ -976,7 +993,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		}
 		if contains(req.Checks, "dialogue") {
 			dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
-			activeRetrieval["dialogue"] = summarizeRetrieval("dialogue", dialogueOpts)
+			activeRetrieval["dialogue"] = summarizeRetrieval("dialogue", dialogueOpts, resolveBeforeChapter(req.ChapterFile, dialogueOpts))
 			traceStarted := time.Now()
 			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, dialogueOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["dialogue"], req.ChapterTitle, req.ChapterFile, dialogueRefs, err, time.Since(traceStarted))
@@ -988,7 +1005,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		}
 		if contains(req.Checks, "world") {
 			worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
-			activeRetrieval["world"] = summarizeRetrieval("world", worldOpts)
+			activeRetrieval["world"] = summarizeRetrieval("world", worldOpts, resolveBeforeChapter(req.ChapterFile, worldOpts))
 			traceStarted := time.Now()
 			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, worldOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["world"], req.ChapterTitle, req.ChapterFile, worldRefs, err, time.Since(traceStarted))
@@ -1283,7 +1300,8 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer close(msgChan)
 
 		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
-		activeRetrieval := summarizeRetrieval("rewrite", mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval))
+		rewriteOpts := mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval)
+		activeRetrieval := summarizeRetrieval("rewrite", rewriteOpts, resolveBeforeChapter(req.ChapterFile, rewriteOpts))
 		traceStarted := time.Now()
 		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, retrievalOptions{
 			Sources:      append([]string(nil), activeRetrieval.Sources...),

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -43,6 +43,10 @@ type referenceSummary struct {
 	Score        float64 `json:"score"`
 	MatchReason  string  `json:"match_reason"`
 	ChapterMatch string  `json:"chapter_match"`
+	ChapterFile  string  `json:"chapter_file,omitempty"`
+	ChapterIndex int     `json:"chapter_index,omitempty"`
+	SceneIndex   int     `json:"scene_index,omitempty"`
+	ChunkType    string  `json:"chunk_type,omitempty"`
 }
 
 type retrievalSummary struct {
@@ -169,6 +173,10 @@ type vectorProfile struct {
 	Score        float64
 	MatchReason  string
 	ChapterMatch string
+	ChapterFile  string
+	ChapterIndex int
+	SceneIndex   int
+	ChunkType    string
 }
 
 func excerptText(content string) string {
@@ -264,6 +272,10 @@ func summarizeReferences(items []vectorProfile) []referenceSummary {
 			Score:        item.Score,
 			MatchReason:  item.MatchReason,
 			ChapterMatch: item.ChapterMatch,
+			ChapterFile:  item.ChapterFile,
+			ChapterIndex: item.ChapterIndex,
+			SceneIndex:   item.SceneIndex,
+			ChunkType:    item.ChunkType,
 		})
 	}
 	return summaries
@@ -399,7 +411,7 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 	docs := s.store.QueryFilteredScored(queryVec, topK, sources, threshold)
 	results := make([]vectorProfile, 0, len(docs))
 	for _, doc := range docs {
-		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ID == "chapter_"+chapterFile {
+		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ChapterFile == chapterFile {
 			continue
 		}
 		name := strings.TrimPrefix(doc.ID, "char_")
@@ -414,6 +426,10 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 			Score:        doc.Score,
 			MatchReason:  reason,
 			ChapterMatch: snippet,
+			ChapterFile:  doc.ChapterFile,
+			ChapterIndex: doc.ChapterIndex,
+			SceneIndex:   doc.SceneIndex,
+			ChunkType:    doc.ChunkType,
 		})
 	}
 	return results, nil

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -38,6 +38,76 @@ func TestParsePositiveChapterRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestDefaultReviewLayersReturnsFourLayersInOrder(t *testing.T) {
+	t.Parallel()
+
+	layers := defaultReviewLayers()
+	if len(layers) != 4 {
+		t.Fatalf("expected 4 layers, got %d", len(layers))
+	}
+
+	want := []struct {
+		name  string
+		label string
+	}{
+		{name: "structure", label: "結構層"},
+		{name: "character", label: "角色層"},
+		{name: "world_logic", label: "世界觀層"},
+		{name: "language", label: "語言層"},
+	}
+
+	for i, layer := range layers {
+		if layer.Name != want[i].name || layer.Label != want[i].label || !layer.Enabled {
+			t.Fatalf("unexpected layer at %d: %#v", i, layer)
+		}
+		if strings.TrimSpace(layer.Prompt) == "" {
+			t.Fatalf("expected prompt for layer %s", layer.Name)
+		}
+	}
+}
+
+func TestResolveReviewLayersPipelineReturnsAllEnabled(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter:   "章節內容",
+		LayerMode: "pipeline",
+	}
+
+	layers := resolveReviewLayers(req)
+	if len(layers) != 4 {
+		t.Fatalf("expected 4 layers in pipeline mode, got %#v", layers)
+	}
+}
+
+func TestResolveReviewLayersSingleReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter:   "章節內容",
+		LayerMode: "single",
+	}
+
+	layers := resolveReviewLayers(req)
+	if layers != nil {
+		t.Fatalf("expected nil layers in single mode, got %#v", layers)
+	}
+}
+
+func TestResolveReviewLayersTreatsEmptyModeAsSingle(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter:   "章節內容",
+		LayerMode: normalizedLayerMode("   "),
+	}
+
+	layers := resolveReviewLayers(req)
+	if layers != nil {
+		t.Fatalf("expected nil layers for empty mode, got %#v", layers)
+	}
+}
+
 func TestResolveStylesReturnsAllStylesWhenNoneSelected(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -327,3 +327,30 @@ func TestResolveCharactersIncludesPronounCandidates(t *testing.T) {
 		t.Fatalf("unexpected resolved characters: %#v", chars)
 	}
 }
+
+func TestSummarizeReferencesIncludesChunkMetadata(t *testing.T) {
+	t.Parallel()
+
+	items := []vectorProfile{
+		{
+			Name:         "第02章_scene_1",
+			Type:         "chapter",
+			Content:      "林昊推門走進雨夜碼頭。",
+			Score:        0.91,
+			MatchReason:  "章節直接提到此參考名稱",
+			ChapterMatch: "…雨夜碼頭…",
+			ChapterFile:  "第02章.md",
+			ChapterIndex: 2,
+			SceneIndex:   1,
+			ChunkType:    "scene",
+		},
+	}
+
+	got := summarizeReferences(items)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 summary, got %#v", got)
+	}
+	if got[0].ChapterFile != "第02章.md" || got[0].ChapterIndex != 2 || got[0].SceneIndex != 1 || got[0].ChunkType != "scene" {
+		t.Fatalf("expected chunk metadata in summary, got %#v", got[0])
+	}
+}

--- a/internal/server/review_layers.go
+++ b/internal/server/review_layers.go
@@ -81,10 +81,11 @@ func (s *Server) runPipelineReview(
 	behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
 	dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
 	worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
+	beforeChapter := resolveBeforeChapter(req.ChapterFile, behaviorOpts)
 	activeRetrieval := map[string]retrievalSummary{
-		"behavior": summarizeRetrieval("behavior", behaviorOpts),
-		"dialogue": summarizeRetrieval("dialogue", dialogueOpts),
-		"world":    summarizeRetrieval("world", worldOpts),
+		"behavior": summarizeRetrieval("behavior", behaviorOpts, beforeChapter),
+		"dialogue": summarizeRetrieval("dialogue", dialogueOpts, beforeChapter),
+		"world":    summarizeRetrieval("world", worldOpts, beforeChapter),
 	}
 
 	behaviorRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)

--- a/internal/server/review_layers.go
+++ b/internal/server/review_layers.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type reviewLayer struct {
+	Name    string `json:"name"`
+	Label   string `json:"label"`
+	Prompt  string `json:"prompt"`
+	Enabled bool   `json:"enabled"`
+}
+
+func defaultReviewLayers() []reviewLayer {
+	return []reviewLayer{
+		{
+			Name:    "structure",
+			Label:   "結構層",
+			Prompt:  "你是專業小說結構編輯。只分析以下章節的敘事節奏、開場鉤子、張力起伏與段落長短，不要評論角色或語言風格。",
+			Enabled: true,
+		},
+		{
+			Name:    "character",
+			Label:   "角色層",
+			Prompt:  "你是角色塑造專家。只分析以下章節的角色行為是否符合人設、對白語氣是否一致，並結合提供的角色資料判斷，不要評論結構或語言。",
+			Enabled: true,
+		},
+		{
+			Name:    "world_logic",
+			Label:   "世界觀層",
+			Prompt:  "你是世界觀邏輯審查員。只分析以下章節的設定自洽性、時間線合理性、道具與地點邏輯，不要評論其他層面。",
+			Enabled: true,
+		},
+		{
+			Name:    "language",
+			Label:   "語言層",
+			Prompt:  "你是文字風格編輯。只分析以下章節的句式多樣性、重複用語、感官描寫密度與語言流暢度，不要評論劇情或角色。",
+			Enabled: true,
+		},
+	}
+}
+
+func resolveReviewLayers(req checkRequest) []reviewLayer {
+	if req.LayerMode != "pipeline" {
+		return nil
+	}
+
+	layers := defaultReviewLayers()
+	out := make([]reviewLayer, 0, len(layers))
+	for _, layer := range layers {
+		if layer.Enabled {
+			out = append(out, layer)
+		}
+	}
+	return out
+}
+
+func (s *Server) runPipelineReview(
+	ctx context.Context,
+	req checkRequest,
+	msgChan chan<- streamEvent,
+	transcript *strings.Builder,
+	worldStatePrefix string,
+) error {
+	layers := resolveReviewLayers(req)
+	if len(layers) == 0 {
+		return nil
+	}
+
+	charsToCheck := s.resolveCharacters(req)
+	if len(charsToCheck) == 0 {
+		text := "\n> 找不到可審查的角色，請先建立角色設定檔。\n"
+		transcript.WriteString(text)
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		return fmt.Errorf("no characters available for pipeline review")
+	}
+
+	reviewBias := reviewBiasInstruction(s.rules.Get().ReviewBias)
+	behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
+	dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
+	worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
+	activeRetrieval := map[string]retrievalSummary{
+		"behavior": summarizeRetrieval("behavior", behaviorOpts),
+		"dialogue": summarizeRetrieval("dialogue", dialogueOpts),
+		"world":    summarizeRetrieval("world", worldOpts),
+	}
+
+	behaviorRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)
+	if err != nil {
+		text := fmt.Sprintf("\n> 行為審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+		transcript.WriteString(text)
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		behaviorRefs = nil
+	}
+	dialogueRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, dialogueOpts)
+	if err != nil {
+		text := fmt.Sprintf("\n> 對白審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+		transcript.WriteString(text)
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		dialogueRefs = nil
+	}
+	worldRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, worldOpts)
+	if err != nil {
+		text := fmt.Sprintf("\n> 世界觀審查的 RAG 參考載入失敗，改用基礎模式繼續：%s\n", err.Error())
+		transcript.WriteString(text)
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		worldRefs = nil
+	}
+
+	msgChan <- streamEvent{Event: "retrieval", Retrieval: map[string]any{"tasks": activeRetrieval}}
+
+	references := mergeReferenceLists(behaviorRefs, dialogueRefs, worldRefs)
+	if len(references) > 0 {
+		msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
+	}
+	if len(charsToCheck) > 0 {
+		gaps := computeRetrievalGaps(req.Chapter, s.profiles.AllNames(), references)
+		if s.store.Len() > 0 {
+			gaps.IndexReady = true
+		}
+		if len(gaps.MissingCharacters) > 0 || len(gaps.MissingLocations) > 0 || len(gaps.MissingSettings) > 0 {
+			msgChan <- streamEvent{Event: "gaps", Gaps: &gaps}
+		}
+	}
+
+	behaviorRefText := joinProfiles(behaviorRefs)
+	dialogueRefText := joinProfiles(dialogueRefs)
+	worldText := joinWorldProfiles(filterReferencesByType(worldRefs, "world"), s.profiles.Worlds)
+
+	styleReq := req
+	styleReq.Checks = []string{"style"}
+	stylesToCheck, err := s.resolveStyles(styleReq)
+	if len(req.Styles) > 0 && err != nil {
+		text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
+		transcript.WriteString(text)
+		msgChan <- streamEvent{Event: "chunk", Text: text}
+		return err
+	}
+
+	styleTexts := make([]string, 0, len(stylesToCheck))
+	for _, sg := range stylesToCheck {
+		styleTexts = append(styleTexts, sg.RawContent)
+	}
+	languageRefs := joinProfiles(filterReferencesByType(references, "style"))
+	if len(styleTexts) > 0 {
+		if languageRefs != "" {
+			languageRefs += "\n\n"
+		}
+		languageRefs += strings.Join(styleTexts, "\n\n")
+	}
+
+	cw := &chanWriter{ch: msgChan, transcript: transcript}
+	for _, layer := range layers {
+		msgChan <- streamEvent{Event: "layer_start", Layer: layer.Name, Label: layer.Label}
+
+		var promptParts []string
+		promptParts = append(promptParts, layer.Prompt)
+		promptParts = append(promptParts, "【審查偏好】\n"+reviewBias)
+
+		switch layer.Name {
+		case "character":
+			profiles := make([]string, 0, len(charsToCheck))
+			for _, ch := range charsToCheck {
+				profiles = append(profiles, ch.RawContent)
+			}
+			if len(profiles) > 0 {
+				promptParts = append(promptParts, "【角色資料】\n"+strings.Join(profiles, "\n\n"))
+			}
+			layerRefs := joinProfiles(mergeReferenceLists(behaviorRefs, dialogueRefs))
+			if layerRefs != "" {
+				promptParts = append(promptParts, "【補充參考資料】\n"+layerRefs)
+			}
+		case "world_logic":
+			if strings.TrimSpace(worldText) != "" {
+				promptParts = append(promptParts, "【世界觀資料】\n"+worldText)
+			}
+		case "language":
+			if strings.TrimSpace(languageRefs) != "" {
+				promptParts = append(promptParts, "【補充參考資料】\n"+languageRefs)
+			}
+		}
+
+		if layer.Name == "character" && strings.TrimSpace(behaviorRefText) != "" && strings.TrimSpace(dialogueRefText) == "" {
+			// Keep behavior reference context available even when dialogue retrieval is empty.
+			promptParts = append(promptParts, "【角色參考摘要】\n"+behaviorRefText)
+		}
+
+		promptParts = append(promptParts, "【章節內容】\n"+req.Chapter)
+		layerErr := s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, strings.Join(promptParts, "\n\n"), cw)
+		if layerErr != nil {
+			if ctx.Err() == nil {
+				text := fmt.Sprintf("\n> 錯誤：%s\n", layerErr.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			}
+			return layerErr
+		}
+
+		msgChan <- streamEvent{Event: "layer_end", Layer: layer.Name}
+		msgChan <- streamEvent{Event: "chunk", Text: "\n"}
+		transcript.WriteString("\n")
+	}
+
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -367,17 +367,15 @@ func (s *Server) Ingest(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("read chapter %s: %w", file.Name(), err)
 		}
-		vec, err := s.embedder.Embed(ctx, string(content))
-		if err != nil {
-			return fmt.Errorf("embed chapter %s: %w", file.Name(), err)
+		for _, chunk := range chunkChapter(file.Name(), string(content)) {
+			vec, err := s.embedder.Embed(ctx, chunk.Content)
+			if err != nil {
+				return fmt.Errorf("embed chapter chunk %s: %w", chunk.ID, err)
+			}
+			chunk.Embedding = vec
+			st.store.Upsert(chunk)
+			log.Printf("indexed chapter chunk: %s", chunk.ID)
 		}
-		st.store.Upsert(vectorstore.Document{
-			ID:        "chapter_" + file.Name(),
-			Type:      "chapter",
-			Content:   string(content),
-			Embedding: vec,
-		})
-		log.Printf("indexed chapter: %s", file.Name())
 	}
 
 	return st.store.Save()

--- a/internal/server/templates_test.go
+++ b/internal/server/templates_test.go
@@ -41,3 +41,25 @@ func TestStylesTemplateRenderStyleAnalysisAvoidsInnerHTMLInterpolation(t *testin
 		t.Fatal("expected style analysis rendering to use textContent")
 	}
 }
+
+func TestCheckTemplateRendersSourceLocationLabel(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../web/templates/check.html")
+	if err != nil {
+		t.Fatalf("read check template: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "function formatSourceLocation(item)") {
+		t.Fatal("expected check template to define source location formatter")
+	}
+	if !strings.Contains(text, "第 ' + item.chapter_index + ' 章") {
+		t.Fatal("expected source formatter to mention chapter index labels")
+	}
+	if !strings.Contains(text, "Scene ' + item.scene_index") {
+		t.Fatal("expected source formatter to mention scene labels")
+	}
+	if !strings.Contains(text, "段落 ' + item.scene_index") {
+		t.Fatal("expected source formatter to mention paragraph labels")
+	}
+}

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -165,6 +165,51 @@ func (s *Store) QueryFilteredScored(queryVec []float64, topK int, types []string
 	return out
 }
 
+// QueryFilteredBeforeChapter is like QueryFilteredScored but additionally
+// excludes chapter-type documents whose ChapterIndex >= beforeChapter.
+// beforeChapter <= 0 means no timeline filter is applied.
+// Non-chapter document types are never filtered by this bound.
+func (s *Store) QueryFilteredBeforeChapter(queryVec []float64, topK int, types []string, threshold float64, beforeChapter int) []ScoredDocument {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	typeSet := make(map[string]struct{}, len(types))
+	for _, item := range types {
+		typeSet[item] = struct{}{}
+	}
+
+	type scored struct {
+		doc   Document
+		score float64
+	}
+	var results []scored
+	for _, d := range s.docs {
+		if len(typeSet) > 0 {
+			if _, ok := typeSet[d.Type]; !ok {
+				continue
+			}
+		}
+		if beforeChapter > 0 && d.Type == "chapter" && d.ChapterIndex >= beforeChapter {
+			continue
+		}
+		score := cosine(queryVec, d.Embedding)
+		if threshold > 0 && score < threshold {
+			continue
+		}
+		results = append(results, scored{doc: d, score: score})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].score > results[j].score })
+
+	out := make([]ScoredDocument, 0, topK)
+	for i := 0; i < topK && i < len(results); i++ {
+		out = append(out, ScoredDocument{
+			Document: results[i].doc,
+			Score:    results[i].score,
+		})
+	}
+	return out
+}
+
 func cosine(a, b []float64) float64 {
 	if len(a) != len(b) {
 		return 0

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -9,10 +9,14 @@ import (
 )
 
 type Document struct {
-	ID        string    `json:"id"`
-	Type      string    `json:"type"` // "character" | "world" | "style" | "chapter"
-	Content   string    `json:"content"`
-	Embedding []float64 `json:"embedding"`
+	ID           string    `json:"id"`
+	Type         string    `json:"type"` // "character" | "world" | "style" | "chapter"
+	Content      string    `json:"content"`
+	Embedding    []float64 `json:"embedding"`
+	ChapterFile  string    `json:"chapter_file,omitempty"`
+	ChapterIndex int       `json:"chapter_index,omitempty"`
+	SceneIndex   int       `json:"scene_index,omitempty"`
+	ChunkType    string    `json:"chunk_type,omitempty"`
 }
 
 type Store struct {

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -1,6 +1,9 @@
 package vectorstore
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestQueryFilteredScoredSupportsThresholdAndTypeFilters(t *testing.T) {
 	t.Parallel()
@@ -52,5 +55,37 @@ func TestQueryFilteredScoredRespectsTopK(t *testing.T) {
 	}
 	if results[0].Score < results[1].Score {
 		t.Fatalf("expected scores sorted descending, got %#v", results)
+	}
+}
+
+func TestDocumentMetadataSurvivesSaveLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "store.json")
+	store := New(path)
+	store.Upsert(Document{
+		ID:           "chapter_第03章.md_scene_1",
+		Type:         "chapter",
+		Content:      "雨落下來。",
+		Embedding:    []float64{0.1, 0.2},
+		ChapterFile:  "第03章.md",
+		ChapterIndex: 3,
+		SceneIndex:   1,
+		ChunkType:    "scene",
+	})
+	if err := store.Save(); err != nil {
+		t.Fatalf("save store: %v", err)
+	}
+
+	loaded := New(path)
+	if err := loaded.Load(); err != nil {
+		t.Fatalf("load store: %v", err)
+	}
+	items := loaded.QueryFilteredScored([]float64{0.1, 0.2}, 1, []string{"chapter"}, 0)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(items))
+	}
+	if items[0].ChapterFile != "第03章.md" || items[0].ChapterIndex != 3 || items[0].SceneIndex != 1 || items[0].ChunkType != "scene" {
+		t.Fatalf("unexpected metadata after reload: %#v", items[0].Document)
 	}
 }

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -89,3 +89,47 @@ func TestDocumentMetadataSurvivesSaveLoad(t *testing.T) {
 		t.Fatalf("unexpected metadata after reload: %#v", items[0].Document)
 	}
 }
+
+func TestQueryFilteredBeforeChapter(t *testing.T) {
+	t.Parallel()
+
+	store := New("")
+	vec := []float64{1, 0}
+	// chapter index 2 — should appear when beforeChapter=3
+	store.Upsert(Document{ID: "ch2", Type: "chapter", ChapterIndex: 2, Embedding: vec, Content: "ch2"})
+	// chapter index 5 — should be excluded when beforeChapter=3
+	store.Upsert(Document{ID: "ch5", Type: "chapter", ChapterIndex: 5, Embedding: vec, Content: "ch5"})
+	// character — never filtered by chapter index
+	store.Upsert(Document{ID: "char1", Type: "character", ChapterIndex: 99, Embedding: vec, Content: "char"})
+
+	t.Run("beforeChapter=0 does not filter", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, nil, 0, 0)
+		if len(results) != 3 {
+			t.Fatalf("expected 3, got %d", len(results))
+		}
+	})
+
+	t.Run("beforeChapter=3 excludes chapter idx>=3", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, nil, 0, 3)
+		ids := make(map[string]bool)
+		for _, r := range results {
+			ids[r.ID] = true
+		}
+		if ids["ch5"] {
+			t.Fatal("ch5 (index 5) should be excluded")
+		}
+		if !ids["ch2"] {
+			t.Fatal("ch2 (index 2) should be included")
+		}
+		if !ids["char1"] {
+			t.Fatal("char1 (non-chapter) should not be filtered")
+		}
+	})
+
+	t.Run("type filter still works alongside beforeChapter", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, []string{"chapter"}, 0, 3)
+		if len(results) != 1 || results[0].ID != "ch2" {
+			t.Fatalf("expected only ch2, got %v", results)
+		}
+	})
+}

--- a/plans/2026-04-20-issue-35-scene-level-chunk-rag.md
+++ b/plans/2026-04-20-issue-35-scene-level-chunk-rag.md
@@ -1,0 +1,91 @@
+# Scene-level Chunk RAG Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change chapter retrieval from whole-chapter vectors to scene or paragraph chunks so review and rewrite flows receive precise excerpts with chapter/scene metadata.
+
+**Architecture:** Keep the existing vectorstore query algorithm and retrieval flow, but replace chapter ingest with a chunk builder that emits scene or paragraph `vectorstore.Document` entries. Propagate chunk metadata through `vectorProfile`, `referenceSummary`, SSE `sources`, and the `check.html` source card renderer so the UI can label each result as `第 N 章・Scene M` or `第 N 章・段落 M`.
+
+**Tech Stack:** Go, Gin, html/template, vanilla JavaScript, Go tests
+
+---
+
+### Task 1: Expand vector document metadata
+
+**Files:**
+- Modify: `internal/vectorstore/store.go`
+- Test: `internal/vectorstore/store_test.go`
+
+- [ ] **Step 1: Write the failing metadata persistence test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 2: Add chapter chunk builder and chapter index parsing
+
+**Files:**
+- Modify: `internal/server/chapters.go`
+- Test: `internal/server/chapters_test.go`
+
+- [ ] **Step 1: Write the failing chunking tests**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 3: Switch ingest from whole chapters to chapter chunks
+
+**Files:**
+- Modify: `internal/server/server.go`
+- Test: `internal/server/e2e_test.go`
+
+- [ ] **Step 1: Write the failing ingest test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 4: Propagate chunk metadata through retrieval summaries
+
+**Files:**
+- Modify: `internal/server/handlers.go`
+- Test: `internal/server/handlers_test.go`
+- Test: `internal/server/e2e_test.go`
+
+- [ ] **Step 1: Write the failing metadata propagation tests**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 5: Render chunk location labels in the source cards
+
+**Files:**
+- Modify: `web/templates/check.html`
+- Test: `internal/server/templates_test.go`
+
+- [ ] **Step 1: Write the failing template test**
+- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 5: Commit**
+
+### Task 6: Final formatting and verification
+
+**Files:**
+- Modify: `internal/vectorstore/store.go`
+- Modify: `internal/vectorstore/store_test.go`
+- Modify: `internal/server/chapters.go`
+- Modify: `internal/server/chapters_test.go`
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/handlers.go`
+- Modify: `internal/server/handlers_test.go`
+- Modify: `internal/server/e2e_test.go`
+- Modify: `internal/server/templates_test.go`
+- Modify: `web/templates/check.html`
+
+- [ ] **Step 1: Run gofmt on modified Go files**
+- [ ] **Step 2: Run the full test suite**
+- [ ] **Step 3: Verify formatting is clean**
+- [ ] **Step 4: Commit**

--- a/plans/2026-04-20-issue-36-multi-layer-review-pipeline.md
+++ b/plans/2026-04-20-issue-36-multi-layer-review-pipeline.md
@@ -1,0 +1,880 @@
+# Multi-Layer Review Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 為章節審查新增 `pipeline` 模式，依序執行結構、角色、世界觀、語言四層獨立 review，同時保留 `single` 模式的既有行為不變。
+
+**Architecture:** 在 `internal/server/review_layers.go` 集中管理 layer 定義、prompt 模板與 pipeline 執行流程；`handleCheckStream` 只負責分流到 `single` 與 `pipeline`。前端 `check.html` 新增模式切換與 layer SSE 呈現，但不在第一版提供部分 layer 勾選。
+
+**Tech Stack:** Go、Gin、既有 SSE stream flow、既有 checker streaming API、HTML template + vanilla JavaScript、Go test。
+
+---
+
+## File Map
+
+- Modify: `internal/server/handlers.go`
+  - 擴充既有 `checkRequest` struct，保留現有欄位並新增 `layer_mode` / `layers`
+  - 在 `handleCheckStream` 做 `single` / `pipeline` 分流
+  - 新增 `streamEvent` 的 layer 欄位支援
+- Create: `internal/server/review_layers.go`
+  - 定義 `reviewLayer`
+  - 實作 `defaultReviewLayers()`
+  - 實作 `resolveReviewLayers(req checkRequest)`
+  - 實作 `runPipelineReview(...)`
+- Modify: `internal/server/handlers_test.go`
+  - 補 unit tests：layer definitions、layer resolution、single mode 不走 pipeline
+- Modify: `internal/server/e2e_test.go`
+  - 補 regression test：`single` 模式不出現 layer events
+  - 補 pipeline success ordering test
+  - 補 pipeline failure path test
+- Modify: `web/templates/check.html`
+  - 新增審稿模式切換 UI
+  - pipeline 模式隱藏 `checks`
+  - SSE 處理 `layer_start` / `layer_end`
+- Modify: `internal/server/templates_test.go`
+  - 補 template 靜態驗證：模式切換 UI 與 layer event handler
+
+## Task 1: 建立 Review Layer Definition 與 Resolution
+
+**Files:**
+- Create: `internal/server/review_layers.go`
+- Modify: `internal/server/handlers_test.go`
+
+- [ ] **Step 1: 先寫 review layer unit test**
+
+在 `internal/server/handlers_test.go` 新增測試：
+
+```go
+func TestDefaultReviewLayersReturnsFourLayersInOrder(t *testing.T) {
+	t.Parallel()
+
+	layers := defaultReviewLayers()
+	if len(layers) != 4 {
+		t.Fatalf("expected 4 layers, got %d", len(layers))
+	}
+
+	want := []struct {
+		name  string
+		label string
+	}{
+		{name: "structure", label: "結構層"},
+		{name: "character", label: "角色層"},
+		{name: "world_logic", label: "世界觀層"},
+		{name: "language", label: "語言層"},
+	}
+
+	for i, layer := range layers {
+		if layer.Name != want[i].name || layer.Label != want[i].label || !layer.Enabled {
+			t.Fatalf("unexpected layer at %d: %#v", i, layer)
+		}
+		if strings.TrimSpace(layer.Prompt) == "" {
+			t.Fatalf("expected prompt for layer %s", layer.Name)
+		}
+	}
+}
+
+func TestResolveReviewLayersPipelineReturnsAllEnabled(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter:   "章節內容",
+		LayerMode: "pipeline",
+	}
+
+	layers := resolveReviewLayers(req)
+	if len(layers) != 4 {
+		t.Fatalf("expected 4 layers in pipeline mode, got %#v", layers)
+	}
+}
+
+func TestResolveReviewLayersSingleReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter:   "章節內容",
+		LayerMode: "single",
+	}
+
+	layers := resolveReviewLayers(req)
+	if layers != nil {
+		t.Fatalf("expected nil layers in single mode, got %#v", layers)
+	}
+}
+```
+
+- [ ] **Step 2: 跑測試確認先紅燈**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestDefaultReviewLayersReturnsFourLayersInOrder|TestResolveReviewLayersPipelineReturnsAllEnabled|TestResolveReviewLayersSingleReturnsNil" -count=1
+```
+
+Expected:
+
+- build fail，因為 `defaultReviewLayers` / `resolveReviewLayers` 尚未存在
+
+- [ ] **Step 3: 新增 `review_layers.go` 最小實作**
+
+在 `internal/server/review_layers.go` 建立：
+
+```go
+package server
+
+type reviewLayer struct {
+	Name    string `json:"name"`
+	Label   string `json:"label"`
+	Prompt  string `json:"prompt"`
+	Enabled bool   `json:"enabled"`
+}
+
+func defaultReviewLayers() []reviewLayer {
+	return []reviewLayer{
+		{
+			Name:    "structure",
+			Label:   "結構層",
+			Prompt:  "你是專業小說結構編輯。只分析以下章節的「敘事節奏、開場鉤子、張力起伏、段落長短」。不要評論角色或語言風格。條列式給出具體問題與改善建議。",
+			Enabled: true,
+		},
+		{
+			Name:    "character",
+			Label:   "角色層",
+			Prompt:  "你是角色塑造專家。只分析以下章節的「角色行為是否符合其人設、對白語氣是否一致」。結合提供的角色資料做判斷。不要評論結構或語言。",
+			Enabled: true,
+		},
+		{
+			Name:    "world_logic",
+			Label:   "世界觀層",
+			Prompt:  "你是世界觀邏輯審查員。只分析以下章節的「設定自洽性、時間線合理性、道具與地點邏輯」。若有提供追蹤器資料，優先以此判斷。不要評論其他層面。",
+			Enabled: true,
+		},
+		{
+			Name:    "language",
+			Label:   "語言層",
+			Prompt:  "你是文字風格編輯。只分析以下章節的「句式多樣性、重複用語、感官描寫密度、語言流暢度」。不要評論劇情或角色。",
+			Enabled: true,
+		},
+	}
+}
+
+func resolveReviewLayers(req checkRequest) []reviewLayer {
+	if req.LayerMode != "pipeline" {
+		return nil
+	}
+	layers := defaultReviewLayers()
+	out := make([]reviewLayer, 0, len(layers))
+	for _, layer := range layers {
+		if layer.Enabled {
+			out = append(out, layer)
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: 重新跑 unit test 確認變綠**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestDefaultReviewLayersReturnsFourLayersInOrder|TestResolveReviewLayersPipelineReturnsAllEnabled|TestResolveReviewLayersSingleReturnsNil" -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/review_layers.go internal/server/handlers_test.go
+git commit -m "feat: define review pipeline layers"
+```
+
+## Task 2: 擴充 Request/SSE 結構並保住 Single Mode 回歸邊界
+
+**Files:**
+- Modify: `internal/server/handlers.go`
+- Modify: `internal/server/handlers_test.go`
+
+- [ ] **Step 1: 先寫 single mode regression 測試**
+
+在 `internal/server/handlers_test.go` 新增：
+
+```go
+func TestResolveReviewLayersTreatsEmptyModeAsSingle(t *testing.T) {
+	t.Parallel()
+
+	req := checkRequest{
+		Chapter: "章節內容",
+	}
+
+	if layers := resolveReviewLayers(req); layers != nil {
+		t.Fatalf("expected empty mode to behave like single, got %#v", layers)
+	}
+}
+```
+
+- [ ] **Step 2: 跑測試確認需求被釘住**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestResolveReviewLayersTreatsEmptyModeAsSingle" -count=1
+```
+
+Expected:
+
+- PASS 或 FAIL，視 Step 3 是否需要調整；若已 PASS，保留該測試作 regression 錨點
+
+- [ ] **Step 3: 擴充既有 `checkRequest` 與 `streamEvent`**
+
+在 `internal/server/handlers.go` 更新既有型別，保留現有欄位，只新增欄位：
+
+```go
+type streamEvent struct {
+	Event     string
+	Text      string
+	Layer     string
+	Label     string
+	Sources   []referenceSummary
+	Retrieval any
+	Gaps      *retrievalGaps
+	Conflicts []consistency.Conflict
+}
+
+type checkRequest struct {
+	Chapter            string                      `json:"chapter"`
+	Checks             []string                    `json:"checks"`
+	Characters         []string                    `json:"characters"`
+	Styles             []string                    `json:"styles"`
+	Retrieval          retrievalOptions            `json:"retrieval"`
+	RetrievalOverrides map[string]retrievalOptions `json:"retrieval_overrides"`
+	ChapterFile        string                      `json:"chapter_file"`
+	ChapterTitle       string                      `json:"chapter_title"`
+	SceneTitle         string                      `json:"scene_title,omitempty"`
+	Scene              string                      `json:"scene,omitempty"`
+	LayerMode          string                      `json:"layer_mode"`
+	Layers             []string                    `json:"layers,omitempty"`
+}
+```
+
+同檔案中補一個 helper：
+
+```go
+func normalizedLayerMode(raw string) string {
+	mode := strings.TrimSpace(raw)
+	if mode == "" {
+		return "single"
+	}
+	return mode
+}
+```
+
+- [ ] **Step 4: 確保 SSE writer 支援 layer event**
+
+在 `handleCheckStream` 的 SSE stream switch 加入：
+
+```go
+if msg.Event == "layer_start" {
+	c.SSEvent("layer_start", gin.H{"layer": msg.Layer, "label": msg.Label})
+	return true
+}
+if msg.Event == "layer_end" {
+	c.SSEvent("layer_end", gin.H{"layer": msg.Layer})
+	return true
+}
+```
+
+- [ ] **Step 5: 跑 handlers 測試**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestResolveReviewLayersTreatsEmptyModeAsSingle|TestDefaultReviewLayersReturnsFourLayersInOrder|TestResolveReviewLayersPipelineReturnsAllEnabled|TestResolveReviewLayersSingleReturnsNil" -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/handlers.go internal/server/handlers_test.go
+git commit -m "feat: add layer mode request and sse events"
+```
+
+## Task 3: 實作 Pipeline Runner 與後端分流
+
+**Files:**
+- Modify: `internal/server/review_layers.go`
+- Modify: `internal/server/handlers.go`
+- Modify: `internal/server/e2e_test.go`
+
+- [ ] **Step 1: 先寫 pipeline 成功路徑 e2e 測試**
+
+在 `internal/server/e2e_test.go` 新增：
+
+```go
+func TestCheckStreamPipelineEmitsOrderedLayerEvents(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+	mustWriteFile(t, filepath.Join(dir, "worldbuilding", "城市規則.md"), "# 城市規則\n- 夜晚才會顯影\n")
+	mustWriteFile(t, filepath.Join(dir, "style", "主線敘事.md"), "# 風格：主線敘事\n- 語氣：克制\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"layer_mode": "pipeline",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pipeline stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	order := []string{
+		"event:layer_start\ndata:{\"label\":\"結構層\",\"layer\":\"structure\"}",
+		"event:layer_end\ndata:{\"layer\":\"structure\"}",
+		"event:layer_start\ndata:{\"label\":\"角色層\",\"layer\":\"character\"}",
+		"event:layer_end\ndata:{\"layer\":\"character\"}",
+		"event:layer_start\ndata:{\"label\":\"世界觀層\",\"layer\":\"world_logic\"}",
+		"event:layer_end\ndata:{\"layer\":\"world_logic\"}",
+		"event:layer_start\ndata:{\"label\":\"語言層\",\"layer\":\"language\"}",
+		"event:layer_end\ndata:{\"layer\":\"language\"}",
+	}
+
+	last := -1
+	for _, marker := range order {
+		idx := strings.Index(body, marker)
+		if idx < 0 {
+			t.Fatalf("expected marker %q in stream, got %s", marker, body)
+		}
+		if idx <= last {
+			t.Fatalf("expected ordered markers, got %s", body)
+		}
+		last = idx
+	}
+	if callCount != 4 {
+		t.Fatalf("expected 4 generate calls, got %d", callCount)
+	}
+}
+```
+
+- [ ] **Step 2: 寫 single regression e2e 測試**
+
+在同檔追加：
+
+```go
+func TestCheckStreamSingleDoesNotEmitLayerEvents(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"checks":     []string{"behavior"},
+		"layer_mode": "single",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("single stream failed: %s", string(resp.Body))
+	}
+	if strings.Contains(string(resp.Body), "event:layer_start") || strings.Contains(string(resp.Body), "event:layer_end") {
+		t.Fatalf("single mode should not emit layer events, got %s", string(resp.Body))
+	}
+}
+```
+
+- [ ] **Step 3: 跑測試確認先失敗**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckStreamPipelineEmitsOrderedLayerEvents|TestCheckStreamSingleDoesNotEmitLayerEvents" -count=1
+```
+
+Expected:
+
+- `pipeline` 測試 FAIL，因為目前尚未實作 layer event 與 pipeline path
+
+- [ ] **Step 4: 在 `review_layers.go` 實作 pipeline runner**
+
+新增 helper：
+
+```go
+func (s *Server) runPipelineReview(
+	ctx context.Context,
+	req checkRequest,
+	msgChan chan<- streamEvent,
+	transcript *strings.Builder,
+	worldStatePrefix string,
+) error {
+	layers := resolveReviewLayers(req)
+	if len(layers) == 0 {
+		return nil
+	}
+
+	charsToCheck := s.resolveCharacters(req)
+	behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
+	dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
+	worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
+
+	behaviorRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)
+	if err != nil {
+		return err
+	}
+	dialogueRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, dialogueOpts)
+	if err != nil {
+		return err
+	}
+	worldRefs, err := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, worldOpts)
+	if err != nil {
+		return err
+	}
+
+	allRefs := mergeReferenceLists(behaviorRefs, dialogueRefs, worldRefs)
+	if len(allRefs) > 0 {
+		msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(allRefs)}
+	}
+
+	for _, layer := range layers {
+		msgChan <- streamEvent{Event: "layer_start", Layer: layer.Name, Label: layer.Label}
+
+		cw := &chanWriter{ch: msgChan, transcript: transcript}
+		var layerErr error
+		switch layer.Name {
+		case "structure":
+			prompt := layer.Prompt + "\n\n【章節內容】\n" + req.Chapter
+			layerErr = s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, prompt, cw)
+		case "character":
+			var profiles []string
+			for _, ch := range charsToCheck {
+				profiles = append(profiles, ch.RawContent)
+			}
+			prompt := layer.Prompt + "\n\n【角色資料】\n" + strings.Join(profiles, "\n\n") + "\n\n【補充參考資料】\n" + joinProfiles(mergeReferenceLists(behaviorRefs, dialogueRefs)) + "\n\n【章節內容】\n" + req.Chapter
+			layerErr = s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, prompt, cw)
+		case "world_logic":
+			prompt := layer.Prompt + "\n\n【補充參考資料】\n" + joinProfiles(worldRefs) + "\n\n【章節內容】\n" + req.Chapter
+			layerErr = s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, prompt, cw)
+		case "language":
+			prompt := layer.Prompt + "\n\n【補充參考資料】\n" + joinProfiles(filterReferencesByType(allRefs, "style")) + "\n\n【章節內容】\n" + req.Chapter
+			layerErr = s.checker.RewriteChapterWithSystemStream(ctx, worldStatePrefix, prompt, cw)
+		}
+
+		if layerErr != nil {
+			if ctx.Err() == nil {
+				text := fmt.Sprintf("\n> 錯誤：%s\n", layerErr.Error())
+				transcript.WriteString(text)
+				msgChan <- streamEvent{Event: "chunk", Text: text}
+			}
+			return layerErr
+		}
+
+		msgChan <- streamEvent{Event: "layer_end", Layer: layer.Name}
+		msgChan <- streamEvent{Event: "chunk", Text: "\n"}
+		transcript.WriteString("\n")
+	}
+
+	return nil
+}
+```
+
+注意：
+
+- 第一版沿用既有 checker stream API，避免為這張票再抽新 checker abstraction
+- `checkRequest` 是擴充既有 struct，不可刪掉現有欄位
+- `structure` 層這裡先沿用通用 streaming 入口來發 token；若要避免「rewrite」語義命名不精準，可在後續小重構處理，不在本票擴 scope
+
+- [ ] **Step 5: 在 `handleCheckStream` 增加分流**
+
+在 goroutine 中，於既有 single flow 前加入：
+
+```go
+	mode := normalizedLayerMode(req.LayerMode)
+	if mode == "pipeline" {
+		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
+		if err := s.runPipelineReview(ctx, req, msgChan, &transcript, worldStatePrefix); err != nil {
+			return
+		}
+
+		completion := "\n\n---\n審查完成\n"
+		msgChan <- streamEvent{Event: "chunk", Text: completion}
+		transcript.WriteString(completion)
+		return
+	}
+```
+
+保留現有 single mode 流程原樣，不挪動既有行為。
+
+- [ ] **Step 6: 跑 pipeline/single e2e 測試**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckStreamPipelineEmitsOrderedLayerEvents|TestCheckStreamSingleDoesNotEmitLayerEvents" -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/server/review_layers.go internal/server/handlers.go internal/server/e2e_test.go
+git commit -m "feat: add pipeline review streaming"
+```
+
+## Task 4: 補齊 Pipeline Failure Path
+
+**Files:**
+- Modify: `internal/server/e2e_test.go`
+- Modify: `internal/server/review_layers.go`（僅在必要時）
+
+- [ ] **Step 1: 先寫 failure path e2e 測試**
+
+在 `internal/server/e2e_test.go` 新增：
+
+```go
+func TestCheckStreamPipelineStopsAfterLayerFailure(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			if callCount == 2 {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n- 說話風格：短句\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":    "林昊站在夜港塔下。",
+		"layer_mode": "pipeline",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pipeline stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+	if !strings.Contains(body, "event:layer_start") || !strings.Contains(body, "\"layer\":\"character\"") {
+		t.Fatalf("expected pipeline to reach failing layer, got %s", body)
+	}
+	if strings.Contains(body, "event:layer_end\ndata:{\"layer\":\"character\"}") {
+		t.Fatalf("failing layer must not emit layer_end, got %s", body)
+	}
+	if strings.Contains(body, "\"layer\":\"world_logic\"") || strings.Contains(body, "\"layer\":\"language\"") {
+		t.Fatalf("pipeline should stop after failing layer, got %s", body)
+	}
+	if !strings.Contains(body, "> 錯誤：") {
+		t.Fatalf("expected streamed error chunk, got %s", body)
+	}
+}
+```
+
+- [ ] **Step 2: 跑測試確認先紅燈**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckStreamPipelineStopsAfterLayerFailure" -count=1
+```
+
+Expected:
+
+- FAIL，直到 failure path 語義符合 spec
+
+- [ ] **Step 3: 修正 pipeline runner 直到失敗即中止**
+
+確認 `runPipelineReview(...)` 遵守：
+
+- 某層失敗時回傳 error
+- 失敗層不送 `layer_end`
+- 後續層不執行
+- 仍透過 `chunk` 送出錯誤訊息
+
+若 `Step 1` 測試已綠，這步只需保留程式碼不再更動。
+
+- [ ] **Step 4: 跑 failure path 測試**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckStreamPipelineStopsAfterLayerFailure" -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/e2e_test.go internal/server/review_layers.go
+git commit -m "test: cover pipeline failure path"
+```
+
+## Task 5: 前端加上模式切換與 Layer 顯示
+
+**Files:**
+- Modify: `web/templates/check.html`
+- Modify: `internal/server/templates_test.go`
+
+- [ ] **Step 1: 先寫 template 靜態驗證**
+
+在 `internal/server/templates_test.go` 新增：
+
+```go
+func TestCheckTemplateSupportsPipelineReviewMode(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile("../../web/templates/check.html")
+	if err != nil {
+		t.Fatalf("read check template: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "id=\"review-mode\"") {
+		t.Fatal("expected review mode selector in check template")
+	}
+	if !strings.Contains(text, "layer_start") || !strings.Contains(text, "layer_end") {
+		t.Fatal("expected layer event handlers in check template")
+	}
+	if !strings.Contains(text, "將固定依序執行：結構層、角色層、世界觀層、語言層") {
+		t.Fatal("expected pipeline helper text in check template")
+	}
+}
+```
+
+- [ ] **Step 2: 跑 template 測試確認先失敗**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckTemplateSupportsPipelineReviewMode" -count=1
+```
+
+Expected:
+
+- FAIL，因為前端尚未有 review mode UI 與 layer handlers
+
+- [ ] **Step 3: 在 `check.html` 新增模式切換與 UI 顯示邏輯**
+
+新增一段表單：
+
+```html
+<div class="form-group">
+  <label for="review-mode">審稿模式</label>
+  <select id="review-mode" onchange="syncReviewModeUI()">
+    <option value="single">單層</option>
+    <option value="pipeline">多層 Pipeline</option>
+  </select>
+  <div id="pipeline-mode-hint" class="helper-text" style="display:none;margin-top:8px">
+    將固定依序執行：結構層、角色層、世界觀層、語言層
+  </div>
+</div>
+```
+
+新增 JS helper：
+
+```js
+function syncReviewModeUI() {
+  const mode = document.getElementById('review-mode').value;
+  const checksGroup = document.querySelector('.form-group:has([name="checks"])');
+  const hint = document.getElementById('pipeline-mode-hint');
+  if (checksGroup) {
+    checksGroup.style.display = mode === 'pipeline' ? 'none' : 'block';
+  }
+  if (hint) {
+    hint.style.display = mode === 'pipeline' ? 'block' : 'none';
+  }
+}
+```
+
+並在 `DOMContentLoaded` 末尾呼叫一次：
+
+```js
+syncReviewModeUI();
+```
+
+注意：若 `:has()` 相容性是顧慮，改成直接給 checks 容器一個固定 `id="checks-group"`，由 JS 直接抓 ID；優先用固定 ID，避免 selector 相容性問題。
+
+- [ ] **Step 4: 在 SSE parser 新增 layer event 顯示**
+
+在 `runCheck()` 的 stream loop 與 buffer flush 分支中加入：
+
+```js
+function appendLayerHeading(label) {
+  const resultBox = document.getElementById('result-box');
+  if (resultBox.textContent && !resultBox.textContent.endsWith('\n')) {
+    resultBox.textContent += '\n';
+  }
+  resultBox.textContent += '── ' + label + ' ──\n';
+  resultBox.scrollTop = resultBox.scrollHeight;
+}
+```
+
+處理事件：
+
+```js
+if (parsed.eventName === 'layer_start') {
+  appendLayerHeading(parsed.payload.label || parsed.payload.layer || 'Layer');
+} else if (parsed.eventName === 'layer_end') {
+  appendResult('\n');
+}
+```
+
+送 request 時加入：
+
+```js
+layer_mode: document.getElementById('review-mode').value,
+```
+
+- [ ] **Step 5: 跑 template test**
+
+Run:
+
+```bash
+go test ./internal/server -run "TestCheckTemplateSupportsPipelineReviewMode" -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/templates/check.html internal/server/templates_test.go
+git commit -m "feat: add pipeline review mode ui"
+```
+
+## Task 6: 全面驗證與整理
+
+**Files:**
+- Modify: `internal/server/handlers.go`
+- Modify: `internal/server/review_layers.go`
+- Modify: `internal/server/handlers_test.go`
+- Modify: `internal/server/e2e_test.go`
+- Modify: `internal/server/templates_test.go`
+- Modify: `web/templates/check.html`
+
+- [ ] **Step 1: 格式化 Go 檔案**
+
+Run:
+
+```bash
+gofmt -w internal/server/handlers.go internal/server/review_layers.go internal/server/handlers_test.go internal/server/e2e_test.go internal/server/templates_test.go
+```
+
+Expected:
+
+- command succeeds with no error output
+
+- [ ] **Step 2: 跑 server focused tests**
+
+Run:
+
+```bash
+go test ./internal/server -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 3: 跑全測試**
+
+Run:
+
+```bash
+go test ./... -count=1
+```
+
+Expected:
+
+- PASS
+
+- [ ] **Step 4: 確認 gofmt 無漏**
+
+Run:
+
+```bash
+gofmt -l internal/server/handlers.go internal/server/review_layers.go internal/server/handlers_test.go internal/server/e2e_test.go internal/server/templates_test.go
+```
+
+Expected:
+
+- no output
+
+- [ ] **Step 5: 檢查變更範圍**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+- 只包含本計畫列出的檔案
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/handlers.go internal/server/review_layers.go internal/server/handlers_test.go internal/server/e2e_test.go internal/server/templates_test.go web/templates/check.html
+git commit -m "feat: add multi-layer review pipeline"
+```

--- a/plans/2026-04-21-issue-44-scene-aware-rag-timeline.md
+++ b/plans/2026-04-21-issue-44-scene-aware-rag-timeline.md
@@ -1,0 +1,49 @@
+# Issue #44 實作計畫：Scene-aware RAG timeline-bounded context retrieval
+
+狀態：進行中
+
+## 背景
+
+現有 `QueryFilteredScored` 只過濾 type，沒有依 `chapter_index` 排除未來章節向量。
+`chapter_index` 已正確寫入 vectorstore（`extractChapterIndex` 解析檔名），只差 retrieval 端過濾。
+
+## 架構決策
+
+- 只對 `type == "chapter"` 的 doc 套用 `before_chapter` 上界過濾；角色/世界觀/風格向量不受影響
+- `before_chapter` 由後端從 `chapterFile` 自動計算（`extractChapterIndex`），不需要前端手動傳遞
+- `retrievalOptions` 加入 `BeforeChapter int` 欄位供未來 override 保留彈性，但預設行為是自動填入
+- `retrievalSummary` 加入 `BeforeChapter int` 欄位，前端顯示「僅含第 N 章以前」
+
+## 待實作 Checklist
+
+- [ ] **Task 1**：`vectorstore.Store` 新增 `QueryFilteredBeforeChapter` 方法
+  - 簽名：`QueryFilteredBeforeChapter(queryVec []float64, topK int, types []string, threshold float64, beforeChapter int) []ScoredDocument`
+  - 只對 `type == "chapter"` 的 doc 做 `ChapterIndex >= beforeChapter` 排除（`beforeChapter <= 0` 代表不過濾）
+  - 補單元測試：`beforeChapter=0` 不過濾、`beforeChapter=3` 排除 idx≥3 的 chapter doc、非 chapter doc 不受影響
+
+- [ ] **Task 2**：`retrievalOptions` 加 `BeforeChapter int`；`retrievalSummary` 加 `BeforeChapter int`
+  - `mergeRetrieval` 傳遞 `BeforeChapter`（如果 override 有設才覆蓋）
+  - `summarizeRetrieval` 傳入 `beforeChapter` 寫入 summary
+
+- [ ] **Task 3**：`buildReferenceContext` 自動從 `chapterFile` 計算 `before_chapter` 並使用新 query 方法
+  - `before_chapter = extractChapterIndex(chapterFile)`；若 `chapterFile == ""` 或 `before_chapter == 0`，不過濾
+  - 若 `opts.BeforeChapter > 0`，以 opts 值優先（override 路徑）
+  - 呼叫 `QueryFilteredBeforeChapter` 取代 `QueryFilteredScored`
+
+- [ ] **Task 4**：前端 `check.html` `renderAppliedRetrieval` 顯示時間範圍
+  - 若 `cfg.before_chapter > 0`，在 retrieval 摘要行尾加上 ` / 限第 N 章以前`
+
+- [ ] **Task 5**：補 e2e 測試
+  - 情境：兩個 chapter 向量（index 2 和 index 5），`chapterFile` = index 3 的章節
+  - 驗證：retrieval 結果只含 index 2，不含 index 5
+
+- [ ] **Task 6**：`gofmt -l` 無輸出 + `go test ./...` 全過
+
+## 驗證方式
+
+```
+go test ./internal/vectorstore/... -v -run "TestQueryFilteredBeforeChapter"
+go test ./internal/server/... -v -run "TestBuildReferenceContextExcludesFutureChapters"
+go test ./... -timeout 120s
+gofmt -l internal/vectorstore/ internal/server/
+```

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -851,7 +851,8 @@ function renderAppliedRetrieval(tasks) {
     const sources = Array.isArray(cfg.sources) && cfg.sources.length
       ? cfg.sources.map(retrievalSourceLabel).join('、')
       : '無';
-    return `${retrievalTaskLabel(task)}：來源 ${sources} / Top-K ${Number(cfg.top_k || 0)} / 門檻 ${Number(cfg.threshold || 0).toFixed(2)}`;
+    const timeline = cfg.before_chapter > 0 ? ` / 限第 ${cfg.before_chapter} 章以前` : '';
+    return `${retrievalTaskLabel(task)}：來源 ${sources} / Top-K ${Number(cfg.top_k || 0)} / 門檻 ${Number(cfg.threshold || 0).toFixed(2)}${timeline}`;
   }).join('<br>');
 }
 

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -133,6 +133,21 @@
           </div>
 
           <div class="form-group">
+            <label>審稿模式</label>
+            <div class="radio-group" style="display:flex;gap:1.5rem">
+              <label class="checkbox-label">
+                <input type="radio" name="layer_mode" value="single" checked> 單層（原有模式）
+              </label>
+              <label class="checkbox-label">
+                <input type="radio" name="layer_mode" value="pipeline"> Pipeline（四層依序）
+              </label>
+            </div>
+            <div id="pipeline-hint" style="display:none;font-size:0.85rem;color:#64748b;margin-top:0.4rem">
+              將固定依序執行：結構層、角色層、世界觀層、語言層
+            </div>
+          </div>
+
+          <div class="form-group" id="checks-section">
             <label>審查項目</label>
             <div class="checkbox-group">
               <label class="checkbox-label">
@@ -362,7 +377,19 @@ let lastAppliedRetrieval = {};
 let tagPreviewVisible = false;
 let emotionChartInstance = null;
 
+function applyLayerMode(mode) {
+  const isPipeline = mode === 'pipeline';
+  document.getElementById('checks-section').style.display = isPipeline ? 'none' : '';
+  document.getElementById('pipeline-hint').style.display = isPipeline ? 'block' : 'none';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[name="layer_mode"]').forEach((el) => {
+    el.addEventListener('change', () => applyLayerMode(el.value));
+  });
+  const initialMode = document.querySelector('[name="layer_mode"]:checked');
+  if (initialMode) applyLayerMode(initialMode.value);
+
   const styleCheck = document.getElementById('check-style');
   if (styleCheck) {
     styleCheck.addEventListener('change', () => {
@@ -977,7 +1004,8 @@ async function runCheck() {
   if (!chapter) { alert('請先輸入章節內容'); return; }
 
   const characters = selectedCharacters();
-  const checks = Array.from(document.querySelectorAll('[name="checks"]:checked')).map(el => el.value);
+  const layerMode = (document.querySelector('[name="layer_mode"]:checked') || {}).value || 'single';
+  const checks = layerMode === 'pipeline' ? [] : Array.from(document.querySelectorAll('[name="checks"]:checked')).map(el => el.value);
   const styles = Array.from(document.querySelectorAll('[name="styles"]:checked')).map(el => el.value);
   const retrievalOverrides = buildCheckRetrievalOverrides(checks);
   const resultBox = document.getElementById('result-box');
@@ -1003,6 +1031,7 @@ async function runCheck() {
         characters,
         checks,
         styles,
+        layer_mode: layerMode,
         retrieval_overrides: retrievalOverrides,
         chapter_file: currentChapterFile,
         chapter_title: chapterTitleFromName(currentChapterFile || document.getElementById('chapter-file-name').value.trim()),
@@ -1034,6 +1063,10 @@ async function runCheck() {
         if (!parsed) continue;
         if (parsed.eventName === 'chunk') {
           appendResult(parsed.payload.text);
+        } else if (parsed.eventName === 'layer_start') {
+          appendResult('\n── ' + (parsed.payload.label || parsed.payload.layer) + ' ──\n');
+        } else if (parsed.eventName === 'layer_end') {
+          appendResult('\n');
         } else if (parsed.eventName === 'sources') {
           renderSources(parsed.payload.items || []);
         } else if (parsed.eventName === 'gaps') {
@@ -1050,6 +1083,8 @@ async function runCheck() {
       const parsed = parseSSEBlock(buffer);
       if (parsed) {
         if (parsed.eventName === 'chunk') appendResult(parsed.payload.text);
+        if (parsed.eventName === 'layer_start') appendResult('\n── ' + (parsed.payload.label || parsed.payload.layer) + ' ──\n');
+        if (parsed.eventName === 'layer_end') appendResult('\n');
         if (parsed.eventName === 'sources') renderSources(parsed.payload.items || []);
         if (parsed.eventName === 'gaps') renderGaps(parsed.payload);
         if (parsed.eventName === 'conflict') renderConflicts(parsed.payload.conflicts || []);

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -692,18 +692,21 @@ function renderSources(items) {
     return item.chapter_file || '';
   }
 
-  box.innerHTML = items.map(item => `
-    <div class="source-card">
-      <div class="source-meta">
-        <span class="source-type">${escapeHTML(item.type)}</span>
-        <strong>${escapeHTML(item.name)}</strong>
+  box.innerHTML = items.map(item => {
+    const location = formatSourceLocation(item);
+    return `
+      <div class="source-card">
+        <div class="source-meta">
+          <span class="source-type">${escapeHTML(item.type)}</span>
+          <strong>${escapeHTML(item.name)}</strong>
+        </div>
+        <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
+        ${location ? `<div class="helper-text">${escapeHTML(location)}</div>` : ''}
+        ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
+        <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
       </div>
-      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
-      ${formatSourceLocation(item) ? `<div class="helper-text">${escapeHTML(formatSourceLocation(item))}</div>` : ''}
-      ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
-      <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
-    </div>
-  `).join('');
+    `;
+  }).join('');
 }
 
 function renderGaps(gaps) {

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -678,15 +678,30 @@ function renderSources(items) {
     return;
   }
 
+  function formatSourceLocation(item) {
+    if (!item || item.type !== 'chapter') return '';
+    if (Number(item.chapter_index || 0) > 0) {
+      if (item.chunk_type === 'scene' && Number(item.scene_index || 0) > 0) {
+        return '第 ' + item.chapter_index + ' 章・Scene ' + item.scene_index;
+      }
+      if (item.chunk_type === 'paragraph' && Number(item.scene_index || 0) > 0) {
+        return '第 ' + item.chapter_index + ' 章・段落 ' + item.scene_index;
+      }
+      return '第 ' + item.chapter_index + ' 章';
+    }
+    return item.chapter_file || '';
+  }
+
   box.innerHTML = items.map(item => `
     <div class="source-card">
       <div class="source-meta">
-        <span class="source-type">${item.type}</span>
-        <strong>${item.name}</strong>
+        <span class="source-type">${escapeHTML(item.type)}</span>
+        <strong>${escapeHTML(item.name)}</strong>
       </div>
-      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${item.match_reason || '由向量相似度命中'}</div>
-      ${item.chapter_match ? `<div class="source-match">章節片段：${item.chapter_match}</div>` : ''}
-      <div class="source-excerpt">${item.excerpt || ''}</div>
+      <div class="helper-text">相似度 ${(Number(item.score || 0) * 100).toFixed(1)}% ・ ${escapeHTML(item.match_reason || '由向量相似度命中')}</div>
+      ${formatSourceLocation(item) ? `<div class="helper-text">${escapeHTML(formatSourceLocation(item))}</div>` : ''}
+      ${item.chapter_match ? `<div class="source-match">章節片段：${escapeHTML(item.chapter_match)}</div>` : ''}
+      <div class="source-excerpt">${escapeHTML(item.excerpt || '')}</div>
     </div>
   `).join('');
 }


### PR DESCRIPTION
## Summary

- `vectorstore.Store` 新增 `QueryFilteredBeforeChapter`：對 `type=chapter` 的 doc 排除 `ChapterIndex >= beforeChapter`；角色/世界觀/風格 doc 不受影響
- `retrievalOptions` 加 `BeforeChapter int`（允許手動 override）
- `retrievalSummary` 加 `BeforeChapter int`，SSE retrieval event 會帶出
- `buildReferenceContext` 新增 `resolveBeforeChapter` helper，自動從 `chapterFile` 透過 `extractChapterIndex` 計算上界
- 前端 `renderAppliedRetrieval` 當 `before_chapter > 0` 時顯示「限第 N 章以前」

## Test plan

- [x] `go test ./...` 全過
- [x] `gofmt -l`（所有修改檔案）無輸出
- [x] vectorstore 單元測試：`beforeChapter=0` 不過濾、`beforeChapter=3` 排除 idx≥3 的 chapter、非 chapter type 不受影響
- [x] e2e：審查第 03 章時，第 05 章 chunk 不出現在 sources，第 02 章正常出現

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)