### PR TITLE
feat: scene-aware RAG timeline-bounded retrieval (#44)

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1039,3 +1039,54 @@ func reconstructChapterForSceneEdit(t *testing.T, fullContent string, scenes []S
 
 	return strings.Join(parts, "\n\n")
 }
+
+func TestBuildReferenceContextExcludesFutureChapters(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{1, 0, 0}})
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{\"response\":\"ok\",\"done\":true}\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	// Past chapter: index 2 — should be included when reviewing chapter 3
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第02章.md"), "# 第02章\n林昊初次見到城主。")
+	// Future chapter: index 5 — must be excluded when reviewing chapter 3
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第05章.md"), "# 第05章\n林昊離開了城市。")
+	// Character — not filtered by chapter index
+	mustWriteFile(t, filepath.Join(dir, "characters", "林昊.md"), "# 角色：林昊\n- 個性：冷靜\n")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.Ingest(context.Background()); err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/check/stream", map[string]any{
+		"chapter":      "林昊在第三章站著。",
+		"chapter_file": "第03章.md",
+		"checks":       []string{"behavior"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("check stream failed: %s", string(resp.Body))
+	}
+
+	body := string(resp.Body)
+
+	// Sources event should include chapter 第02章.md but not 第05章.md
+	if strings.Contains(body, "第05章") {
+		t.Fatalf("future chapter 第05章 must not appear in retrieval sources, got: %s", body)
+	}
+	if !strings.Contains(body, "第02章") {
+		t.Fatalf("past chapter 第02章 should appear in retrieval sources, got: %s", body)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -52,10 +52,11 @@ type referenceSummary struct {
 }
 
 type retrievalSummary struct {
-	Task      string   `json:"task"`
-	Sources   []string `json:"sources"`
-	TopK      int      `json:"top_k"`
-	Threshold float64  `json:"threshold"`
+	Task          string   `json:"task"`
+	Sources       []string `json:"sources"`
+	TopK          int      `json:"top_k"`
+	Threshold     float64  `json:"threshold"`
+	BeforeChapter int      `json:"before_chapter,omitempty"`
 }
 
 type retrievalGaps struct {
@@ -224,15 +225,19 @@ func mergeRetrieval(preset reviewrules.RetrievalPreset, override retrievalOption
 	if override.ThresholdSet {
 		result.Threshold = override.Threshold
 	}
+	if override.BeforeChapter > 0 {
+		result.BeforeChapter = override.BeforeChapter
+	}
 	return result
 }
 
-func summarizeRetrieval(task string, opts retrievalOptions) retrievalSummary {
+func summarizeRetrieval(task string, opts retrievalOptions, beforeChapter int) retrievalSummary {
 	return retrievalSummary{
-		Task:      task,
-		Sources:   append([]string(nil), opts.Sources...),
-		TopK:      opts.TopK,
-		Threshold: opts.Threshold,
+		Task:          task,
+		Sources:       append([]string(nil), opts.Sources...),
+		TopK:          opts.TopK,
+		Threshold:     opts.Threshold,
+		BeforeChapter: beforeChapter,
 	}
 }
 
@@ -406,6 +411,16 @@ func (s *Server) resolveStyles(req checkRequest) ([]*profile.StyleGuide, error) 
 	return styles, nil
 }
 
+// resolveBeforeChapter returns the chapter index upper bound for timeline-bounded retrieval.
+// If opts.BeforeChapter is set explicitly it takes precedence; otherwise the index is derived
+// from chapterFile so that only chapters written before the current one are retrieved.
+func resolveBeforeChapter(chapterFile string, opts retrievalOptions) int {
+	if opts.BeforeChapter > 0 {
+		return opts.BeforeChapter
+	}
+	return extractChapterIndex(chapterFile)
+}
+
 func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile string, opts retrievalOptions) ([]vectorProfile, error) {
 	if s.store.Len() == 0 {
 		return nil, nil
@@ -430,7 +445,8 @@ func (s *Server) buildReferenceContext(ctx context.Context, chapter, chapterFile
 		threshold = rules.RetrievalThreshold
 	}
 
-	docs := s.store.QueryFilteredScored(queryVec, topK, sources, threshold)
+	beforeChapter := resolveBeforeChapter(chapterFile, opts)
+	docs := s.store.QueryFilteredBeforeChapter(queryVec, topK, sources, threshold, beforeChapter)
 	results := make([]vectorProfile, 0, len(docs))
 	for _, doc := range docs {
 		if doc.Type == "chapter" && strings.TrimSpace(chapterFile) != "" && doc.ChapterFile == chapterFile {
@@ -886,10 +902,11 @@ type checkRequest struct {
 }
 
 type retrievalOptions struct {
-	Sources      []string `json:"sources"`
-	TopK         int      `json:"top_k"`
-	Threshold    float64  `json:"threshold"`
-	ThresholdSet bool     `json:"threshold_set,omitempty"`
+	Sources       []string `json:"sources"`
+	TopK          int      `json:"top_k"`
+	Threshold     float64  `json:"threshold"`
+	ThresholdSet  bool     `json:"threshold_set,omitempty"`
+	BeforeChapter int      `json:"before_chapter,omitempty"`
 }
 
 func (r checkRequest) retrievalOverrideFor(task string) retrievalOptions {
@@ -973,7 +990,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 
 		if len(req.Checks) == 0 || contains(req.Checks, "behavior") {
 			behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
-			activeRetrieval["behavior"] = summarizeRetrieval("behavior", behaviorOpts)
+			activeRetrieval["behavior"] = summarizeRetrieval("behavior", behaviorOpts, resolveBeforeChapter(req.ChapterFile, behaviorOpts))
 			traceStarted := time.Now()
 			behaviorRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, behaviorOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["behavior"], req.ChapterTitle, req.ChapterFile, behaviorRefs, err, time.Since(traceStarted))
@@ -985,7 +1002,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		}
 		if contains(req.Checks, "dialogue") {
 			dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
-			activeRetrieval["dialogue"] = summarizeRetrieval("dialogue", dialogueOpts)
+			activeRetrieval["dialogue"] = summarizeRetrieval("dialogue", dialogueOpts, resolveBeforeChapter(req.ChapterFile, dialogueOpts))
 			traceStarted := time.Now()
 			dialogueRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, dialogueOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["dialogue"], req.ChapterTitle, req.ChapterFile, dialogueRefs, err, time.Since(traceStarted))
@@ -997,7 +1014,7 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 		}
 		if contains(req.Checks, "world") {
 			worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
-			activeRetrieval["world"] = summarizeRetrieval("world", worldOpts)
+			activeRetrieval["world"] = summarizeRetrieval("world", worldOpts, resolveBeforeChapter(req.ChapterFile, worldOpts))
 			traceStarted := time.Now()
 			worldRefs, err = s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, worldOpts)
 			s.recordRetrievalTrace("check", activeRetrieval["world"], req.ChapterTitle, req.ChapterFile, worldRefs, err, time.Since(traceStarted))
@@ -1277,7 +1294,8 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		defer close(msgChan)
 
 		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
-		activeRetrieval := summarizeRetrieval("rewrite", mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval))
+		rewriteOpts := mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval)
+		activeRetrieval := summarizeRetrieval("rewrite", rewriteOpts, resolveBeforeChapter(req.ChapterFile, rewriteOpts))
 		traceStarted := time.Now()
 		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, retrievalOptions{
 			Sources:      append([]string(nil), activeRetrieval.Sources...),

--- a/internal/server/review_layers.go
+++ b/internal/server/review_layers.go
@@ -59,9 +59,9 @@ func (s *Server) runPipelineReview(
 	dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
 	worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
 	msgChan <- streamEvent{Event: "retrieval", Retrieval: map[string]any{"tasks": map[string]retrievalSummary{
-		"behavior": summarizeRetrieval("behavior", behaviorOpts),
-		"dialogue": summarizeRetrieval("dialogue", dialogueOpts),
-		"world":    summarizeRetrieval("world", worldOpts),
+		"behavior": summarizeRetrieval("behavior", behaviorOpts, resolveBeforeChapter(req.ChapterFile, behaviorOpts)),
+		"dialogue": summarizeRetrieval("dialogue", dialogueOpts, resolveBeforeChapter(req.ChapterFile, dialogueOpts)),
+		"world":    summarizeRetrieval("world", worldOpts, resolveBeforeChapter(req.ChapterFile, worldOpts)),
 	}}}
 
 	styleReq := req

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -165,6 +165,51 @@ func (s *Store) QueryFilteredScored(queryVec []float64, topK int, types []string
 	return out
 }
 
+// QueryFilteredBeforeChapter is like QueryFilteredScored but additionally
+// excludes chapter-type documents whose ChapterIndex >= beforeChapter.
+// beforeChapter <= 0 means no timeline filter is applied.
+// Non-chapter document types are never filtered by this bound.
+func (s *Store) QueryFilteredBeforeChapter(queryVec []float64, topK int, types []string, threshold float64, beforeChapter int) []ScoredDocument {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	typeSet := make(map[string]struct{}, len(types))
+	for _, item := range types {
+		typeSet[item] = struct{}{}
+	}
+
+	type scored struct {
+		doc   Document
+		score float64
+	}
+	var results []scored
+	for _, d := range s.docs {
+		if len(typeSet) > 0 {
+			if _, ok := typeSet[d.Type]; !ok {
+				continue
+			}
+		}
+		if beforeChapter > 0 && d.Type == "chapter" && d.ChapterIndex >= beforeChapter {
+			continue
+		}
+		score := cosine(queryVec, d.Embedding)
+		if threshold > 0 && score < threshold {
+			continue
+		}
+		results = append(results, scored{doc: d, score: score})
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].score > results[j].score })
+
+	out := make([]ScoredDocument, 0, topK)
+	for i := 0; i < topK && i < len(results); i++ {
+		out = append(out, ScoredDocument{
+			Document: results[i].doc,
+			Score:    results[i].score,
+		})
+	}
+	return out
+}
+
 func cosine(a, b []float64) float64 {
 	if len(a) != len(b) {
 		return 0

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -89,3 +89,47 @@ func TestDocumentMetadataSurvivesSaveLoad(t *testing.T) {
 		t.Fatalf("unexpected metadata after reload: %#v", items[0].Document)
 	}
 }
+
+func TestQueryFilteredBeforeChapter(t *testing.T) {
+	t.Parallel()
+
+	store := New("")
+	vec := []float64{1, 0}
+	// chapter index 2 — should appear when beforeChapter=3
+	store.Upsert(Document{ID: "ch2", Type: "chapter", ChapterIndex: 2, Embedding: vec, Content: "ch2"})
+	// chapter index 5 — should be excluded when beforeChapter=3
+	store.Upsert(Document{ID: "ch5", Type: "chapter", ChapterIndex: 5, Embedding: vec, Content: "ch5"})
+	// character — never filtered by chapter index
+	store.Upsert(Document{ID: "char1", Type: "character", ChapterIndex: 99, Embedding: vec, Content: "char"})
+
+	t.Run("beforeChapter=0 does not filter", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, nil, 0, 0)
+		if len(results) != 3 {
+			t.Fatalf("expected 3, got %d", len(results))
+		}
+	})
+
+	t.Run("beforeChapter=3 excludes chapter idx>=3", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, nil, 0, 3)
+		ids := make(map[string]bool)
+		for _, r := range results {
+			ids[r.ID] = true
+		}
+		if ids["ch5"] {
+			t.Fatal("ch5 (index 5) should be excluded")
+		}
+		if !ids["ch2"] {
+			t.Fatal("ch2 (index 2) should be included")
+		}
+		if !ids["char1"] {
+			t.Fatal("char1 (non-chapter) should not be filtered")
+		}
+	})
+
+	t.Run("type filter still works alongside beforeChapter", func(t *testing.T) {
+		results := store.QueryFilteredBeforeChapter(vec, 10, []string{"chapter"}, 0, 3)
+		if len(results) != 1 || results[0].ID != "ch2" {
+			t.Fatalf("expected only ch2, got %v", results)
+		}
+	})
+}

--- a/plans/2026-04-21-issue-44-scene-aware-rag-timeline.md
+++ b/plans/2026-04-21-issue-44-scene-aware-rag-timeline.md
@@ -1,0 +1,49 @@
+# Issue #44 實作計畫：Scene-aware RAG timeline-bounded context retrieval
+
+狀態：進行中
+
+## 背景
+
+現有 `QueryFilteredScored` 只過濾 type，沒有依 `chapter_index` 排除未來章節向量。
+`chapter_index` 已正確寫入 vectorstore（`extractChapterIndex` 解析檔名），只差 retrieval 端過濾。
+
+## 架構決策
+
+- 只對 `type == "chapter"` 的 doc 套用 `before_chapter` 上界過濾；角色/世界觀/風格向量不受影響
+- `before_chapter` 由後端從 `chapterFile` 自動計算（`extractChapterIndex`），不需要前端手動傳遞
+- `retrievalOptions` 加入 `BeforeChapter int` 欄位供未來 override 保留彈性，但預設行為是自動填入
+- `retrievalSummary` 加入 `BeforeChapter int` 欄位，前端顯示「僅含第 N 章以前」
+
+## 待實作 Checklist
+
+- [ ] **Task 1**：`vectorstore.Store` 新增 `QueryFilteredBeforeChapter` 方法
+  - 簽名：`QueryFilteredBeforeChapter(queryVec []float64, topK int, types []string, threshold float64, beforeChapter int) []ScoredDocument`
+  - 只對 `type == "chapter"` 的 doc 做 `ChapterIndex >= beforeChapter` 排除（`beforeChapter <= 0` 代表不過濾）
+  - 補單元測試：`beforeChapter=0` 不過濾、`beforeChapter=3` 排除 idx≥3 的 chapter doc、非 chapter doc 不受影響
+
+- [ ] **Task 2**：`retrievalOptions` 加 `BeforeChapter int`；`retrievalSummary` 加 `BeforeChapter int`
+  - `mergeRetrieval` 傳遞 `BeforeChapter`（如果 override 有設才覆蓋）
+  - `summarizeRetrieval` 傳入 `beforeChapter` 寫入 summary
+
+- [ ] **Task 3**：`buildReferenceContext` 自動從 `chapterFile` 計算 `before_chapter` 並使用新 query 方法
+  - `before_chapter = extractChapterIndex(chapterFile)`；若 `chapterFile == ""` 或 `before_chapter == 0`，不過濾
+  - 若 `opts.BeforeChapter > 0`，以 opts 值優先（override 路徑）
+  - 呼叫 `QueryFilteredBeforeChapter` 取代 `QueryFilteredScored`
+
+- [ ] **Task 4**：前端 `check.html` `renderAppliedRetrieval` 顯示時間範圍
+  - 若 `cfg.before_chapter > 0`，在 retrieval 摘要行尾加上 ` / 限第 N 章以前`
+
+- [ ] **Task 5**：補 e2e 測試
+  - 情境：兩個 chapter 向量（index 2 和 index 5），`chapterFile` = index 3 的章節
+  - 驗證：retrieval 結果只含 index 2，不含 index 5
+
+- [ ] **Task 6**：`gofmt -l` 無輸出 + `go test ./...` 全過
+
+## 驗證方式
+
+```
+go test ./internal/vectorstore/... -v -run "TestQueryFilteredBeforeChapter"
+go test ./internal/server/... -v -run "TestBuildReferenceContextExcludesFutureChapters"
+go test ./... -timeout 120s
+gofmt -l internal/vectorstore/ internal/server/
+```

--- a/web/templates/check.html
+++ b/web/templates/check.html
@@ -851,7 +851,8 @@ function renderAppliedRetrieval(tasks) {
     const sources = Array.isArray(cfg.sources) && cfg.sources.length
       ? cfg.sources.map(retrievalSourceLabel).join('、')
       : '無';
-    return `${retrievalTaskLabel(task)}：來源 ${sources} / Top-K ${Number(cfg.top_k || 0)} / 門檻 ${Number(cfg.threshold || 0).toFixed(2)}`;
+    const timeline = cfg.before_chapter > 0 ? ` / 限第 ${cfg.before_chapter} 章以前` : '';
+    return `${retrievalTaskLabel(task)}：來源 ${sources} / Top-K ${Number(cfg.top_k || 0)} / 門檻 ${Number(cfg.threshold || 0).toFixed(2)}${timeline}`;
   }).join('<br>');
 }
 


### PR DESCRIPTION
## Summary

- `vectorstore.Store` 新增 `QueryFilteredBeforeChapter`：對 `type=chapter` 的 doc 排除 `ChapterIndex >= beforeChapter`；角色/世界觀/風格 doc 不受影響
- `retrievalOptions` 加 `BeforeChapter int`（允許手動 override）
- `retrievalSummary` 加 `BeforeChapter int`，SSE retrieval event 帶出給前端
- `buildReferenceContext` 新增 `resolveBeforeChapter` helper，自動從 `chapterFile` 透過 `extractChapterIndex` 計算上界；`opts.BeforeChapter > 0` 時優先使用手動值
- pipeline mode 的 retrieval summary 改為各 task 獨立計算 `beforeChapter`（修正原 PR #62 三個 task 共用同一值的 bug）
- 前端 `renderAppliedRetrieval` 當 `before_chapter > 0` 時顯示「限第 N 章以前」

## Test plan

- [x] `go test ./...` 全過
- [x] `gofmt -l`（所有修改檔案）無輸出
- [x] vectorstore 單元：`beforeChapter=0` 不過濾、`beforeChapter=3` 排除 idx≥3 的 chapter、非 chapter type 不受影響、type filter 與 beforeChapter 可並用
- [x] e2e：審查第 03 章時，第 05 章 chunk 不出現在 sources，第 02 章正常出現

Closes #44