### PR TITLE
feat: Hook Tracker — LLM auto-detection and confirm/dismiss (#45)

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -476,6 +476,44 @@ func (c *Checker) stream(ctx context.Context, system, prompt string, w io.Writer
 	return scanner.Err()
 }
 
+// HookCandidate is a potential foreshadowing element detected by the LLM.
+type HookCandidate struct {
+	Description string `json:"description"`
+	Context     string `json:"context"`
+	Confidence  string `json:"confidence"` // "高" | "中" | "低"
+}
+
+// ExtractHooks asks the LLM to detect potential foreshadowing elements in the
+// chapter and returns them as structured candidates for user confirmation.
+func (c *Checker) ExtractHooks(ctx context.Context, chapter string) ([]HookCandidate, error) {
+	prompt := fmt.Sprintf(`分析以下章節內容，找出潛在的伏筆元素（物件、謎題、承諾、暗示、未解答的問題）。
+對每個伏筆估計可信度（高/中/低）。
+輸出嚴格 JSON 陣列，不要有任何額外說明文字：
+[
+  {"description":"...","context":"...","confidence":"高|中|低"}
+]
+
+章節內容：
+%s
+`, chapter)
+
+	var buf strings.Builder
+	if err := c.stream(ctx, "你是專業小說伏筆分析師，只輸出 JSON，不輸出任何額外文字。請用繁體中文填寫欄位。", prompt, &buf); err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(buf.String())
+	start := strings.Index(raw, "[")
+	end := strings.LastIndex(raw, "]")
+	if start < 0 || end <= start {
+		return nil, fmt.Errorf("無法解析伏筆偵測回應")
+	}
+	var candidates []HookCandidate
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &candidates); err != nil {
+		return nil, fmt.Errorf("JSON 解析失敗：%w", err)
+	}
+	return candidates, nil
+}
+
 func ExtractNames(text string, knownNames []string) []string {
 	var found []string
 	for _, name := range knownNames {

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1090,3 +1090,127 @@ func TestBuildReferenceContextExcludesFutureChapters(t *testing.T) {
 		t.Fatalf("past chapter 第02章 should appear in retrieval sources, got: %s", body)
 	}
 }
+
+func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			w.Header().Set("Content-Type", "application/json")
+			// Return a valid JSON array of hook candidates.
+			_, _ = w.Write([]byte(`{"response":"[{\"description\":\"神秘信封\",\"context\":\"桌上\",\"confidence\":\"高\"}]","done":true}` + "\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	// detect: LLM should return one candidate
+	detectResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "林昊看到桌上的信封，沒有打開。",
+		"chapter_index": 3,
+	})
+	if detectResp.StatusCode != http.StatusOK {
+		t.Fatalf("detect failed: %s", string(detectResp.Body))
+	}
+	var detectPayload struct {
+		Pending []struct {
+			ID           string `json:"id"`
+			Description  string `json:"description"`
+			ChapterIndex int    `json:"chapter_index"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal(detectResp.Body, &detectPayload); err != nil {
+		t.Fatalf("decode detect response: %v", err)
+	}
+	if len(detectPayload.Pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d: %s", len(detectPayload.Pending), string(detectResp.Body))
+	}
+	if detectPayload.Pending[0].ChapterIndex != 3 {
+		t.Fatalf("expected chapter_index 3, got %d", detectPayload.Pending[0].ChapterIndex)
+	}
+	pendingID := detectPayload.Pending[0].ID
+
+	// second detect on same chapter_index should replace, not accumulate
+	detectResp2 := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "林昊又看了一眼信封。",
+		"chapter_index": 3,
+	})
+	if detectResp2.StatusCode != http.StatusOK {
+		t.Fatalf("second detect failed: %s", string(detectResp2.Body))
+	}
+	var detectPayload2 struct {
+		Pending []struct{ ID string `json:"id"` } `json:"pending"`
+	}
+	if err := json.Unmarshal(detectResp2.Body, &detectPayload2); err != nil {
+		t.Fatalf("decode second detect: %v", err)
+	}
+	if len(detectPayload2.Pending) != 1 {
+		t.Fatalf("expected pending list replaced (1 item), got %d", len(detectPayload2.Pending))
+	}
+	pendingID2 := detectPayload2.Pending[0].ID
+
+	// dismiss the new pending
+	dismissResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/dismiss", map[string]any{"id": pendingID2})
+	if dismissResp.StatusCode != http.StatusOK {
+		t.Fatalf("dismiss failed: %s", string(dismissResp.Body))
+	}
+
+	// re-detect to get a fresh pending for confirm test
+	detectResp3 := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "林昊盯著信封。",
+		"chapter_index": 3,
+	})
+	if detectResp3.StatusCode != http.StatusOK {
+		t.Fatalf("third detect failed: %s", string(detectResp3.Body))
+	}
+	var detectPayload3 struct {
+		Pending []struct{ ID string `json:"id"` } `json:"pending"`
+	}
+	if err := json.Unmarshal(detectResp3.Body, &detectPayload3); err != nil {
+		t.Fatalf("decode third detect: %v", err)
+	}
+	if len(detectPayload3.Pending) != 1 {
+		t.Fatalf("expected 1 pending after re-detect, got %d", len(detectPayload3.Pending))
+	}
+	_ = pendingID // first pending was replaced; variable kept for clarity
+
+	// confirm: invalid chapter should return 400
+	badConfirm := performJSONRequest(t, app.URL, "POST", "/foreshadow/confirm", map[string]any{
+		"id": detectPayload3.Pending[0].ID, "chapter": 0, "planted_in": "",
+	})
+	if badConfirm.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for chapter=0, got %d", badConfirm.StatusCode)
+	}
+
+	// confirm with valid chapter
+	confirmResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/confirm", map[string]any{
+		"id": detectPayload3.Pending[0].ID, "chapter": 3, "planted_in": "桌上的信",
+	})
+	if confirmResp.StatusCode != http.StatusOK {
+		t.Fatalf("confirm failed: %s", string(confirmResp.Body))
+	}
+
+	// stale: confirmed item planted at ch3, current=7, threshold=3 → stale
+	staleResp := performJSONRequest(t, app.URL, "GET", "/api/foreshadow/stale?current_chapter=7&threshold=3", nil)
+	if staleResp.StatusCode != http.StatusOK {
+		t.Fatalf("stale failed: %s", string(staleResp.Body))
+	}
+	var stalePayload struct {
+		Items []struct {
+			Description string `json:"description"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(staleResp.Body, &stalePayload); err != nil {
+		t.Fatalf("decode stale: %v", err)
+	}
+	if len(stalePayload.Items) != 1 {
+		t.Fatalf("expected 1 stale item, got %d: %s", len(stalePayload.Items), string(staleResp.Body))
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1146,7 +1146,9 @@ func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
 		t.Fatalf("second detect failed: %s", string(detectResp2.Body))
 	}
 	var detectPayload2 struct {
-		Pending []struct{ ID string `json:"id"` } `json:"pending"`
+		Pending []struct {
+			ID string `json:"id"`
+		} `json:"pending"`
 	}
 	if err := json.Unmarshal(detectResp2.Body, &detectPayload2); err != nil {
 		t.Fatalf("decode second detect: %v", err)
@@ -1171,7 +1173,9 @@ func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
 		t.Fatalf("third detect failed: %s", string(detectResp3.Body))
 	}
 	var detectPayload3 struct {
-		Pending []struct{ ID string `json:"id"` } `json:"pending"`
+		Pending []struct {
+			ID string `json:"id"`
+		} `json:"pending"`
 	}
 	if err := json.Unmarshal(detectResp3.Body, &detectPayload3); err != nil {
 		t.Fatalf("decode third detect: %v", err)

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1111,6 +1111,14 @@ func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
 	app := httptest.NewServer(s.router)
 	defer app.Close()
 
+	// detect: missing chapter_index should return 400
+	badDetect := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter": "林昊看到桌上的信封，沒有打開。",
+	})
+	if badDetect.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing chapter_index, got %d", badDetect.StatusCode)
+	}
+
 	// detect: LLM should return one candidate
 	detectResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
 		"chapter":       "林昊看到桌上的信封，沒有打開。",
@@ -1202,7 +1210,7 @@ func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
 	}
 
 	// stale: confirmed item planted at ch3, current=7, threshold=3 → stale
-	staleResp := performJSONRequest(t, app.URL, "GET", "/api/foreshadow/stale?current_chapter=7&threshold=3", nil)
+	staleResp := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=7&threshold=3", nil)
 	if staleResp.StatusCode != http.StatusOK {
 		t.Fatalf("stale failed: %s", string(staleResp.Body))
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -841,9 +841,11 @@ func (s *Server) handleDiagnosticsPage(c *gin.Context) {
 }
 
 func (s *Server) handleForeshadowPage(c *gin.Context) {
+	pending := s.foreshadow.GetPending()
 	c.HTML(http.StatusOK, "foreshadow.html", gin.H{
 		"Title":       "伏筆追蹤",
 		"Foreshadows": s.foreshadow.GetAll(),
+		"Pending":     pending,
 	})
 }
 
@@ -1532,6 +1534,96 @@ func (s *Server) handleDeleteForeshadow(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+func (s *Server) handleDetectForeshadow(c *gin.Context) {
+	var req struct {
+		Chapter      string `json:"chapter"`
+		ChapterIndex int    `json:"chapter_index"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(req.Chapter) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可為空"})
+		return
+	}
+	candidates, err := s.checker.ExtractHooks(c.Request.Context(), req.Chapter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	hooks := make([]tracker.PendingHook, len(candidates))
+	for i, cand := range candidates {
+		hooks[i] = tracker.PendingHook{
+			Description: cand.Description,
+			Context:     cand.Context,
+			Confidence:  cand.Confidence,
+		}
+	}
+	s.foreshadow.AddPending(hooks)
+	if !saveOrAbort(c, s.foreshadow.Save(), "save foreshadow") {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"pending": s.foreshadow.GetPending()})
+}
+
+func (s *Server) handleConfirmForeshadow(c *gin.Context) {
+	var req struct {
+		ID        string `json:"id"`
+		Chapter   int    `json:"chapter"`
+		PlantedIn string `json:"planted_in"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if !s.foreshadow.ConfirmPending(req.ID, req.Chapter, req.PlantedIn) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pending hook not found"})
+		return
+	}
+	if !saveOrAbort(c, s.foreshadow.Save(), "save foreshadow") {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "pending": s.foreshadow.GetPending()})
+}
+
+func (s *Server) handleDismissForeshadow(c *gin.Context) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if !s.foreshadow.DismissPending(req.ID) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "pending hook not found"})
+		return
+	}
+	if !saveOrAbort(c, s.foreshadow.Save(), "save foreshadow") {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true, "pending": s.foreshadow.GetPending()})
+}
+
+func (s *Server) handleStaleForeshadow(c *gin.Context) {
+	currentChapter, err := parsePositiveChapter(c.Query("current_chapter"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "current_chapter 必須為正整數"})
+		return
+	}
+	threshold := 3
+	if t := c.Query("threshold"); t != "" {
+		if v, err := parsePositiveChapter(t); err == nil {
+			threshold = v
+		}
+	}
+	stale := s.foreshadow.StaleForeshadows(currentChapter, threshold)
+	if stale == nil {
+		stale = []*tracker.Foreshadowing{}
+	}
+	c.JSON(http.StatusOK, gin.H{"items": stale})
 }
 
 // ─── export ───────────────────────────────────────────────────────────────────

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1557,9 +1557,10 @@ func (s *Server) handleDetectForeshadow(c *gin.Context) {
 	hooks := make([]tracker.PendingHook, len(candidates))
 	for i, cand := range candidates {
 		hooks[i] = tracker.PendingHook{
-			Description: cand.Description,
-			Context:     cand.Context,
-			Confidence:  cand.Confidence,
+			Description:  cand.Description,
+			Context:      cand.Context,
+			Confidence:   cand.Confidence,
+			ChapterIndex: req.ChapterIndex,
 		}
 	}
 	s.foreshadow.AddPending(hooks)
@@ -1577,6 +1578,10 @@ func (s *Server) handleConfirmForeshadow(c *gin.Context) {
 	}
 	if err := c.BindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Chapter <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "chapter 必須為正整數"})
 		return
 	}
 	if !s.foreshadow.ConfirmPending(req.ID, req.Chapter, req.PlantedIn) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1549,6 +1549,10 @@ func (s *Server) handleDetectForeshadow(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可為空"})
 		return
 	}
+	if len(req.Chapter) > 20000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可超過 20000 字元"})
+		return
+	}
 	if req.ChapterIndex < 1 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "chapter_index 必須為正整數"})
 		return
@@ -1624,9 +1628,12 @@ func (s *Server) handleStaleForeshadow(c *gin.Context) {
 	}
 	threshold := 3
 	if t := c.Query("threshold"); t != "" {
-		if v, err := parsePositiveChapter(t); err == nil {
-			threshold = v
+		v, err := parsePositiveChapter(t)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "threshold 必須為正整數"})
+			return
 		}
+		threshold = v
 	}
 	stale := s.foreshadow.StaleForeshadows(currentChapter, threshold)
 	if stale == nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1549,6 +1549,10 @@ func (s *Server) handleDetectForeshadow(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可為空"})
 		return
 	}
+	if req.ChapterIndex < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "chapter_index 必須為正整數"})
+		return
+	}
 	candidates, err := s.checker.ExtractHooks(c.Request.Context(), req.Chapter)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -198,6 +198,10 @@ func (s *Server) setupRoutes() {
 	protected.POST("/foreshadow", s.handleAddForeshadow)
 	protected.POST("/foreshadow/resolve", s.handleResolveForeshadow)
 	protected.POST("/foreshadow/delete", s.handleDeleteForeshadow)
+	protected.POST("/foreshadow/detect", s.handleDetectForeshadow)
+	protected.POST("/foreshadow/confirm", s.handleConfirmForeshadow)
+	protected.POST("/foreshadow/dismiss", s.handleDismissForeshadow)
+	protected.GET("/api/foreshadow/stale", s.handleStaleForeshadow)
 
 	protected.POST("/export", s.handleExport)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -201,7 +201,7 @@ func (s *Server) setupRoutes() {
 	protected.POST("/foreshadow/detect", s.handleDetectForeshadow)
 	protected.POST("/foreshadow/confirm", s.handleConfirmForeshadow)
 	protected.POST("/foreshadow/dismiss", s.handleDismissForeshadow)
-	protected.GET("/api/foreshadow/stale", s.handleStaleForeshadow)
+	protected.GET("/foreshadow/stale", s.handleStaleForeshadow)
 
 	protected.POST("/export", s.handleExport)
 }

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -9,19 +9,35 @@ import (
 )
 
 type Foreshadowing struct {
-	ID          string    `json:"id"`
-	Chapter     int       `json:"chapter"`
-	Description string    `json:"description"`
-	PlantedIn   string    `json:"planted_in"`
-	ResolvedIn  string    `json:"resolved_in"`
-	Status      string    `json:"status"` // "未回收" | "已回收"
-	CreatedAt   time.Time `json:"created_at"`
+	ID              string    `json:"id"`
+	Chapter         int       `json:"chapter"`
+	Description     string    `json:"description"`
+	PlantedIn       string    `json:"planted_in"`
+	ResolvedIn      string    `json:"resolved_in"`
+	Status          string    `json:"status"` // "未回收" | "已回收"
+	LastSeenChapter int       `json:"last_seen_chapter,omitempty"`
+	Confidence      string    `json:"confidence,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// PendingHook is an LLM-suggested hook awaiting user confirmation.
+type PendingHook struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Context     string `json:"context"`
+	Confidence  string `json:"confidence"`
+}
+
+type foreshadowStore struct {
+	Items   []*Foreshadowing `json:"items"`
+	Pending []*PendingHook   `json:"pending,omitempty"`
 }
 
 type ForeshadowTracker struct {
-	mu    sync.RWMutex
-	Items []*Foreshadowing `json:"items"`
-	path  string
+	mu      sync.RWMutex
+	Items   []*Foreshadowing `json:"items"`
+	Pending []*PendingHook   `json:"pending,omitempty"`
+	path    string
 }
 
 func NewForeshadowTracker(path string) *ForeshadowTracker {
@@ -38,13 +54,20 @@ func (t *ForeshadowTracker) Load() error {
 	if err != nil {
 		return err
 	}
+	// Try new wrapper format first; fall back to legacy array format.
+	var store foreshadowStore
+	if json.Unmarshal(data, &store) == nil && (store.Items != nil || store.Pending != nil) {
+		t.Items = store.Items
+		t.Pending = store.Pending
+		return nil
+	}
 	return json.Unmarshal(data, &t.Items)
 }
 
 func (t *ForeshadowTracker) Save() error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	data, _ := json.MarshalIndent(t.Items, "", "  ")
+	data, _ := json.MarshalIndent(foreshadowStore{Items: t.Items, Pending: t.Pending}, "", "  ")
 	return os.WriteFile(t.path, data, 0644)
 }
 
@@ -88,4 +111,93 @@ func (t *ForeshadowTracker) GetAll() []*Foreshadowing {
 	result := make([]*Foreshadowing, len(t.Items))
 	copy(result, t.Items)
 	return result
+}
+
+// AddPending appends LLM-suggested hooks awaiting user confirmation.
+func (t *ForeshadowTracker) AddPending(hooks []PendingHook) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range hooks {
+		h := hooks[i]
+		h.ID = fmt.Sprintf("ph_%d_%d", time.Now().UnixNano(), i)
+		t.Pending = append(t.Pending, &h)
+	}
+}
+
+// GetPending returns a copy of all pending hooks.
+func (t *ForeshadowTracker) GetPending() []PendingHook {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]PendingHook, len(t.Pending))
+	for i, p := range t.Pending {
+		out[i] = *p
+	}
+	return out
+}
+
+// ConfirmPending moves a pending hook into the confirmed Items list.
+// Returns false if the id is not found.
+func (t *ForeshadowTracker) ConfirmPending(id string, chapter int, plantedIn string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var remaining []*PendingHook
+	found := false
+	for _, p := range t.Pending {
+		if p.ID == id {
+			found = true
+			f := &Foreshadowing{
+				ID:          fmt.Sprintf("fs_%d", time.Now().UnixNano()),
+				Chapter:     chapter,
+				Description: p.Description,
+				PlantedIn:   plantedIn,
+				Status:      "未回收",
+				Confidence:  p.Confidence,
+				CreatedAt:   time.Now(),
+			}
+			t.Items = append(t.Items, f)
+		} else {
+			remaining = append(remaining, p)
+		}
+	}
+	t.Pending = remaining
+	return found
+}
+
+// DismissPending removes a pending hook without adding it to Items.
+func (t *ForeshadowTracker) DismissPending(id string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var remaining []*PendingHook
+	found := false
+	for _, p := range t.Pending {
+		if p.ID == id {
+			found = true
+		} else {
+			remaining = append(remaining, p)
+		}
+	}
+	t.Pending = remaining
+	return found
+}
+
+// StaleForeshadows returns unresolved hooks whose LastSeenChapter is more
+// than threshold chapters before currentChapter.
+// Hooks with LastSeenChapter == 0 use their planted Chapter as baseline.
+func (t *ForeshadowTracker) StaleForeshadows(currentChapter, threshold int) []*Foreshadowing {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var out []*Foreshadowing
+	for _, item := range t.Items {
+		if item.Status == "已回收" {
+			continue
+		}
+		baseline := item.LastSeenChapter
+		if baseline == 0 {
+			baseline = item.Chapter
+		}
+		if currentChapter-baseline >= threshold {
+			out = append(out, item)
+		}
+	}
+	return out
 }

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -37,8 +37,8 @@ type foreshadowStore struct {
 
 type ForeshadowTracker struct {
 	mu      sync.RWMutex
-	Items   []*Foreshadowing `json:"items"`
-	Pending []*PendingHook   `json:"pending,omitempty"`
+	Items   []*Foreshadowing
+	Pending []*PendingHook
 	path    string
 }
 
@@ -120,7 +120,8 @@ func (t *ForeshadowTracker) GetAll() []*Foreshadowing {
 
 // AddPending replaces any existing pending hooks for the same ChapterIndex
 // and appends the new suggestions. If ChapterIndex == 0 all previous pending
-// hooks are cleared before appending.
+// hooks are cleared before appending. All hooks in the batch must share the
+// same ChapterIndex; only hooks[0].ChapterIndex is used to determine scope.
 func (t *ForeshadowTracker) AddPending(hooks []PendingHook) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -164,14 +165,15 @@ func (t *ForeshadowTracker) ConfirmPending(id string, chapter int, plantedIn str
 	for _, p := range t.Pending {
 		if p.ID == id {
 			found = true
+			now := time.Now()
 			f := &Foreshadowing{
-				ID:          fmt.Sprintf("fs_%d", time.Now().UnixNano()),
+				ID:          fmt.Sprintf("fs_%d", now.UnixNano()),
 				Chapter:     chapter,
 				Description: p.Description,
 				PlantedIn:   plantedIn,
 				Status:      "未回收",
 				Confidence:  p.Confidence,
-				CreatedAt:   time.Now(),
+				CreatedAt:   now,
 			}
 			t.Items = append(t.Items, f)
 		} else {

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -215,7 +215,8 @@ func (t *ForeshadowTracker) StaleForeshadows(currentChapter, threshold int) []*F
 			baseline = item.Chapter
 		}
 		if currentChapter-baseline >= threshold {
-			out = append(out, item)
+			cp := *item
+			out = append(out, &cp)
 		}
 	}
 	return out

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -1,6 +1,7 @@
 package tracker
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -22,10 +23,11 @@ type Foreshadowing struct {
 
 // PendingHook is an LLM-suggested hook awaiting user confirmation.
 type PendingHook struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	Context     string `json:"context"`
-	Confidence  string `json:"confidence"`
+	ID           string `json:"id"`
+	Description  string `json:"description"`
+	Context      string `json:"context"`
+	Confidence   string `json:"confidence"`
+	ChapterIndex int    `json:"chapter_index,omitempty"`
 }
 
 type foreshadowStore struct {
@@ -54,9 +56,12 @@ func (t *ForeshadowTracker) Load() error {
 	if err != nil {
 		return err
 	}
-	// Try new wrapper format first; fall back to legacy array format.
-	var store foreshadowStore
-	if json.Unmarshal(data, &store) == nil && (store.Items != nil || store.Pending != nil) {
+	// Distinguish new wrapper format {"items":...} from legacy plain array.
+	if trimmed := bytes.TrimSpace(data); len(trimmed) > 0 && trimmed[0] == '{' {
+		var store foreshadowStore
+		if err := json.Unmarshal(data, &store); err != nil {
+			return err
+		}
 		t.Items = store.Items
 		t.Pending = store.Pending
 		return nil
@@ -113,13 +118,27 @@ func (t *ForeshadowTracker) GetAll() []*Foreshadowing {
 	return result
 }
 
-// AddPending appends LLM-suggested hooks awaiting user confirmation.
+// AddPending replaces any existing pending hooks for the same ChapterIndex
+// and appends the new suggestions. If ChapterIndex == 0 all previous pending
+// hooks are cleared before appending.
 func (t *ForeshadowTracker) AddPending(hooks []PendingHook) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if len(hooks) == 0 {
+		return
+	}
+	chapterIndex := hooks[0].ChapterIndex
+	var kept []*PendingHook
+	for _, p := range t.Pending {
+		if chapterIndex == 0 || p.ChapterIndex != chapterIndex {
+			kept = append(kept, p)
+		}
+	}
+	t.Pending = kept
+	now := time.Now().UnixNano()
 	for i := range hooks {
 		h := hooks[i]
-		h.ID = fmt.Sprintf("ph_%d_%d", time.Now().UnixNano(), i)
+		h.ID = fmt.Sprintf("ph_%d_%d", now, i)
 		t.Pending = append(t.Pending, &h)
 	}
 }

--- a/internal/tracker/foreshadow_test.go
+++ b/internal/tracker/foreshadow_test.go
@@ -103,10 +103,9 @@ func TestStaleForeshadows(t *testing.T) {
 	tr.Add(&Foreshadowing{Chapter: 1, Description: "舊伏筆"})
 	// planted ch4, seen at ch4 → not stale at current=5
 	tr.Add(&Foreshadowing{Chapter: 4, Description: "新伏筆", LastSeenChapter: 4})
-	// resolved → not counted
-	tr.Add(&Foreshadowing{Chapter: 1, Description: "已回收", Status: "已回收"})
-
-	// Fix status of first two (Add sets status)
+	// resolved → not included in stale results
+	// Add() always forces Status="未回收"; override directly since we are in the same package.
+	tr.Add(&Foreshadowing{Chapter: 1, Description: "已回收伏筆"})
 	tr.Items[2].Status = "已回收"
 
 	stale := tr.StaleForeshadows(5, 3)

--- a/internal/tracker/foreshadow_test.go
+++ b/internal/tracker/foreshadow_test.go
@@ -1,0 +1,125 @@
+package tracker
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestForeshadowTrackerSaveLoadRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "foreshadow.json")
+	tr := NewForeshadowTracker(path)
+	tr.Add(&Foreshadowing{Chapter: 2, Description: "神秘信封", PlantedIn: "桌上的信"})
+	hooks := []PendingHook{{Description: "破損徽章", Context: "地板上", Confidence: "高"}}
+	tr.AddPending(hooks)
+	if err := tr.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	tr2 := NewForeshadowTracker(path)
+	if err := tr2.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(tr2.Items) != 1 || tr2.Items[0].Description != "神秘信封" {
+		t.Fatalf("unexpected items: %#v", tr2.Items)
+	}
+	if len(tr2.Pending) != 1 || tr2.Pending[0].Description != "破損徽章" {
+		t.Fatalf("unexpected pending: %#v", tr2.Pending)
+	}
+}
+
+func TestForeshadowTrackerLegacyArrayLoad(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "foreshadow.json")
+	// Write old-format JSON (plain array)
+	old := []*Foreshadowing{{ID: "fs_old", Chapter: 1, Description: "古老伏筆", Status: "未回收"}}
+	data, _ := json.MarshalIndent(old, "", "  ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	tr := NewForeshadowTracker(path)
+	if err := tr.Load(); err != nil {
+		t.Fatalf("load legacy: %v", err)
+	}
+	if len(tr.Items) != 1 || tr.Items[0].Description != "古老伏筆" {
+		t.Fatalf("unexpected items after legacy load: %#v", tr.Items)
+	}
+}
+
+func TestConfirmPendingMovesToItems(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	tr.AddPending([]PendingHook{{Description: "遺失的鑰匙", Context: "抽屜", Confidence: "中"}})
+	pending := tr.GetPending()
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(pending))
+	}
+	id := pending[0].ID
+
+	if !tr.ConfirmPending(id, 3, "林昊隨手扔進口袋") {
+		t.Fatal("expected ConfirmPending to return true")
+	}
+	if len(tr.GetPending()) != 0 {
+		t.Fatal("pending should be empty after confirm")
+	}
+	items := tr.GetAll()
+	if len(items) != 1 || items[0].Description != "遺失的鑰匙" {
+		t.Fatalf("unexpected items after confirm: %#v", items)
+	}
+	if items[0].Chapter != 3 || items[0].PlantedIn != "林昊隨手扔進口袋" {
+		t.Fatalf("unexpected item fields: %#v", items[0])
+	}
+}
+
+func TestDismissPendingRemovesWithoutAdding(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	tr.AddPending([]PendingHook{{Description: "神秘聲音", Confidence: "低"}})
+	id := tr.GetPending()[0].ID
+
+	if !tr.DismissPending(id) {
+		t.Fatal("expected DismissPending to return true")
+	}
+	if len(tr.GetPending()) != 0 {
+		t.Fatal("pending should be empty after dismiss")
+	}
+	if len(tr.GetAll()) != 0 {
+		t.Fatal("items should remain empty after dismiss")
+	}
+}
+
+func TestStaleForeshadows(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	// planted ch1, not seen since → stale when current=5, threshold=3
+	tr.Add(&Foreshadowing{Chapter: 1, Description: "舊伏筆"})
+	// planted ch4, seen at ch4 → not stale at current=5
+	tr.Add(&Foreshadowing{Chapter: 4, Description: "新伏筆", LastSeenChapter: 4})
+	// resolved → not counted
+	tr.Add(&Foreshadowing{Chapter: 1, Description: "已回收", Status: "已回收"})
+
+	// Fix status of first two (Add sets status)
+	tr.Items[2].Status = "已回收"
+
+	stale := tr.StaleForeshadows(5, 3)
+	if len(stale) != 1 || stale[0].Description != "舊伏筆" {
+		t.Fatalf("expected only 舊伏筆, got %#v", stale)
+	}
+}
+
+func TestConfirmPendingReturnsFalseForMissingID(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	if tr.ConfirmPending("nonexistent", 1, "") {
+		t.Fatal("expected false for missing id")
+	}
+}

--- a/web/templates/foreshadow.html
+++ b/web/templates/foreshadow.html
@@ -46,7 +46,7 @@
                 </div>
               </div>
               <div style="display:flex;flex-direction:column;gap:4px;white-space:nowrap">
-                <button class="btn btn-sm btn-success" onclick="confirmHook('{{.ID}}')">確認採用</button>
+                <button class="btn btn-sm btn-success" onclick="confirmHook('{{.ID}}', {{.ChapterIndex}})">確認採用</button>
                 <button class="btn btn-sm btn-ghost" onclick="dismissHook('{{.ID}}')">忽略</button>
               </div>
             </div>
@@ -209,16 +209,19 @@ function renderPending(pending, chapter) {
 }
 
 async function confirmHook(id, chapter) {
+  let chapterNum = parseInt(chapter, 10);
+  if (!chapterNum || chapterNum < 1) {
+    const input = prompt('請輸入此伏筆所在章節編號：');
+    chapterNum = parseInt(input, 10);
+    if (!chapterNum || chapterNum < 1) { alert('章節編號無效'); return; }
+  }
   const planted = prompt('請描述伏筆埋下方式（可留空）：') ?? '';
   const resp = await fetch('/foreshadow/confirm', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id, chapter: chapter || 0, planted_in: planted }),
+    body: JSON.stringify({ id, chapter: chapterNum, planted_in: planted }),
   });
   if (!resp.ok) { alert('確認失敗'); return; }
-  const data = await resp.json();
-  document.getElementById('ph-' + id)?.remove();
-  renderPending(data.pending || [], chapter);
   location.reload();
 }
 

--- a/web/templates/foreshadow.html
+++ b/web/templates/foreshadow.html
@@ -16,11 +16,51 @@
       <p>記錄埋下的伏筆，追蹤是否已在後續章節回收</p>
     </div>
 
+    <!-- 自動偵測區 -->
+    <div class="card" style="margin-bottom:1.5rem">
+      <h2>LLM 自動偵測</h2>
+      <p class="helper-text">貼入章節內容，讓 AI 偵測潛在伏筆，再逐一確認或忽略。</p>
+      <div class="form-group">
+        <label>章節編號（確認後用於記錄埋下章節）</label>
+        <input type="number" id="detect-chapter" min="1" placeholder="例：3" style="width:120px">
+      </div>
+      <div class="form-group">
+        <label>章節內容</label>
+        <textarea id="detect-content" style="min-height:120px" placeholder="貼入章節全文…"></textarea>
+      </div>
+      <button class="btn" onclick="detectHooks()" id="detect-btn">偵測伏筆</button>
+      <div id="detect-status" class="helper-text" style="margin-top:8px"></div>
+
+      <!-- 待確認清單 -->
+      <div id="pending-section" style="margin-top:1rem;display:{{if .Pending}}block{{else}}none{{end}}">
+        <h3 style="margin-bottom:0.5rem">待確認建議（{{len .Pending}} 筆）</h3>
+        <div id="pending-list">
+          {{range .Pending}}
+          <div class="card" id="ph-{{.ID}}" style="margin-bottom:0.75rem;background:#1e293b">
+            <div style="display:flex;gap:0.5rem;align-items:flex-start">
+              <div style="flex:1">
+                <div style="font-weight:600">{{.Description}}</div>
+                {{if .Context}}<div class="helper-text" style="margin-top:4px">「{{.Context}}」</div>{{end}}
+                <div style="margin-top:4px">
+                  <span class="badge {{if eq .Confidence "高"}}badge-open{{else}}badge-resolved{{end}}">可信度：{{.Confidence}}</span>
+                </div>
+              </div>
+              <div style="display:flex;flex-direction:column;gap:4px;white-space:nowrap">
+                <button class="btn btn-sm btn-success" onclick="confirmHook('{{.ID}}')">確認採用</button>
+                <button class="btn btn-sm btn-ghost" onclick="dismissHook('{{.ID}}')">忽略</button>
+              </div>
+            </div>
+          </div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
     <div class="grid-2" style="align-items:start">
 
       <!-- 新增伏筆 -->
       <div class="card">
-        <h2>新增伏筆</h2>
+        <h2>手動新增伏筆</h2>
         <form action="/foreshadow" method="post">
           <div class="form-group">
             <label>埋下章節</label>
@@ -57,6 +97,9 @@
                 {{end}}
                 {{if .ResolvedIn}}
                 <div style="color:#86efac;font-size:0.8rem;margin-top:4px">回收：{{.ResolvedIn}}</div>
+                {{end}}
+                {{if .Confidence}}
+                <div style="color:#94a3b8;font-size:0.75rem;margin-top:2px">可信度：{{.Confidence}}</div>
                 {{end}}
               </td>
               <td>
@@ -112,6 +155,87 @@ function deleteForeshadow(id) {
       document.getElementById('fs-' + id)?.remove();
       document.getElementById('resolve-' + id)?.remove();
     });
+}
+
+async function detectHooks() {
+  const chapter = parseInt(document.getElementById('detect-chapter').value, 10);
+  const content = document.getElementById('detect-content').value.trim();
+  const status = document.getElementById('detect-status');
+  if (!content) { alert('請輸入章節內容'); return; }
+  if (!chapter || chapter < 1) { alert('請輸入有效的章節編號'); return; }
+
+  document.getElementById('detect-btn').disabled = true;
+  status.textContent = '偵測中…';
+
+  const resp = await fetch('/foreshadow/detect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chapter: content, chapter_index: chapter }),
+  });
+  document.getElementById('detect-btn').disabled = false;
+
+  if (!resp.ok) {
+    status.textContent = '偵測失敗：' + (await resp.text());
+    return;
+  }
+  const data = await resp.json();
+  status.textContent = `偵測完成，找到 ${data.pending?.length ?? 0} 個建議`;
+  renderPending(data.pending || [], chapter);
+}
+
+function renderPending(pending, chapter) {
+  const section = document.getElementById('pending-section');
+  const list = document.getElementById('pending-list');
+  if (!pending.length) { section.style.display = 'none'; return; }
+  section.style.display = 'block';
+  section.querySelector('h3').textContent = `待確認建議（${pending.length} 筆）`;
+  list.innerHTML = pending.map(p => `
+    <div class="card" id="ph-${p.id}" style="margin-bottom:0.75rem;background:#1e293b">
+      <div style="display:flex;gap:0.5rem;align-items:flex-start">
+        <div style="flex:1">
+          <div style="font-weight:600">${escapeHTML(p.description)}</div>
+          ${p.context ? `<div class="helper-text" style="margin-top:4px">「${escapeHTML(p.context)}」</div>` : ''}
+          <div style="margin-top:4px">
+            <span class="badge ${p.confidence === '高' ? 'badge-open' : 'badge-resolved'}">可信度：${escapeHTML(p.confidence)}</span>
+          </div>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:4px;white-space:nowrap">
+          <button class="btn btn-sm btn-success" onclick="confirmHook('${p.id}', ${chapter})">確認採用</button>
+          <button class="btn btn-sm btn-ghost" onclick="dismissHook('${p.id}')">忽略</button>
+        </div>
+      </div>
+    </div>
+  `).join('');
+}
+
+async function confirmHook(id, chapter) {
+  const planted = prompt('請描述伏筆埋下方式（可留空）：') ?? '';
+  const resp = await fetch('/foreshadow/confirm', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, chapter: chapter || 0, planted_in: planted }),
+  });
+  if (!resp.ok) { alert('確認失敗'); return; }
+  const data = await resp.json();
+  document.getElementById('ph-' + id)?.remove();
+  renderPending(data.pending || [], chapter);
+  location.reload();
+}
+
+async function dismissHook(id) {
+  const resp = await fetch('/foreshadow/dismiss', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
+  });
+  if (!resp.ok) { alert('忽略失敗'); return; }
+  const data = await resp.json();
+  document.getElementById('ph-' + id)?.remove();
+  renderPending(data.pending || [], 0);
+}
+
+function escapeHTML(str) {
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 </script>
 </body>

--- a/web/templates/foreshadow.html
+++ b/web/templates/foreshadow.html
@@ -157,6 +157,8 @@ function deleteForeshadow(id) {
     });
 }
 
+let currentDetectChapter = 0;
+
 async function detectHooks() {
   const chapter = parseInt(document.getElementById('detect-chapter').value, 10);
   const content = document.getElementById('detect-content').value.trim();
@@ -179,11 +181,12 @@ async function detectHooks() {
     return;
   }
   const data = await resp.json();
+  currentDetectChapter = chapter;
   status.textContent = `偵測完成，找到 ${data.pending?.length ?? 0} 個建議`;
-  renderPending(data.pending || [], chapter);
+  renderPending(data.pending || []);
 }
 
-function renderPending(pending, chapter) {
+function renderPending(pending) {
   const section = document.getElementById('pending-section');
   const list = document.getElementById('pending-list');
   if (!pending.length) { section.style.display = 'none'; return; }
@@ -200,7 +203,7 @@ function renderPending(pending, chapter) {
           </div>
         </div>
         <div style="display:flex;flex-direction:column;gap:4px;white-space:nowrap">
-          <button class="btn btn-sm btn-success" onclick="confirmHook('${p.id}', ${chapter})">確認採用</button>
+          <button class="btn btn-sm btn-success" onclick="confirmHook('${p.id}', ${p.chapter_index || 0})">確認採用</button>
           <button class="btn btn-sm btn-ghost" onclick="dismissHook('${p.id}')">忽略</button>
         </div>
       </div>
@@ -208,8 +211,8 @@ function renderPending(pending, chapter) {
   `).join('');
 }
 
-async function confirmHook(id, chapter) {
-  let chapterNum = parseInt(chapter, 10);
+async function confirmHook(id, chapterHint) {
+  let chapterNum = parseInt(chapterHint, 10) || currentDetectChapter;
   if (!chapterNum || chapterNum < 1) {
     const input = prompt('請輸入此伏筆所在章節編號：');
     chapterNum = parseInt(input, 10);
@@ -234,7 +237,7 @@ async function dismissHook(id) {
   if (!resp.ok) { alert('忽略失敗'); return; }
   const data = await resp.json();
   document.getElementById('ph-' + id)?.remove();
-  renderPending(data.pending || [], 0);
+  renderPending(data.pending || []);
 }
 
 function escapeHTML(str) {


### PR DESCRIPTION
## Summary

- **資料模型擴充**：`Foreshadowing` 新增 `LastSeenChapter`、`Confidence` 欄位；JSON 儲存改為 `{items, pending}` wrapper，向下相容舊版純陣列格式
- **`PendingHook`**：LLM 建議但尚未確認的伏筆候選，持久化於同一 JSON 檔案
- **`ForeshadowTracker` 新方法**：`AddPending`、`GetPending`、`ConfirmPending`、`DismissPending`、`StaleForeshadows`（超過 N 章未提及回傳清單，預設閾值 3）
- **`checker.ExtractHooks`**：沿用 `GenerateWorldStateChanges` 的 JSON 擷取模式，LLM 輸出伏筆候選陣列
- **四個新 API**：`POST /foreshadow/detect`、`POST /foreshadow/confirm`、`POST /foreshadow/dismiss`、`GET /api/foreshadow/stale`
- **`foreshadow.html`**：新增自動偵測區（貼入章節、LLM 分析、待確認清單 + 確認/忽略按鈕）；既有伏筆列表顯示 Confidence 標籤

## Test plan

- [x] `go test ./...` 全過
- [x] `gofmt -l` 無輸出
- [x] 單元：`ConfirmPending`、`DismissPending`、`StaleForeshadows`、`Save/Load` roundtrip、舊格式相容性

Closes #45