### PR TITLE
fix: populate Sources and RetrievalConfigs in pipeline mode history entry

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -947,7 +947,8 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 
 		worldStatePrefix := s.worldStateSystemPrefix(req.ChapterFile)
 		if layerMode == "pipeline" {
-			if err := s.runPipelineReview(ctx, req, msgChan, &transcript, worldStatePrefix); err != nil {
+			pipelineRefs, pipelineRetrieval, err := s.runPipelineReview(ctx, req, msgChan, &transcript, worldStatePrefix)
+			if err != nil {
 				return
 			}
 
@@ -957,14 +958,16 @@ func (s *Server) handleCheckStream(c *gin.Context) {
 
 			chapterTitle, chapterFile := resolveReviewChapterMeta(req)
 			s.history.Add(&reviewhistory.Entry{
-				Kind:         "review",
-				ChapterTitle: chapterTitle,
-				ChapterFile:  chapterFile,
-				SceneTitle:   strings.TrimSpace(req.SceneTitle),
-				InputContent: req.Chapter,
-				Checks:       append([]string(nil), req.Checks...),
-				Styles:       append([]string(nil), req.Styles...),
-				Result:       transcript.String(),
+				Kind:             "review",
+				ChapterTitle:     chapterTitle,
+				ChapterFile:      chapterFile,
+				SceneTitle:       strings.TrimSpace(req.SceneTitle),
+				InputContent:     req.Chapter,
+				Checks:           append([]string(nil), req.Checks...),
+				Styles:           append([]string(nil), req.Styles...),
+				Sources:          referenceNames(pipelineRefs),
+				RetrievalConfigs: buildHistoryRetrievalConfigs(pipelineRetrieval),
+				Result:           transcript.String(),
 			})
 			if err := s.history.Save(); err != nil {
 				log.Printf("save review history: %v", err)

--- a/internal/server/review_layers.go
+++ b/internal/server/review_layers.go
@@ -44,6 +44,9 @@ func resolveReviewLayers(layerMode string) []reviewLayer {
 	return defaultReviewLayers()
 }
 
+// runPipelineReview executes the multi-layer review pipeline.
+// Returns the accumulated vector refs across all layers, the active retrieval
+// summary map, and any error that aborted the pipeline.
 func (s *Server) runPipelineReview(
 	ctx context.Context,
 	req checkRequest,

--- a/internal/server/review_layers.go
+++ b/internal/server/review_layers.go
@@ -50,7 +50,7 @@ func (s *Server) runPipelineReview(
 	msgChan chan<- streamEvent,
 	transcript *strings.Builder,
 	worldStatePrefix string,
-) error {
+) ([]vectorProfile, map[string]retrievalSummary, error) {
 	layers := defaultReviewLayers()
 	charsToCheck := s.resolveCharacters(req)
 	reviewBias := reviewBiasInstruction(s.rules.Get().ReviewBias)
@@ -58,11 +58,14 @@ func (s *Server) runPipelineReview(
 	behaviorOpts := mergeRetrieval(s.rules.PresetFor("behavior"), req.retrievalOverrideFor("behavior"))
 	dialogueOpts := mergeRetrieval(s.rules.PresetFor("dialogue"), req.retrievalOverrideFor("dialogue"))
 	worldOpts := mergeRetrieval(s.rules.PresetFor("world"), req.retrievalOverrideFor("world"))
-	msgChan <- streamEvent{Event: "retrieval", Retrieval: map[string]any{"tasks": map[string]retrievalSummary{
+	activeRetrieval := map[string]retrievalSummary{
 		"behavior": summarizeRetrieval("behavior", behaviorOpts, resolveBeforeChapter(req.ChapterFile, behaviorOpts)),
 		"dialogue": summarizeRetrieval("dialogue", dialogueOpts, resolveBeforeChapter(req.ChapterFile, dialogueOpts)),
 		"world":    summarizeRetrieval("world", worldOpts, resolveBeforeChapter(req.ChapterFile, worldOpts)),
-	}}}
+	}
+	msgChan <- streamEvent{Event: "retrieval", Retrieval: map[string]any{"tasks": activeRetrieval}}
+
+	var allRefs []vectorProfile
 
 	styleReq := req
 	styleReq.Checks = []string{"style"}
@@ -71,7 +74,7 @@ func (s *Server) runPipelineReview(
 		text := fmt.Sprintf("\n> 錯誤：%s\n", err.Error())
 		transcript.WriteString(text)
 		msgChan <- streamEvent{Event: "chunk", Text: text}
-		return err
+		return nil, nil, err
 	}
 	styleTexts := make([]string, 0, len(stylesToCheck))
 	for _, sg := range stylesToCheck {
@@ -101,6 +104,7 @@ func (s *Server) runPipelineReview(
 				msgChan <- streamEvent{Event: "chunk", Text: text}
 			}
 			refs := mergeReferenceLists(behaviorRefs, dialogueRefs)
+			allRefs = append(allRefs, refs...)
 			if len(refs) > 0 {
 				msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(refs)}
 			}
@@ -130,6 +134,7 @@ func (s *Server) runPipelineReview(
 				transcript.WriteString(text)
 				msgChan <- streamEvent{Event: "chunk", Text: text}
 			}
+			allRefs = append(allRefs, worldRefs...)
 			worldText := joinWorldProfiles(filterReferencesByType(worldRefs, "world"), s.profiles.Worlds)
 			if strings.TrimSpace(worldText) != "" {
 				promptParts = append(promptParts, "【世界觀資料】\n"+worldText)
@@ -148,7 +153,7 @@ func (s *Server) runPipelineReview(
 				transcript.WriteString(text)
 				msgChan <- streamEvent{Event: "chunk", Text: text}
 			}
-			return layerErr
+			return nil, nil, layerErr
 		}
 
 		msgChan <- streamEvent{Event: "layer_end", Layer: layer.Name}
@@ -156,5 +161,5 @@ func (s *Server) runPipelineReview(
 		transcript.WriteString("\n")
 	}
 
-	return nil
+	return allRefs, activeRetrieval, nil
 }


### PR DESCRIPTION
## Summary

- `runPipelineReview` 回傳型別從 `error` 改為 `([]vectorProfile, map[string]retrievalSummary, error)`
- 在 `character` 與 `world_logic` layer 中累積各自載入的 refs 至 `allRefs`
- 將原本只作為 SSE event 發出的 `activeRetrieval` map 保存至局部變數後一併回傳
- `handleCheckStream` pipeline 路徑改用回傳值填入 `reviewhistory.Entry` 的 `Sources` 與 `RetrievalConfigs`，與 single 模式行為一致

## Test plan

- [ ] `go test ./internal/server/... -run Pipeline` 全部 PASS
- [ ] `go test ./...` 無 regression

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)