### PR TITLE
fix: pass rewriteOpts directly to buildReferenceContext to preserve BeforeChapter

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1297,12 +1297,7 @@ func (s *Server) handleRewriteStream(c *gin.Context) {
 		rewriteOpts := mergeRetrieval(s.rules.PresetFor("rewrite"), req.Retrieval)
 		activeRetrieval := summarizeRetrieval("rewrite", rewriteOpts, resolveBeforeChapter(req.ChapterFile, rewriteOpts))
 		traceStarted := time.Now()
-		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, retrievalOptions{
-			Sources:      append([]string(nil), activeRetrieval.Sources...),
-			TopK:         activeRetrieval.TopK,
-			Threshold:    activeRetrieval.Threshold,
-			ThresholdSet: true,
-		})
+		references, refErr := s.buildReferenceContext(ctx, req.Chapter, req.ChapterFile, rewriteOpts)
 		s.recordRetrievalTrace("rewrite", activeRetrieval, req.ChapterTitle, req.ChapterFile, references, refErr, time.Since(traceStarted))
 		cw := &chanWriter{ch: msgChan, transcript: &transcript}
 		msgChan <- streamEvent{Event: "retrieval", Retrieval: gin.H{"tasks": gin.H{"rewrite": activeRetrieval}}}


### PR DESCRIPTION
## Summary

- `handleRewriteStream` 原本從 `activeRetrieval` 重建 `retrievalOptions` 再傳入 `buildReferenceContext`，遺漏了 `BeforeChapter` 欄位
- 直接傳入 `rewriteOpts` 即可，所有欄位（含手動 override 的 `BeforeChapter`）皆完整保留
- 同步移除無效的 `ThresholdSet: true`（`buildReferenceContext` 從未讀取該欄位）

## Test plan

- [ ] `go test ./...` 全部 PASS

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)