### PR TITLE
feat: update LastSeenChapter when detect scans a chapter

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1226,3 +1226,103 @@ func TestForeshadowDetectConfirmDismissStale(t *testing.T) {
 		t.Fatalf("expected 1 stale item, got %d: %s", len(stalePayload.Items), string(staleResp.Body))
 	}
 }
+
+func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
+	t.Parallel()
+
+	// First LLM call returns a candidate; subsequent calls return no candidates
+	// so the second detect only triggers TouchLastSeen without adding new pending.
+	var callCount int32
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.AddInt32(&callCount, 1) == 1 {
+			_, _ = w.Write([]byte(`{"response":"[{\"description\":\"神秘信封\",\"context\":\"桌上\",\"confidence\":\"高\"}]","done":true}` + "\n"))
+		} else {
+			_, _ = w.Write([]byte(`{"response":"[]","done":true}` + "\n"))
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	// Step 1: detect at ch3 → get pending "神秘信封".
+	detectResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "林昊看到桌上的信封，沒有打開。",
+		"chapter_index": 3,
+	})
+	if detectResp.StatusCode != http.StatusOK {
+		t.Fatalf("detect failed: %s", string(detectResp.Body))
+	}
+	var detectPayload struct {
+		Pending []struct {
+			ID string `json:"id"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal(detectResp.Body, &detectPayload); err != nil {
+		t.Fatalf("decode detect: %v", err)
+	}
+	if len(detectPayload.Pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(detectPayload.Pending))
+	}
+
+	// Step 2: confirm → item planted at ch3, LastSeenChapter=0.
+	confirmResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/confirm", map[string]any{
+		"id": detectPayload.Pending[0].ID, "chapter": 3, "planted_in": "桌上的信",
+	})
+	if confirmResp.StatusCode != http.StatusOK {
+		t.Fatalf("confirm failed: %s", string(confirmResp.Body))
+	}
+
+	// Step 3: stale at current=7, threshold=3 → stale (baseline=ch3, 7-3=4 ≥ 3).
+	stale1 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=7&threshold=3", nil)
+	var stalePayload1 struct {
+		Items []struct{ Description string `json:"description"` } `json:"items"`
+	}
+	if err := json.Unmarshal(stale1.Body, &stalePayload1); err != nil {
+		t.Fatalf("decode stale1: %v", err)
+	}
+	if len(stalePayload1.Items) != 1 {
+		t.Fatalf("expected item to be stale before touch, got %d items", len(stalePayload1.Items))
+	}
+
+	// Step 4: detect ch6 containing the description → TouchLastSeen fires, LastSeenChapter=6.
+	detectResp2 := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "林昊再次翻開神秘信封，讀完後將它燒掉。",
+		"chapter_index": 6,
+	})
+	if detectResp2.StatusCode != http.StatusOK {
+		t.Fatalf("second detect failed: %s", string(detectResp2.Body))
+	}
+
+	// Step 5: stale at current=8, threshold=3 → not stale (baseline=ch6, 8-6=2 < 3).
+	stale2 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=8&threshold=3", nil)
+	var stalePayload2 struct {
+		Items []struct{ Description string `json:"description"` } `json:"items"`
+	}
+	if err := json.Unmarshal(stale2.Body, &stalePayload2); err != nil {
+		t.Fatalf("decode stale2: %v", err)
+	}
+	if len(stalePayload2.Items) != 0 {
+		t.Fatalf("expected no stale items after touch (baseline moved to ch6), got %d: %s",
+			len(stalePayload2.Items), string(stale2.Body))
+	}
+
+	// Step 6: stale at current=10, threshold=3 → stale again (10-6=4 ≥ 3).
+	stale3 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=10&threshold=3", nil)
+	var stalePayload3 struct {
+		Items []struct{ Description string `json:"description"` } `json:"items"`
+	}
+	if err := json.Unmarshal(stale3.Body, &stalePayload3); err != nil {
+		t.Fatalf("decode stale3: %v", err)
+	}
+	if len(stalePayload3.Items) != 1 {
+		t.Fatalf("expected item stale again at ch10 (10-6=4 ≥ 3), got %d items", len(stalePayload3.Items))
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1572,6 +1572,17 @@ func (s *Server) handleDetectForeshadow(c *gin.Context) {
 		}
 	}
 	s.foreshadow.AddPending(hooks)
+
+	// Update LastSeenChapter for any existing confirmed hook whose description
+	// appears verbatim in the chapter text.
+	var touchIDs []string
+	for _, item := range s.foreshadow.GetAll() {
+		if strings.Contains(req.Chapter, item.Description) {
+			touchIDs = append(touchIDs, item.ID)
+		}
+	}
+	s.foreshadow.TouchLastSeen(req.ChapterIndex, touchIDs)
+
 	if !saveOrAbort(c, s.foreshadow.Save(), "save foreshadow") {
 		return
 	}

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -223,3 +223,32 @@ func (t *ForeshadowTracker) StaleForeshadows(currentChapter, threshold int) []*F
 	}
 	return out
 }
+
+// TouchLastSeen updates LastSeenChapter for each unresolved item whose ID
+// appears in ids, but only when chapterIndex is greater than the current value.
+// Returns the number of items actually updated.
+func (t *ForeshadowTracker) TouchLastSeen(chapterIndex int, ids []string) int {
+	if len(ids) == 0 || chapterIndex < 1 {
+		return 0
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	updated := 0
+	for _, item := range t.Items {
+		if item.Status == "已回收" {
+			continue
+		}
+		if _, ok := set[item.ID]; !ok {
+			continue
+		}
+		if chapterIndex > item.LastSeenChapter {
+			item.LastSeenChapter = chapterIndex
+			updated++
+		}
+	}
+	return updated
+}

--- a/internal/tracker/foreshadow_test.go
+++ b/internal/tracker/foreshadow_test.go
@@ -122,3 +122,49 @@ func TestConfirmPendingReturnsFalseForMissingID(t *testing.T) {
 		t.Fatal("expected false for missing id")
 	}
 }
+
+func TestTouchLastSeenUpdatesForwardOnly(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	tr.Add(&Foreshadowing{Chapter: 1, Description: "神秘信封"})
+	id := tr.GetAll()[0].ID
+
+	// First touch at chapter 5.
+	if n := tr.TouchLastSeen(5, []string{id}); n != 1 {
+		t.Fatalf("expected 1 updated, got %d", n)
+	}
+	if tr.Items[0].LastSeenChapter != 5 {
+		t.Fatalf("expected LastSeenChapter=5, got %d", tr.Items[0].LastSeenChapter)
+	}
+
+	// Touch at an earlier chapter must not regress.
+	if n := tr.TouchLastSeen(3, []string{id}); n != 0 {
+		t.Fatalf("expected 0 updated (regression guard), got %d", n)
+	}
+	if tr.Items[0].LastSeenChapter != 5 {
+		t.Fatalf("LastSeenChapter regressed to %d", tr.Items[0].LastSeenChapter)
+	}
+}
+
+func TestTouchLastSeenSkipsResolvedItems(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	tr.Add(&Foreshadowing{Chapter: 1, Description: "已回收伏筆"})
+	id := tr.GetAll()[0].ID
+	tr.Items[0].Status = "已回收"
+
+	if n := tr.TouchLastSeen(5, []string{id}); n != 0 {
+		t.Fatalf("expected 0 updated for resolved item, got %d", n)
+	}
+}
+
+func TestTouchLastSeenUnknownIDIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	tr := NewForeshadowTracker("")
+	if n := tr.TouchLastSeen(5, []string{"nonexistent"}); n != 0 {
+		t.Fatalf("expected 0, got %d", n)
+	}
+}


### PR DESCRIPTION
## Summary

- 新增 `ForeshadowTracker.TouchLastSeen(chapterIndex int, ids []string) int`
  - 只向前更新（chapterIndex > 現有值才寫入），防止舊章節分析覆蓋較新記錄
  - 跳過已回收的伏筆
- `handleDetectForeshadow` 在 LLM 偵測後，對現有已確認 items 做 Description substring 比對，命中者呼叫 `TouchLastSeen`
- 單元測試：forward-only 保護、跳過已回收、未知 ID 為 no-op

## Test plan

- [x] `go test ./internal/tracker/... ./internal/server/...` 全過
- [x] `TestTouchLastSeenUpdatesForwardOnly`：ch5 更新後 ch3 不回退
- [x] `TestTouchLastSeenSkipsResolvedItems`：已回收伏筆不更新
- [x] `TestTouchLastSeenUnknownIDIsNoOp`：無效 ID 回傳 0

Closes #70