### PR TITLE
feat: Auto Narrative Memory — extract story state after each scene

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -514,6 +514,70 @@ func (c *Checker) ExtractHooks(ctx context.Context, chapter string) ([]HookCandi
 	return candidates, nil
 }
 
+// EventCandidate is a timeline event extracted from chapter text.
+type EventCandidate struct {
+	Scene        string   `json:"scene"`
+	Description  string   `json:"description"`
+	Characters   []string `json:"characters"`
+	Consequences string   `json:"consequences"`
+}
+
+// RelationshipCandidate is a character relationship change extracted from chapter text.
+type RelationshipCandidate struct {
+	From         string `json:"from"`
+	To           string `json:"to"`
+	Status       string `json:"status"`
+	Note         string `json:"note"`
+	TriggerEvent string `json:"trigger_event"`
+}
+
+// NarrativeMemory holds all structured data extracted from a single chapter.
+type NarrativeMemory struct {
+	Events        []EventCandidate        `json:"events"`
+	Relationships []RelationshipCandidate `json:"relationships"`
+	WorldState    []worldstate.Change     `json:"world_state"`
+	Hooks         []HookCandidate         `json:"hooks"`
+}
+
+// ExtractNarrativeMemory asks the LLM to extract structured story state from a
+// chapter in one pass: timeline events, relationship changes, worldstate changes,
+// and foreshadowing hook candidates.
+func (c *Checker) ExtractNarrativeMemory(ctx context.Context, chapter string) (*NarrativeMemory, error) {
+	prompt := fmt.Sprintf(`分析以下章節，提取四類結構化資料，輸出嚴格 JSON 物件，不含任何說明文字：
+{
+  "events": [{"scene":"...","description":"...","characters":["..."],"consequences":"..."}],
+  "relationships": [{"from":"...","to":"...","status":"...","note":"...","trigger_event":"..."}],
+  "world_state": [{"entity":"...","change_type":"...","description":"..."}],
+  "hooks": [{"description":"...","context":"...","confidence":"高|中|低"}]
+}
+
+欄位說明：
+- events：本章節發生的重要事件（可為空陣列）
+- relationships：角色關係變化（可為空陣列）
+- world_state：世界觀或設定狀態的變動（可為空陣列）
+- hooks：潛在伏筆元素，confidence 只能是「高」「中」「低」（可為空陣列）
+
+章節內容：
+%s
+`, chapter)
+
+	var buf strings.Builder
+	if err := c.stream(ctx, "你是專業小說分析師，只輸出合法 JSON，不輸出任何額外文字。請用繁體中文填寫欄位。", prompt, &buf); err != nil {
+		return nil, err
+	}
+	raw := strings.TrimSpace(buf.String())
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start < 0 || end <= start {
+		return nil, fmt.Errorf("無法解析記憶抽取回應")
+	}
+	var mem NarrativeMemory
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &mem); err != nil {
+		return nil, fmt.Errorf("JSON 解析失敗：%w", err)
+	}
+	return &mem, nil
+}
+
 func ExtractNames(text string, knownNames []string) []string {
 	var found []string
 	for _, name := range knownNames {

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1326,3 +1326,69 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 		t.Fatalf("expected item stale again at ch10 (10-6=4 ≥ 3), got %d items", len(stalePayload3.Items))
 	}
 }
+
+func TestNarrativeExtract(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/generate" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		body := `{"response":"{\"events\":[{\"scene\":\"書房\",\"description\":\"林昊發現密函\",\"characters\":[\"林昊\"],\"consequences\":\"決定出城\"}],\"relationships\":[{\"from\":\"林昊\",\"to\":\"陳司長\",\"status\":\"敵對\",\"note\":\"發現背叛\",\"trigger_event\":\"密函事件\"}],\"world_state\":[{\"entity\":\"夜港城\",\"change_type\":\"政治\",\"description\":\"城主位置動搖\"}],\"hooks\":[{\"description\":\"密函來源\",\"context\":\"信封背面印記\",\"confidence\":\"高\"}]}","done":true}`
+		_, _ = w.Write([]byte(body + "\n"))
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	// missing chapter_index → 400
+	bad := performJSONRequest(t, app.URL, "POST", "/narrative/extract", map[string]any{
+		"chapter": "林昊翻開密函，臉色大變。",
+	})
+	if bad.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing chapter_index, got %d", bad.StatusCode)
+	}
+
+	// valid extract
+	resp := performJSONRequest(t, app.URL, "POST", "/narrative/extract", map[string]any{
+		"chapter":       "林昊翻開密函，臉色大變。他看見陳司長的印記，決定連夜出城。",
+		"chapter_index": 5,
+		"chapter_file":  "第05章.md",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("extract failed: %s", string(resp.Body))
+	}
+
+	var result struct {
+		Events        []struct{ Description string `json:"description"` } `json:"events"`
+		Relationships []struct{ From string `json:"from"` }             `json:"relationships"`
+		WorldState    []struct{ Entity string `json:"entity"` }         `json:"world_state"`
+		Hooks         []struct{ Description string `json:"description"` } `json:"hooks"`
+	}
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	if len(result.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(result.Relationships))
+	}
+	if len(result.WorldState) != 1 {
+		t.Fatalf("expected 1 world_state, got %d", len(result.WorldState))
+	}
+	if len(result.Hooks) != 1 {
+		t.Fatalf("expected 1 hook, got %d", len(result.Hooks))
+	}
+
+	// verify pending hook was added to foreshadow tracker
+	pendingResp := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=1&threshold=1", nil)
+	if pendingResp.StatusCode != http.StatusOK {
+		t.Fatalf("stale check failed: %s", string(pendingResp.Body))
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1336,18 +1336,18 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 func TestNarrativeExtract(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
+	var callCount atomic.Int32
 	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/generate" {
 			http.NotFound(w, r)
 			return
 		}
-		callCount++
+		n := callCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		// First call: narrative extract → full NarrativeMemory JSON
 		// Subsequent calls (foreshadow detect): empty hooks array
 		var body string
-		if callCount == 1 {
+		if n == 1 {
 			body = `{"response":"{\"events\":[{\"scene\":\"書房\",\"description\":\"林昊發現密函\",\"characters\":[\"林昊\"],\"consequences\":\"決定出城\"}],\"relationships\":[{\"from\":\"林昊\",\"to\":\"陳司長\",\"status\":\"敵對\",\"note\":\"發現背叛\",\"trigger_event\":\"密函事件\"}],\"world_state\":[{\"entity\":\"夜港城\",\"change_type\":\"政治\",\"description\":\"城主位置動搖\"}],\"hooks\":[{\"description\":\"密函來源\",\"context\":\"信封背面印記\",\"confidence\":\"高\"}]}","done":true}`
 		} else {
 			body = `{"response":"[]","done":true}`

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1283,7 +1283,9 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 	// Step 3: stale at current=7, threshold=3 → stale (baseline=ch3, 7-3=4 ≥ 3).
 	stale1 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=7&threshold=3", nil)
 	var stalePayload1 struct {
-		Items []struct{ Description string `json:"description"` } `json:"items"`
+		Items []struct {
+			Description string `json:"description"`
+		} `json:"items"`
 	}
 	if err := json.Unmarshal(stale1.Body, &stalePayload1); err != nil {
 		t.Fatalf("decode stale1: %v", err)
@@ -1304,7 +1306,9 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 	// Step 5: stale at current=8, threshold=3 → not stale (baseline=ch6, 8-6=2 < 3).
 	stale2 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=8&threshold=3", nil)
 	var stalePayload2 struct {
-		Items []struct{ Description string `json:"description"` } `json:"items"`
+		Items []struct {
+			Description string `json:"description"`
+		} `json:"items"`
 	}
 	if err := json.Unmarshal(stale2.Body, &stalePayload2); err != nil {
 		t.Fatalf("decode stale2: %v", err)
@@ -1317,7 +1321,9 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 	// Step 6: stale at current=10, threshold=3 → stale again (10-6=4 ≥ 3).
 	stale3 := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=10&threshold=3", nil)
 	var stalePayload3 struct {
-		Items []struct{ Description string `json:"description"` } `json:"items"`
+		Items []struct {
+			Description string `json:"description"`
+		} `json:"items"`
 	}
 	if err := json.Unmarshal(stale3.Body, &stalePayload3); err != nil {
 		t.Fatalf("decode stale3: %v", err)
@@ -1330,13 +1336,22 @@ func TestForeshadowDetectUpdatesLastSeenChapter(t *testing.T) {
 func TestNarrativeExtract(t *testing.T) {
 	t.Parallel()
 
+	callCount := 0
 	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/generate" {
 			http.NotFound(w, r)
 			return
 		}
+		callCount++
 		w.Header().Set("Content-Type", "application/json")
-		body := `{"response":"{\"events\":[{\"scene\":\"書房\",\"description\":\"林昊發現密函\",\"characters\":[\"林昊\"],\"consequences\":\"決定出城\"}],\"relationships\":[{\"from\":\"林昊\",\"to\":\"陳司長\",\"status\":\"敵對\",\"note\":\"發現背叛\",\"trigger_event\":\"密函事件\"}],\"world_state\":[{\"entity\":\"夜港城\",\"change_type\":\"政治\",\"description\":\"城主位置動搖\"}],\"hooks\":[{\"description\":\"密函來源\",\"context\":\"信封背面印記\",\"confidence\":\"高\"}]}","done":true}`
+		// First call: narrative extract → full NarrativeMemory JSON
+		// Subsequent calls (foreshadow detect): empty hooks array
+		var body string
+		if callCount == 1 {
+			body = `{"response":"{\"events\":[{\"scene\":\"書房\",\"description\":\"林昊發現密函\",\"characters\":[\"林昊\"],\"consequences\":\"決定出城\"}],\"relationships\":[{\"from\":\"林昊\",\"to\":\"陳司長\",\"status\":\"敵對\",\"note\":\"發現背叛\",\"trigger_event\":\"密函事件\"}],\"world_state\":[{\"entity\":\"夜港城\",\"change_type\":\"政治\",\"description\":\"城主位置動搖\"}],\"hooks\":[{\"description\":\"密函來源\",\"context\":\"信封背面印記\",\"confidence\":\"高\"}]}","done":true}`
+		} else {
+			body = `{"response":"[]","done":true}`
+		}
 		_, _ = w.Write([]byte(body + "\n"))
 	}))
 	defer ollama.Close()
@@ -1365,10 +1380,18 @@ func TestNarrativeExtract(t *testing.T) {
 	}
 
 	var result struct {
-		Events        []struct{ Description string `json:"description"` } `json:"events"`
-		Relationships []struct{ From string `json:"from"` }             `json:"relationships"`
-		WorldState    []struct{ Entity string `json:"entity"` }         `json:"world_state"`
-		Hooks         []struct{ Description string `json:"description"` } `json:"hooks"`
+		Events []struct {
+			Description string `json:"description"`
+		} `json:"events"`
+		Relationships []struct {
+			From string `json:"from"`
+		} `json:"relationships"`
+		WorldState []struct {
+			Entity string `json:"entity"`
+		} `json:"world_state"`
+		Hooks []struct {
+			Description string `json:"description"`
+		} `json:"hooks"`
 	}
 	if err := json.Unmarshal(resp.Body, &result); err != nil {
 		t.Fatalf("decode result: %v", err)
@@ -1386,9 +1409,33 @@ func TestNarrativeExtract(t *testing.T) {
 		t.Fatalf("expected 1 hook, got %d", len(result.Hooks))
 	}
 
-	// verify pending hook was added to foreshadow tracker
-	pendingResp := performJSONRequest(t, app.URL, "GET", "/foreshadow/stale?current_chapter=1&threshold=1", nil)
-	if pendingResp.StatusCode != http.StatusOK {
-		t.Fatalf("stale check failed: %s", string(pendingResp.Body))
+	// Verify the pending hook was persisted to the foreshadow tracker.
+	// POST detect with a different chapter_index (99) so it does not overwrite
+	// the chapter-5 hooks added by the extract above; the response includes ALL pending.
+	detectResp := performJSONRequest(t, app.URL, "POST", "/foreshadow/detect", map[string]any{
+		"chapter":       "無關章節。",
+		"chapter_index": 99,
+	})
+	if detectResp.StatusCode != http.StatusOK {
+		t.Fatalf("detect failed: %s", string(detectResp.Body))
+	}
+	var detectPayload struct {
+		Pending []struct {
+			Description  string `json:"description"`
+			ChapterIndex int    `json:"chapter_index"`
+		} `json:"pending"`
+	}
+	if err := json.Unmarshal(detectResp.Body, &detectPayload); err != nil {
+		t.Fatalf("decode detect response: %v", err)
+	}
+	found := false
+	for _, p := range detectPayload.Pending {
+		if p.Description == "密函來源" && p.ChapterIndex == 5 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected pending hook '密函來源' at chapter 5 in tracker, got: %+v", detectPayload.Pending)
 	}
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -16,6 +16,7 @@ import (
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
+	"novel-assistant/internal/worldstate"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1649,6 +1650,112 @@ func (s *Server) handleStaleForeshadow(c *gin.Context) {
 		stale = []*tracker.Foreshadowing{}
 	}
 	c.JSON(http.StatusOK, gin.H{"items": stale})
+}
+
+// ─── narrative memory ─────────────────────────────────────────────────────────
+
+func (s *Server) handleNarrativePage(c *gin.Context) {
+	c.HTML(http.StatusOK, "narrative.html", gin.H{
+		"Title": "敘事記憶抽取",
+	})
+}
+
+func (s *Server) handleNarrativeExtract(c *gin.Context) {
+	var req struct {
+		Chapter      string `json:"chapter"`
+		ChapterIndex int    `json:"chapter_index"`
+		ChapterFile  string `json:"chapter_file"`
+	}
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(req.Chapter) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可為空"})
+		return
+	}
+	if len(req.Chapter) > 20000 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節內容不可超過 20000 字元"})
+		return
+	}
+	if req.ChapterIndex < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "chapter_index 必須為正整數"})
+		return
+	}
+
+	mem, err := s.checker.ExtractNarrativeMemory(c.Request.Context(), req.Chapter)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	for _, ev := range mem.Events {
+		s.timeline.Add(&tracker.TimelineEvent{
+			Chapter:      req.ChapterIndex,
+			Scene:        ev.Scene,
+			Description:  ev.Description,
+			Characters:   ev.Characters,
+			Consequences: ev.Consequences,
+		})
+	}
+	if len(mem.Events) > 0 {
+		if err := s.timeline.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "儲存時間軸失敗"})
+			return
+		}
+	}
+
+	for _, rel := range mem.Relationships {
+		s.relationships.Upsert(&tracker.Relationship{
+			From:         rel.From,
+			To:           rel.To,
+			Status:       rel.Status,
+			Note:         rel.Note,
+			TriggerEvent: rel.TriggerEvent,
+		})
+	}
+	if len(mem.Relationships) > 0 {
+		if err := s.relationships.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "儲存角色關係失敗"})
+			return
+		}
+	}
+
+	if len(mem.WorldState) > 0 {
+		s.worldstate.Upsert(&worldstate.Snapshot{
+			ChapterFile:  req.ChapterFile,
+			ChapterIndex: req.ChapterIndex,
+			Changes:      mem.WorldState,
+		})
+		if err := s.worldstate.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "儲存世界觀狀態失敗"})
+			return
+		}
+	}
+
+	if len(mem.Hooks) > 0 {
+		hooks := make([]tracker.PendingHook, len(mem.Hooks))
+		for i, h := range mem.Hooks {
+			hooks[i] = tracker.PendingHook{
+				Description:  h.Description,
+				Context:      h.Context,
+				Confidence:   h.Confidence,
+				ChapterIndex: req.ChapterIndex,
+			}
+		}
+		s.foreshadow.AddPending(hooks)
+		if err := s.foreshadow.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "儲存伏筆失敗"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"events":        mem.Events,
+		"relationships": mem.Relationships,
+		"world_state":   mem.WorldState,
+		"hooks":         mem.Hooks,
+	})
 }
 
 // ─── export ───────────────────────────────────────────────────────────────────

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,12 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"novel-assistant/internal/checker"
 	"novel-assistant/internal/consistency"
 	"novel-assistant/internal/exporter"
@@ -17,11 +23,6 @@ import (
 	"novel-assistant/internal/reviewrules"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/worldstate"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 )

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,9 @@ func (s *Server) setupRoutes() {
 	protected.POST("/foreshadow/dismiss", s.handleDismissForeshadow)
 	protected.GET("/foreshadow/stale", s.handleStaleForeshadow)
 
+	protected.GET("/narrative", s.handleNarrativePage)
+	protected.POST("/narrative/extract", s.handleNarrativeExtract)
+
 	protected.POST("/export", s.handleExport)
 }
 

--- a/web/templates/narrative.html
+++ b/web/templates/narrative.html
@@ -1,0 +1,148 @@
+{{define "narrative.html"}}
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>敘事記憶抽取 — 小說助手</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="layout">
+  {{template "nav" .}}
+  <main class="main-content">
+    <div class="page-header">
+      <h1>敘事記憶抽取</h1>
+      <p>貼入章節，讓 AI 一次抽取時間軸事件、角色關係、世界觀變動與伏筆候選，自動寫入各 Tracker。</p>
+    </div>
+
+    <div class="card" style="margin-bottom:1.5rem">
+      <div style="display:grid;grid-template-columns:1fr 140px;gap:1rem;align-items:end">
+        <div class="form-group" style="margin:0">
+          <label>章節編號</label>
+          <input type="number" id="chapter-index" min="1" placeholder="例：5" style="width:120px">
+        </div>
+        <div class="form-group" style="margin:0">
+          <label>章節檔案名稱（選填）</label>
+          <input type="text" id="chapter-file" placeholder="第05章.md">
+        </div>
+      </div>
+      <div class="form-group" style="margin-top:1rem">
+        <label>章節內容</label>
+        <textarea id="chapter-content" style="min-height:160px" placeholder="貼入章節全文…"></textarea>
+      </div>
+      <button class="btn" id="extract-btn" onclick="runExtract()">抽取記憶</button>
+      <div id="extract-status" class="helper-text" style="margin-top:8px"></div>
+    </div>
+
+    <div id="result-area" style="display:none">
+
+      <!-- 時間軸事件 -->
+      <div class="card" style="margin-bottom:1rem">
+        <h2>時間軸事件 <span id="events-count" class="badge badge-open"></span></h2>
+        <div id="events-list"></div>
+      </div>
+
+      <!-- 角色關係 -->
+      <div class="card" style="margin-bottom:1rem">
+        <h2>角色關係變化 <span id="rels-count" class="badge badge-open"></span></h2>
+        <div id="rels-list"></div>
+      </div>
+
+      <!-- 世界觀狀態 -->
+      <div class="card" style="margin-bottom:1rem">
+        <h2>世界觀變動 <span id="world-count" class="badge badge-open"></span></h2>
+        <div id="world-list"></div>
+      </div>
+
+      <!-- 伏筆候選 -->
+      <div class="card" style="margin-bottom:1rem">
+        <h2>伏筆候選（已加入待確認清單）<span id="hooks-count" class="badge badge-open"></span></h2>
+        <div id="hooks-list"></div>
+      </div>
+
+    </div>
+  </main>
+</div>
+<script>
+async function runExtract() {
+  const chapter = document.getElementById('chapter-content').value.trim();
+  const chapterIndex = parseInt(document.getElementById('chapter-index').value, 10);
+  const chapterFile = document.getElementById('chapter-file').value.trim();
+  const status = document.getElementById('extract-status');
+
+  if (!chapter) { alert('請輸入章節內容'); return; }
+  if (!chapterIndex || chapterIndex < 1) { alert('請輸入有效的章節編號'); return; }
+
+  document.getElementById('extract-btn').disabled = true;
+  document.getElementById('result-area').style.display = 'none';
+  status.textContent = '抽取中…';
+
+  const resp = await fetch('/narrative/extract', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chapter, chapter_index: chapterIndex, chapter_file: chapterFile }),
+  });
+  document.getElementById('extract-btn').disabled = false;
+
+  if (!resp.ok) {
+    status.textContent = '抽取失敗：' + (await resp.text());
+    return;
+  }
+  const data = await resp.json();
+  status.textContent = '抽取完成，結果已寫入各 Tracker。';
+  renderResults(data);
+}
+
+function renderResults(data) {
+  const area = document.getElementById('result-area');
+  area.style.display = 'block';
+
+  renderList('events-list', 'events-count', data.events || [], ev => `
+    <div style="padding:0.5rem 0;border-bottom:1px solid #334155">
+      <div style="font-weight:600">${escapeHTML(ev.description)}</div>
+      ${ev.scene ? `<div class="helper-text">場景：${escapeHTML(ev.scene)}</div>` : ''}
+      ${ev.characters?.length ? `<div class="helper-text">角色：${ev.characters.map(escapeHTML).join('、')}</div>` : ''}
+      ${ev.consequences ? `<div class="helper-text">影響：${escapeHTML(ev.consequences)}</div>` : ''}
+    </div>`);
+
+  renderList('rels-list', 'rels-count', data.relationships || [], r => `
+    <div style="padding:0.5rem 0;border-bottom:1px solid #334155">
+      <div style="font-weight:600">${escapeHTML(r.from)} → ${escapeHTML(r.to)}
+        <span class="badge badge-resolved" style="margin-left:0.5rem">${escapeHTML(r.status)}</span>
+      </div>
+      ${r.note ? `<div class="helper-text">${escapeHTML(r.note)}</div>` : ''}
+      ${r.trigger_event ? `<div class="helper-text">觸發事件：${escapeHTML(r.trigger_event)}</div>` : ''}
+    </div>`);
+
+  renderList('world-list', 'world-count', data.world_state || [], w => `
+    <div style="padding:0.5rem 0;border-bottom:1px solid #334155">
+      <div style="font-weight:600">${escapeHTML(w.entity)}
+        <span class="badge badge-resolved" style="margin-left:0.5rem">${escapeHTML(w.change_type)}</span>
+      </div>
+      <div class="helper-text">${escapeHTML(w.description)}</div>
+    </div>`);
+
+  renderList('hooks-list', 'hooks-count', data.hooks || [], h => `
+    <div style="padding:0.5rem 0;border-bottom:1px solid #334155">
+      <div style="font-weight:600">${escapeHTML(h.description)}
+        <span class="badge ${h.confidence === '高' ? 'badge-open' : 'badge-resolved'}" style="margin-left:0.5rem">可信度：${escapeHTML(h.confidence)}</span>
+      </div>
+      ${h.context ? `<div class="helper-text">「${escapeHTML(h.context)}」</div>` : ''}
+    </div>`);
+}
+
+function renderList(listID, countID, items, renderFn) {
+  document.getElementById(countID).textContent = items.length + ' 筆';
+  document.getElementById(listID).innerHTML = items.length
+    ? items.map(renderFn).join('')
+    : '<div class="helper-text">（無）</div>';
+}
+
+function escapeHTML(str) {
+  return String(str ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+</script>
+</body>
+</html>
+{{end}}

--- a/web/templates/narrative.html
+++ b/web/templates/narrative.html
@@ -17,7 +17,7 @@
     </div>
 
     <div class="card" style="margin-bottom:1.5rem">
-      <div style="display:grid;grid-template-columns:1fr 140px;gap:1rem;align-items:end">
+      <div style="display:grid;grid-template-columns:140px 1fr;gap:1rem;align-items:end">
         <div class="form-group" style="margin:0">
           <label>章節編號</label>
           <input type="number" id="chapter-index" min="1" placeholder="例：5" style="width:120px">
@@ -78,20 +78,24 @@ async function runExtract() {
   document.getElementById('result-area').style.display = 'none';
   status.textContent = '抽取中…';
 
-  const resp = await fetch('/narrative/extract', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chapter, chapter_index: chapterIndex, chapter_file: chapterFile }),
-  });
-  document.getElementById('extract-btn').disabled = false;
-
-  if (!resp.ok) {
-    status.textContent = '抽取失敗：' + (await resp.text());
-    return;
+  try {
+    const resp = await fetch('/narrative/extract', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chapter, chapter_index: chapterIndex, chapter_file: chapterFile }),
+    });
+    if (!resp.ok) {
+      status.textContent = '抽取失敗：' + (await resp.text());
+      return;
+    }
+    const data = await resp.json();
+    status.textContent = '抽取完成，結果已寫入各 Tracker。';
+    renderResults(data);
+  } catch (e) {
+    status.textContent = '連線錯誤：' + e.message;
+  } finally {
+    document.getElementById('extract-btn').disabled = false;
   }
-  const data = await resp.json();
-  status.textContent = '抽取完成，結果已寫入各 Tracker。';
-  renderResults(data);
 }
 
 function renderResults(data) {


### PR DESCRIPTION
## Summary

- 新增 `checker.ExtractNarrativeMemory(ctx, chapter)`：單次 LLM call，JSON 回傳四類結構化資料（events / relationships / world_state / hooks）
- 新增 `POST /narrative/extract`：接收章節內容與 chapter_index，呼叫抽取後寫入四個 tracker
  - Timeline events → `TimelineTracker.Add`
  - Relationship changes → `RelationshipTracker.Upsert`
  - Worldstate changes → `worldstate.Store.Upsert`
  - Hook candidates → `ForeshadowTracker.AddPending`（Hook Tracker #45 整合）
- 新增 `GET /narrative` debug 頁面：貼入章節 → 觸發抽取 → 四區塊顯示結果
- 字數限制 20000 字元（與 detect 端點一致）

## Acceptance Criteria 對應

- [x] 場景輸入後可觸發 LLM 抽取結構化狀態
- [x] 抽取結果寫入 timeline / relationship / foreshadow tracker
- [x] 下次 reindex 後抽取資料可被 retrieval 使用（worldstate 寫入後即生效）
- [x] 提供 debug 檢視頁面（`/narrative`）
- [x] Hook Tracker 整合：抽取到的 hook 自動進入待確認清單

## Test plan

- [x] `go test ./...` 全過
- [x] `TestNarrativeExtract`：mock LLM → extract → 驗證四種資料正確回傳
- [x] 400 驗證：缺 chapter_index 回傳 400

Closes #46