### PR TITLE
feat(first-run): Ollama status check, model pull API, dashboard banner, settings tier selector

### DIFF
--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// entryAliases are all model name variants that resolve to the Entry hardware tier.
+// llama3.2, llama3.2:latest, and llama3.2:3b are treated as equivalent for readiness checks.
+var entryAliases = map[string]bool{
+	"llama3.2":        true,
+	"llama3.2:latest": true,
+	"llama3.2:3b":     true,
+}
+
+// entryPullTarget is the concrete model name to pull when the configured model is an Entry alias.
+const entryPullTarget = "llama3.2:3b"
+
+// normalizeModel strips a trailing ":latest" tag for general equality checks.
+// This lets "nomic-embed-text" match "nomic-embed-text:latest" in the Ollama tag list.
+func normalizeModel(name string) string {
+	return strings.TrimSuffix(name, ":latest")
+}
+
+// pullTarget returns the concrete model name that should be passed to ollama pull.
+// Entry aliases are resolved to entryPullTarget; all others are returned as-is.
+func pullTarget(configured string) string {
+	if entryAliases[configured] {
+		return entryPullTarget
+	}
+	return configured
+}
+
+// modelReady reports whether the configured model name is satisfied by the
+// list of models that Ollama reports. Two-layer matching:
+//  1. Entry alias: any of the entryAliases set matches any of the reported names.
+//  2. General: strip :latest from both sides and compare.
+func modelReady(configured string, reported []string) bool {
+	if entryAliases[configured] {
+		for _, r := range reported {
+			if entryAliases[r] {
+				return true
+			}
+		}
+		return false
+	}
+	norm := normalizeModel(configured)
+	for _, r := range reported {
+		if normalizeModel(r) == norm {
+			return true
+		}
+	}
+	return false
+}
+
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name  string `json:"name"`
+		Model string `json:"model"`
+	} `json:"models"`
+}
+
+type ollamaStatusResponse struct {
+	Running       bool     `json:"running"`
+	Models        []string `json:"models"`
+	LLMReady      bool     `json:"llm_ready"`
+	EmbedReady    bool     `json:"embed_ready"`
+	LLMModel      string   `json:"llm_model"`
+	EmbedModel    string   `json:"embed_model"`
+	LLMPullModel  string   `json:"llm_pull_model"`
+	EmbedPullModel string   `json:"embed_pull_model"`
+}
+
+func (s *Server) handleOllamaStatus(c *gin.Context) {
+	llmModel := s.cfg.LLMModel
+	embedModel := s.cfg.EmbedModel
+
+	resp := ollamaStatusResponse{
+		LLMModel:       llmModel,
+		EmbedModel:     embedModel,
+		LLMPullModel:   pullTarget(llmModel),
+		EmbedPullModel: pullTarget(embedModel),
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", s.cfg.OllamaURL+"/api/tags", nil)
+	if err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&tags); err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	resp.Running = true
+	names := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		name := m.Name
+		if name == "" {
+			name = m.Model
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	resp.Models = names
+	resp.LLMReady = modelReady(llmModel, names)
+	resp.EmbedReady = modelReady(embedModel, names)
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// inflight tracks models currently being pulled; value is a cancel func.
+var (
+	inflightMu sync.Mutex
+	inflight   = map[string]context.CancelFunc{}
+)
+
+func (s *Server) handleOllamaPull(c *gin.Context) {
+	var req struct {
+		Model string `json:"model"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "請求格式錯誤"})
+		return
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model 不可為空"})
+		return
+	}
+
+	inflightMu.Lock()
+	if _, ok := inflight[model]; ok {
+		inflightMu.Unlock()
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("模型 %s 已在下載中", model)})
+		return
+	}
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	inflight[model] = cancel
+	inflightMu.Unlock()
+
+	defer func() {
+		inflightMu.Lock()
+		delete(inflight, model)
+		inflightMu.Unlock()
+		cancel()
+	}()
+
+	body, _ := json.Marshal(map[string]string{"model": model, "stream": "true"})
+	pullReq, err := http.NewRequestWithContext(ctx, "POST", s.cfg.OllamaURL+"/api/pull",
+		strings.NewReader(string(body)))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	pullReq.Header.Set("Content-Type", "application/json")
+
+	// Short dial timeout only; the response stream follows client context lifetime.
+	client := &http.Client{Transport: &http.Transport{
+		ResponseHeaderTimeout: 5 * time.Second,
+	}}
+	pullResp, err := client.Do(pullReq)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "無法連線 Ollama：" + err.Error()})
+		return
+	}
+	defer pullResp.Body.Close()
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	flusher, _ := c.Writer.(http.Flusher)
+
+	scanner := bufio.NewScanner(pullResp.Body)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var frame map[string]any
+		if err := json.Unmarshal(line, &frame); err != nil {
+			continue
+		}
+		if errMsg, ok := frame["error"].(string); ok {
+			fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n",
+				mustJSON(map[string]string{"error": errMsg}))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		// "status":"success" marks completion in Ollama pull stream
+		if status, _ := frame["status"].(string); status == "success" {
+			fmt.Fprintf(c.Writer, "event: done\ndata: {}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		fmt.Fprintf(c.Writer, "event: progress\ndata: %s\n\n", mustJSON(frame))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	// EOF without explicit success frame — treat as done
+	fmt.Fprintf(c.Writer, "event: done\ndata: {}\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/internal/server/ollama_test.go
+++ b/internal/server/ollama_test.go
@@ -1,0 +1,372 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ─── unit: normalize helpers ─────────────────────────────────────────────────
+
+func TestNormalizeModel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"nomic-embed-text", "nomic-embed-text"},
+		{"nomic-embed-text:latest", "nomic-embed-text"},
+		{"llama3.1:8b", "llama3.1:8b"},
+		{"llama3.2:latest", "llama3.2"},
+	}
+	for _, c := range cases {
+		if got := normalizeModel(c.in); got != c.want {
+			t.Errorf("normalizeModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPullTarget(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"llama3.2", entryPullTarget},
+		{"llama3.2:latest", entryPullTarget},
+		{"llama3.2:3b", entryPullTarget},
+		{"llama3.1:8b", "llama3.1:8b"},
+		{"nomic-embed-text", "nomic-embed-text"},
+		{"gemma3:27b", "gemma3:27b"},
+	}
+	for _, c := range cases {
+		if got := pullTarget(c.in); got != c.want {
+			t.Errorf("pullTarget(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestModelReady(t *testing.T) {
+	reported := []string{"llama3.2:latest", "nomic-embed-text:latest", "llama3.1:8b"}
+
+	cases := []struct {
+		configured string
+		want       bool
+	}{
+		// Entry alias: any alias matches any alias in reported
+		{"llama3.2", true},
+		{"llama3.2:latest", true},
+		{"llama3.2:3b", true},
+		// General :latest strip
+		{"nomic-embed-text", true},
+		{"nomic-embed-text:latest", true},
+		// Exact (after strip)
+		{"llama3.1:8b", true},
+		// Not present
+		{"gemma3:27b", false},
+		{"llama3.3:70b", false},
+	}
+	for _, c := range cases {
+		if got := modelReady(c.configured, reported); got != c.want {
+			t.Errorf("modelReady(%q, reported) = %v, want %v", c.configured, got, c.want)
+		}
+	}
+}
+
+// ─── integration: handleOllamaStatus ─────────────────────────────────────────
+
+func ollamaMockServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprint(w, body)
+	}))
+}
+
+func TestHandleOllamaStatus_Down(t *testing.T) {
+	t.Parallel()
+	// Point to a server that immediately rejects connections
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Close connection immediately to simulate Ollama being down
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "", http.StatusServiceUnavailable)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	s := newTestServerWithOllama(t, srv.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var resp ollamaStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Running {
+		t.Error("expected running=false when Ollama is down")
+	}
+	if resp.LLMReady || resp.EmbedReady {
+		t.Error("expected llm_ready=false and embed_ready=false when Ollama is down")
+	}
+}
+
+func TestHandleOllamaStatus_AllReady(t *testing.T) {
+	t.Parallel()
+	body := `{"models":[{"name":"llama3.2:latest"},{"name":"nomic-embed-text:latest"}]}`
+	mock := ollamaMockServer(t, 200, body)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if !resp.Running {
+		t.Error("expected running=true")
+	}
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true for llama3.2 matched against llama3.2:latest")
+	}
+	if !resp.EmbedReady {
+		t.Error("expected embed_ready=true for nomic-embed-text matched against nomic-embed-text:latest")
+	}
+}
+
+func TestHandleOllamaStatus_MissingLLM(t *testing.T) {
+	t.Parallel()
+	body := `{"models":[{"name":"nomic-embed-text:latest"}]}`
+	mock := ollamaMockServer(t, 200, body)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.1:8b", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if !resp.Running {
+		t.Error("expected running=true")
+	}
+	if resp.LLMReady {
+		t.Error("expected llm_ready=false")
+	}
+	if !resp.EmbedReady {
+		t.Error("expected embed_ready=true")
+	}
+}
+
+func TestHandleOllamaStatus_MissingEmbed(t *testing.T) {
+	t.Parallel()
+	body := `{"models":[{"name":"llama3.2:3b"}]}`
+	mock := ollamaMockServer(t, 200, body)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true (llama3.2 entry alias matches llama3.2:3b)")
+	}
+	if resp.EmbedReady {
+		t.Error("expected embed_ready=false")
+	}
+}
+
+func TestHandleOllamaStatus_LatestNormalize(t *testing.T) {
+	t.Parallel()
+	// Ollama reports llama3.1:8b:latest (unusual but possible)
+	body := `{"models":[{"name":"llama3.1:8b"},{"name":"nomic-embed-text"}]}`
+	mock := ollamaMockServer(t, 200, body)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.1:8b", "nomic-embed-text:latest")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true")
+	}
+	if !resp.EmbedReady {
+		t.Error("expected embed_ready=true for nomic-embed-text:latest matched against nomic-embed-text")
+	}
+}
+
+func TestHandleOllamaStatus_EntryAlias(t *testing.T) {
+	t.Parallel()
+	// Configured as llama3.2:3b; Ollama reports llama3.2:latest
+	body := `{"models":[{"name":"llama3.2:latest"},{"name":"nomic-embed-text"}]}`
+	mock := ollamaMockServer(t, 200, body)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2:3b", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true: llama3.2:3b entry alias should match llama3.2:latest")
+	}
+	if resp.LLMPullModel != entryPullTarget {
+		t.Errorf("expected llm_pull_model=%q, got %q", entryPullTarget, resp.LLMPullModel)
+	}
+}
+
+// ─── integration: handleOllamaPull ───────────────────────────────────────────
+
+func TestHandleOllamaPull_ForwardsProgress(t *testing.T) {
+	t.Parallel()
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"status":"pulling manifest","completed":0,"total":100}`)
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"llama3.2:3b"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	resp := rec.Body.String()
+	if !strings.Contains(resp, "event: progress") {
+		t.Errorf("expected progress event, got: %s", resp)
+	}
+	if !strings.Contains(resp, "event: done") {
+		t.Errorf("expected done event, got: %s", resp)
+	}
+}
+
+func TestHandleOllamaPull_ForwardsError(t *testing.T) {
+	t.Parallel()
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"error":"model 'nosuchmodel' not found"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"nosuchmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	resp := rec.Body.String()
+	if !strings.Contains(resp, "event: error") {
+		t.Errorf("expected error event, got: %s", resp)
+	}
+	if strings.Contains(resp, "event: done") {
+		t.Errorf("should not emit done after error, got: %s", resp)
+	}
+}
+
+func TestHandleOllamaPull_DuplicateReturns409(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			close(started)
+			<-unblock
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+	defer close(unblock)
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+
+	go func() {
+		body := strings.NewReader(`{"model":"slowmodel"}`)
+		req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+		req.Header.Set("Content-Type", "application/json")
+		s.router.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	<-started
+
+	body := strings.NewReader(`{"model":"slowmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", rec.Code)
+	}
+}
+
+func TestHandleOllamaPull_ReleasesLockAfterCompletion(t *testing.T) {
+	t.Parallel()
+
+	// Verify the inflight lock is released via defer after the handler finishes,
+	// regardless of whether the client cancelled or the stream completed normally.
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			// Write headers then signal done; scanner will see EOF and handler will return.
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"lockmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	s.router.ServeHTTP(httptest.NewRecorder(), req)
+
+	inflightMu.Lock()
+	_, locked := inflight["lockmodel"]
+	inflightMu.Unlock()
+
+	if locked {
+		t.Error("inflight lock not released after handler completion")
+	}
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func newTestServerWithOllama(t *testing.T, ollamaURL, llmModel, embedModel string) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollamaURL)
+	s.cfg.LLMModel = llmModel
+	s.cfg.EmbedModel = embedModel
+	return s
+}
+
+func newTestRequest(t *testing.T, s *Server, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	s.router.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,8 @@ func (s *Server) setupRoutes() {
 	protected.GET("/evaluate", s.handleEvaluatePage)
 	protected.POST("/evaluate/stream", s.handleEvaluateStream)
 	protected.GET("/api/demo", s.handleDemoData)
+	protected.GET("/api/ollama/status", s.handleOllamaStatus)
+	protected.POST("/api/ollama/pull", s.handleOllamaPull)
 
 	protected.POST("/export", s.handleExport)
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -16,6 +16,8 @@
       <p>你的小說專案總覽</p>
     </div>
 
+    <div id="ollama-banner" style="display:none;margin-bottom:1.5rem"></div>
+
     <div class="stats-grid">
       <div class="stat-card">
         <div class="stat-num">{{.CharCount}}</div>
@@ -155,6 +157,126 @@
   </main>
 </div>
 <script>
+// ─── Ollama status banner ─────────────────────────────────────────────────────
+
+let _ollamaPulling = {};
+
+async function refreshOllamaStatus() {
+  try {
+    const resp = await fetch('/api/ollama/status');
+    if (!resp.ok) return;
+    renderOllamaBanner(await resp.json());
+  } catch (_) {}
+}
+
+function renderOllamaBanner(s) {
+  const banner = document.getElementById('ollama-banner');
+  const rows = [];
+
+  if (!s.running) {
+    rows.push(`
+      <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;padding:0.75rem 1rem;background:#431407;border:1px solid #c2410c;border-radius:8px;margin-bottom:0.5rem">
+        <span style="color:#fb923c;font-weight:600;font-size:0.85rem">⚠ Ollama 未啟動</span>
+        <span style="color:#94a3b8;font-size:0.85rem">請先安裝並啟動 Ollama，才能使用 AI 審查功能。</span>
+        <a href="https://ollama.com/download" target="_blank" rel="noopener" class="btn" style="margin-left:auto;padding:0.3rem 0.8rem;font-size:0.8rem">下載 Ollama</a>
+        <button class="btn" style="padding:0.3rem 0.8rem;font-size:0.8rem" onclick="copyCmd('ollama serve')">複製啟動指令</button>
+      </div>`);
+  } else {
+    if (!s.llm_ready) {
+      rows.push(missingModelRow(s.llm_model, s.llm_pull_model, 'llm'));
+    }
+    if (!s.embed_ready) {
+      rows.push(missingModelRow(s.embed_model, s.embed_pull_model, 'embed'));
+    }
+  }
+
+  if (rows.length === 0) {
+    banner.style.display = 'none';
+    banner.innerHTML = '';
+  } else {
+    banner.innerHTML = rows.join('');
+    banner.style.display = 'block';
+  }
+}
+
+function missingModelRow(displayModel, pullModel, key) {
+  const btnId = `pull-btn-${key}`;
+  const progId = `pull-prog-${key}`;
+  return `
+    <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;padding:0.75rem 1rem;background:#1c1917;border:1px solid #78350f;border-radius:8px;margin-bottom:0.5rem">
+      <span style="color:#fbbf24;font-weight:600;font-size:0.85rem">⚠ 缺少模型</span>
+      <span style="color:#94a3b8;font-size:0.85rem">需要 <code>${escHTMLInline(displayModel)}</code></span>
+      <button id="${btnId}" class="btn" style="margin-left:auto;padding:0.3rem 0.8rem;font-size:0.8rem"
+        onclick="pullModel('${escHTMLInline(pullModel)}','${key}')">下載 ${escHTMLInline(pullModel)}</button>
+      <span id="${progId}" style="font-size:0.8rem;color:#94a3b8"></span>
+    </div>`;
+}
+
+async function pullModel(model, key) {
+  if (_ollamaPulling[key]) return;
+  _ollamaPulling[key] = true;
+  const btn = document.getElementById(`pull-btn-${key}`);
+  const prog = document.getElementById(`pull-prog-${key}`);
+  if (btn) btn.disabled = true;
+
+  try {
+    const resp = await fetch('/api/ollama/pull', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    });
+    if (!resp.ok) {
+      const err = await resp.text();
+      if (prog) prog.textContent = '下載失敗：' + err;
+      return;
+    }
+    const reader = resp.body.getReader();
+    const dec = new TextDecoder();
+    let buf = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      let event = '';
+      for (const line of lines) {
+        if (line.startsWith('event:')) { event = line.slice(6).trim(); continue; }
+        if (!line.startsWith('data:')) continue;
+        const data = JSON.parse(line.slice(5).trim());
+        if (event === 'error') {
+          if (prog) prog.textContent = '下載失敗：' + (data.error || '未知錯誤');
+          return;
+        }
+        if (event === 'progress' && prog) {
+          const pct = data.total > 0 ? Math.round(data.completed / data.total * 100) : null;
+          prog.textContent = pct !== null ? `${pct}%` : (data.status || '下載中…');
+        }
+        if (event === 'done') break;
+      }
+    }
+    if (prog) prog.textContent = '下載完成';
+    await refreshOllamaStatus();
+  } catch (e) {
+    if (prog) prog.textContent = '下載失敗：' + e.message;
+  } finally {
+    _ollamaPulling[key] = false;
+    if (btn) btn.disabled = false;
+  }
+}
+
+function copyCmd(cmd) {
+  navigator.clipboard.writeText(cmd).then(() => alert('已複製：' + cmd));
+}
+
+function escHTMLInline(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+refreshOllamaStatus();
+
+// ─── template helper ──────────────────────────────────────────────────────────
+
 async function applyTemplate(template) {
   const status = document.getElementById('template-status');
   status.textContent = '套用模板中...';

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -24,8 +24,18 @@
           <input type="text" id="ollama-url" value="{{.Project.OllamaURL}}">
         </div>
         <div class="form-group">
-          <label for="llm-model">LLM 模型</label>
-          <input type="text" id="llm-model" value="{{.Project.LLMModel}}">
+          <label>硬體規格（自動推薦模型）</label>
+          <select id="hw-tier" onchange="onTierChange(this.value)" style="width:100%;margin-bottom:6px">
+            <option value="entry">Entry — 4GB VRAM（llama3.2:3b）</option>
+            <option value="standard">Standard — 8GB VRAM（llama3.1:8b）</option>
+            <option value="advanced">Advanced — 24GB VRAM（gemma3:27b）</option>
+            <option value="pro">Pro — 48GB+ VRAM（llama3.3:70b）</option>
+            <option value="custom">自訂</option>
+          </select>
+          <label for="llm-model">LLM 模型名稱</label>
+          <input type="text" id="llm-model" value="{{.Project.LLMModel}}" placeholder="llama3.1:8b">
+          <button type="button" class="btn" id="pull-llm-btn" style="margin-top:6px;padding:0.3rem 0.8rem;font-size:0.85rem" onclick="pullSettingsModel('llm')">下載所選模型</button>
+          <span id="pull-llm-prog" class="helper-text" style="margin-left:8px"></span>
         </div>
         <div class="form-group">
           <label for="embed-model">Embedding 模型</label>
@@ -149,6 +159,97 @@
   </main>
 </div>
 <script>
+// ─── Hardware tier selector ───────────────────────────────────────────────────
+
+const TIER_MODELS = {
+  entry:    'llama3.2:3b',
+  standard: 'llama3.1:8b',
+  advanced: 'gemma3:27b',
+  pro:      'llama3.3:70b',
+};
+const ENTRY_ALIASES = ['llama3.2', 'llama3.2:latest', 'llama3.2:3b'];
+
+function modelToTier(model) {
+  if (ENTRY_ALIASES.includes(model)) return 'entry';
+  for (const [tier, m] of Object.entries(TIER_MODELS)) {
+    if (m === model) return tier;
+  }
+  return 'custom';
+}
+
+function onTierChange(tier) {
+  const input = document.getElementById('llm-model');
+  if (tier !== 'custom') {
+    input.value = TIER_MODELS[tier];
+    input.readOnly = true;
+  } else {
+    input.readOnly = false;
+    input.focus();
+  }
+}
+
+(function initTierSelector() {
+  const current = document.getElementById('llm-model').value.trim();
+  const tier = modelToTier(current);
+  document.getElementById('hw-tier').value = tier;
+  document.getElementById('llm-model').readOnly = (tier !== 'custom');
+})();
+
+let _settingsPulling = {};
+
+async function pullSettingsModel(key) {
+  if (_settingsPulling[key]) return;
+  const model = document.getElementById('llm-model').value.trim();
+  if (!model) { alert('請先輸入模型名稱'); return; }
+
+  _settingsPulling[key] = true;
+  const btn = document.getElementById(`pull-${key}-btn`);
+  const prog = document.getElementById(`pull-${key}-prog`);
+  btn.disabled = true;
+  prog.textContent = '準備下載…';
+
+  try {
+    const resp = await fetch('/api/ollama/pull', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    });
+    if (!resp.ok) {
+      prog.textContent = '下載失敗：' + (await resp.text());
+      return;
+    }
+    const reader = resp.body.getReader();
+    const dec = new TextDecoder();
+    let buf = '';
+    outer: while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      let event = '';
+      for (const line of lines) {
+        if (line.startsWith('event:')) { event = line.slice(6).trim(); continue; }
+        if (!line.startsWith('data:')) continue;
+        const data = JSON.parse(line.slice(5).trim());
+        if (event === 'error') { prog.textContent = '下載失敗：' + (data.error || '未知錯誤'); break outer; }
+        if (event === 'progress') {
+          const pct = data.total > 0 ? Math.round(data.completed / data.total * 100) : null;
+          prog.textContent = pct !== null ? `${pct}%` : (data.status || '下載中…');
+        }
+        if (event === 'done') { prog.textContent = '下載完成'; break outer; }
+      }
+    }
+  } catch (e) {
+    prog.textContent = '下載失敗：' + e.message;
+  } finally {
+    _settingsPulling[key] = false;
+    btn.disabled = false;
+  }
+}
+
+// ─── Settings page ────────────────────────────────────────────────────────────
+
 const presetChecks = {{ jsonJS .DefaultChecks }};
 const presetStyles = {{ jsonJS .DefaultStyles }};
 const reviewBias = {{ jsonJS .Settings.ReviewBias }};


### PR DESCRIPTION
## Summary

- **`GET /api/ollama/status`** — 檢查 Ollama 連線狀態與模型就緒情況，回傳 `running`、`llm_ready`、`embed_ready`、`llm_pull_model`、`embed_pull_model`；含兩層 normalize（Entry alias + :latest strip）
- **`POST /api/ollama/pull`** — SSE 串流轉發 Ollama pull 進度，含防重入（409）、client context 綁定、error frame 轉發
- **儀表板 Ollama 狀態列** — 頁面載入後自動 fetch status；Ollama 未啟動 → 橙色 banner + 下載連結；缺模型 → 黃色 row + 各自「下載」按鈕 + 進度顯示；全就緒時 banner 隱藏
- **設定頁硬體分級選擇器** — 從現有 `llm_model` 反推初始 tier（含 Entry alias 識別）；選 tier 自動填模型名稱且鎖定編輯；選「自訂」可自由輸入；「下載所選模型」按鈕含 SSE 進度

## Normalize 規則

| 情境 | 規則 |
|---|---|
| Entry alias | `llama3.2`、`llama3.2:latest`、`llama3.2:3b` 視為同一組，任一對任一都算 ready |
| 一般模型 | 去掉 `:latest` suffix 後 exact match |
| pull target | Entry alias 統一送 `llama3.2:3b`；其他保持設定值 |

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` 通過（12 個 ollama 相關測試全綠）
- [x] 覆蓋：status down / all ready / missing LLM / missing embed / :latest normalize / Entry alias
- [x] 覆蓋：pull progress forwarding / error forwarding / duplicate 409 / lock released after completion

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)