### PR TITLE
feat(ollama): GET /api/ollama/status with two-layer model normalize

### DIFF
--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+var entryAliases = map[string]bool{
+	"llama3.2":        true,
+	"llama3.2:latest": true,
+	"llama3.2:3b":     true,
+}
+
+const entryPullTarget = "llama3.2:3b"
+
+func normalizeModel(name string) string {
+	return strings.TrimSuffix(name, ":latest")
+}
+
+func pullTarget(configured string) string {
+	if entryAliases[configured] {
+		return entryPullTarget
+	}
+	return configured
+}
+
+func modelReady(configured string, reported []string) bool {
+	if entryAliases[configured] {
+		for _, r := range reported {
+			if entryAliases[r] {
+				return true
+			}
+		}
+		return false
+	}
+	norm := normalizeModel(configured)
+	for _, r := range reported {
+		if normalizeModel(r) == norm {
+			return true
+		}
+	}
+	return false
+}
+
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name  string `json:"name"`
+		Model string `json:"model"`
+	} `json:"models"`
+}
+
+type ollamaStatusResponse struct {
+	Running        bool     `json:"running"`
+	Models         []string `json:"models"`
+	LLMReady       bool     `json:"llm_ready"`
+	EmbedReady     bool     `json:"embed_ready"`
+	LLMModel       string   `json:"llm_model"`
+	EmbedModel     string   `json:"embed_model"`
+	LLMPullModel   string   `json:"llm_pull_model"`
+	EmbedPullModel string   `json:"embed_pull_model"`
+}
+
+func (s *Server) handleOllamaStatus(c *gin.Context) {
+	llmModel := s.cfg.LLMModel
+	embedModel := s.cfg.EmbedModel
+
+	resp := ollamaStatusResponse{
+		LLMModel:       llmModel,
+		EmbedModel:     embedModel,
+		LLMPullModel:   pullTarget(llmModel),
+		EmbedPullModel: pullTarget(embedModel),
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", s.cfg.OllamaURL+"/api/tags", nil)
+	if err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	httpResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+	defer httpResp.Body.Close()
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(httpResp.Body).Decode(&tags); err != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
+	resp.Running = true
+	names := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		name := m.Name
+		if name == "" {
+			name = m.Model
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	resp.Models = names
+	resp.LLMReady = modelReady(llmModel, names)
+	resp.EmbedReady = modelReady(embedModel, names)
+
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -92,6 +92,11 @@ func (s *Server) handleOllamaStatus(c *gin.Context) {
 	}
 	defer httpResp.Body.Close()
 
+	if httpResp.StatusCode != http.StatusOK {
+		c.JSON(http.StatusOK, resp)
+		return
+	}
+
 	var tags ollamaTagsResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&tags); err != nil {
 		c.JSON(http.StatusOK, resp)

--- a/internal/server/ollama_test.go
+++ b/internal/server/ollama_test.go
@@ -147,6 +147,27 @@ func TestHandleOllamaStatus_LatestNormalize(t *testing.T) {
 	}
 }
 
+func TestHandleOllamaStatus_Non200TagsResponse(t *testing.T) {
+	t.Parallel()
+	// Ollama or a proxy returns 500 with a JSON error body.
+	// running should remain false, not be set to true with empty models.
+	mock := ollamaMockServer(t, 500, `{"error":"internal server error"}`)
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	if resp.Running {
+		t.Error("expected running=false when /api/tags returns non-200")
+	}
+	if resp.LLMReady || resp.EmbedReady {
+		t.Error("expected both ready=false when /api/tags returns non-200")
+	}
+}
+
 func TestHandleOllamaStatus_EntryAlias(t *testing.T) {
 	t.Parallel()
 	mock := ollamaMockServer(t, 200, `{"models":[{"name":"llama3.2:latest"},{"name":"nomic-embed-text"}]}`)

--- a/internal/server/ollama_test.go
+++ b/internal/server/ollama_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNormalizeModel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"nomic-embed-text", "nomic-embed-text"},
+		{"nomic-embed-text:latest", "nomic-embed-text"},
+		{"llama3.1:8b", "llama3.1:8b"},
+		{"llama3.2:latest", "llama3.2"},
+	}
+	for _, c := range cases {
+		if got := normalizeModel(c.in); got != c.want {
+			t.Errorf("normalizeModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPullTarget(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"llama3.2", entryPullTarget},
+		{"llama3.2:latest", entryPullTarget},
+		{"llama3.2:3b", entryPullTarget},
+		{"llama3.1:8b", "llama3.1:8b"},
+		{"nomic-embed-text", "nomic-embed-text"},
+	}
+	for _, c := range cases {
+		if got := pullTarget(c.in); got != c.want {
+			t.Errorf("pullTarget(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestModelReady(t *testing.T) {
+	reported := []string{"llama3.2:latest", "nomic-embed-text:latest", "llama3.1:8b"}
+	cases := []struct {
+		configured string
+		want       bool
+	}{
+		{"llama3.2", true},
+		{"llama3.2:latest", true},
+		{"llama3.2:3b", true},
+		{"nomic-embed-text", true},
+		{"nomic-embed-text:latest", true},
+		{"llama3.1:8b", true},
+		{"gemma3:27b", false},
+		{"llama3.3:70b", false},
+	}
+	for _, c := range cases {
+		if got := modelReady(c.configured, reported); got != c.want {
+			t.Errorf("modelReady(%q, reported) = %v, want %v", c.configured, got, c.want)
+		}
+	}
+}
+
+func ollamaMockServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		fmt.Fprint(w, body)
+	}))
+}
+
+func TestHandleOllamaStatus_Down(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "", http.StatusServiceUnavailable)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer srv.Close()
+	s := newTestServerWithOllama(t, srv.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Running {
+		t.Error("expected running=false when Ollama is down")
+	}
+}
+
+func TestHandleOllamaStatus_AllReady(t *testing.T) {
+	t.Parallel()
+	mock := ollamaMockServer(t, 200, `{"models":[{"name":"llama3.2:latest"},{"name":"nomic-embed-text:latest"}]}`)
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.Running || !resp.LLMReady || !resp.EmbedReady {
+		t.Errorf("expected all ready, got running=%v llm=%v embed=%v", resp.Running, resp.LLMReady, resp.EmbedReady)
+	}
+}
+
+func TestHandleOllamaStatus_MissingLLM(t *testing.T) {
+	t.Parallel()
+	mock := ollamaMockServer(t, 200, `{"models":[{"name":"nomic-embed-text:latest"}]}`)
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.1:8b", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.LLMReady {
+		t.Error("expected llm_ready=false")
+	}
+	if !resp.EmbedReady {
+		t.Error("expected embed_ready=true")
+	}
+}
+
+func TestHandleOllamaStatus_MissingEmbed(t *testing.T) {
+	t.Parallel()
+	mock := ollamaMockServer(t, 200, `{"models":[{"name":"llama3.2:3b"}]}`)
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true (entry alias)")
+	}
+	if resp.EmbedReady {
+		t.Error("expected embed_ready=false")
+	}
+}
+
+func TestHandleOllamaStatus_LatestNormalize(t *testing.T) {
+	t.Parallel()
+	mock := ollamaMockServer(t, 200, `{"models":[{"name":"llama3.1:8b"},{"name":"nomic-embed-text"}]}`)
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.1:8b", "nomic-embed-text:latest")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.LLMReady || !resp.EmbedReady {
+		t.Errorf("expected both ready after :latest normalize, got llm=%v embed=%v", resp.LLMReady, resp.EmbedReady)
+	}
+}
+
+func TestHandleOllamaStatus_EntryAlias(t *testing.T) {
+	t.Parallel()
+	mock := ollamaMockServer(t, 200, `{"models":[{"name":"llama3.2:latest"},{"name":"nomic-embed-text"}]}`)
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2:3b", "nomic-embed-text")
+	rec := newTestRequest(t, s, "GET", "/api/ollama/status", nil)
+	var resp ollamaStatusResponse
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if !resp.LLMReady {
+		t.Error("expected llm_ready=true: llama3.2:3b alias matches llama3.2:latest")
+	}
+	if resp.LLMPullModel != entryPullTarget {
+		t.Errorf("expected llm_pull_model=%q, got %q", entryPullTarget, resp.LLMPullModel)
+	}
+}
+
+func newTestServerWithOllama(t *testing.T, ollamaURL, llmModel, embedModel string) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollamaURL)
+	s.cfg.LLMModel = llmModel
+	s.cfg.EmbedModel = embedModel
+	return s
+}
+
+func newTestRequest(t *testing.T, s *Server, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	s.router.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,7 @@ func (s *Server) setupRoutes() {
 	protected.GET("/evaluate", s.handleEvaluatePage)
 	protected.POST("/evaluate/stream", s.handleEvaluateStream)
 	protected.GET("/api/demo", s.handleDemoData)
+	protected.GET("/api/ollama/status", s.handleOllamaStatus)
 
 	protected.POST("/export", s.handleExport)
 }


### PR DESCRIPTION
## Summary

- 新增 `GET /api/ollama/status`（protected group）
- 呼叫 `{OllamaURL}/api/tags`，timeout 2s；解析 `models[].name`（fallback `models[].model`）
- 兩層 normalize：Entry alias（llama3.2 / llama3.2:latest / llama3.2:3b 視為同一組）+ 一般 `:latest` strip
- 回傳 `running`, `llm_ready`, `embed_ready`, `llm_pull_model`, `embed_pull_model`

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./...` 通過（9 個測試：down / all ready / missing LLM / missing embed / :latest normalize / Entry alias + unit normalize/pullTarget/modelReady）

Part of #78 (1/5)
🤖 Generated with [Claude Code](https://claude.com/claude-code)