### PR TITLE
feat(settings): hardware tier selector with reverse-mapping and pull UI

### DIFF
--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -24,8 +24,18 @@
           <input type="text" id="ollama-url" value="{{.Project.OllamaURL}}">
         </div>
         <div class="form-group">
-          <label for="llm-model">LLM 模型</label>
-          <input type="text" id="llm-model" value="{{.Project.LLMModel}}">
+          <label>硬體規格（自動推薦模型）</label>
+          <select id="hw-tier" onchange="onTierChange(this.value)" style="width:100%;margin-bottom:6px">
+            <option value="entry">Entry — 4GB VRAM（llama3.2:3b）</option>
+            <option value="standard">Standard — 8GB VRAM（llama3.1:8b）</option>
+            <option value="advanced">Advanced — 24GB VRAM（gemma3:27b）</option>
+            <option value="pro">Pro — 48GB+ VRAM（llama3.3:70b）</option>
+            <option value="custom">自訂</option>
+          </select>
+          <label for="llm-model">LLM 模型名稱</label>
+          <input type="text" id="llm-model" value="{{.Project.LLMModel}}" placeholder="llama3.1:8b">
+          <button type="button" class="btn" id="pull-llm-btn" style="margin-top:6px;padding:0.3rem 0.8rem;font-size:0.85rem" onclick="pullSettingsModel('llm')">下載所選模型</button>
+          <span id="pull-llm-prog" class="helper-text" style="margin-left:8px"></span>
         </div>
         <div class="form-group">
           <label for="embed-model">Embedding 模型</label>
@@ -149,6 +159,97 @@
   </main>
 </div>
 <script>
+// ─── Hardware tier selector ───────────────────────────────────────────────────
+
+const TIER_MODELS = {
+  entry:    'llama3.2:3b',
+  standard: 'llama3.1:8b',
+  advanced: 'gemma3:27b',
+  pro:      'llama3.3:70b',
+};
+const ENTRY_ALIASES = ['llama3.2', 'llama3.2:latest', 'llama3.2:3b'];
+
+function modelToTier(model) {
+  if (ENTRY_ALIASES.includes(model)) return 'entry';
+  for (const [tier, m] of Object.entries(TIER_MODELS)) {
+    if (m === model) return tier;
+  }
+  return 'custom';
+}
+
+function onTierChange(tier) {
+  const input = document.getElementById('llm-model');
+  if (tier !== 'custom') {
+    input.value = TIER_MODELS[tier];
+    input.readOnly = true;
+  } else {
+    input.readOnly = false;
+    input.focus();
+  }
+}
+
+(function initTierSelector() {
+  const current = document.getElementById('llm-model').value.trim();
+  const tier = modelToTier(current);
+  document.getElementById('hw-tier').value = tier;
+  document.getElementById('llm-model').readOnly = (tier !== 'custom');
+})();
+
+let _settingsPulling = {};
+
+async function pullSettingsModel(key) {
+  if (_settingsPulling[key]) return;
+  const model = document.getElementById('llm-model').value.trim();
+  if (!model) { alert('請先輸入模型名稱'); return; }
+
+  _settingsPulling[key] = true;
+  const btn = document.getElementById(`pull-${key}-btn`);
+  const prog = document.getElementById(`pull-${key}-prog`);
+  btn.disabled = true;
+  prog.textContent = '準備下載…';
+
+  try {
+    const resp = await fetch('/api/ollama/pull', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model }),
+    });
+    if (!resp.ok) {
+      prog.textContent = '下載失敗：' + (await resp.text());
+      return;
+    }
+    const reader = resp.body.getReader();
+    const dec = new TextDecoder();
+    let buf = '';
+    outer: while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      let event = '';
+      for (const line of lines) {
+        if (line.startsWith('event:')) { event = line.slice(6).trim(); continue; }
+        if (!line.startsWith('data:')) continue;
+        const data = JSON.parse(line.slice(5).trim());
+        if (event === 'error') { prog.textContent = '下載失敗：' + (data.error || '未知錯誤'); break outer; }
+        if (event === 'progress') {
+          const pct = data.total > 0 ? Math.round(data.completed / data.total * 100) : null;
+          prog.textContent = pct !== null ? `${pct}%` : (data.status || '下載中…');
+        }
+        if (event === 'done') { prog.textContent = '下載完成'; break outer; }
+      }
+    }
+  } catch (e) {
+    prog.textContent = '下載失敗：' + e.message;
+  } finally {
+    _settingsPulling[key] = false;
+    btn.disabled = false;
+  }
+}
+
+// ─── Settings page ────────────────────────────────────────────────────────────
+
 const presetChecks = {{ jsonJS .DefaultChecks }};
 const presetStyles = {{ jsonJS .DefaultStyles }};
 const reviewBias = {{ jsonJS .Settings.ReviewBias }};


### PR DESCRIPTION
## Summary

- LLM 模型欄改為硬體規格選擇器 + 模型名稱欄組合
- 四個 tier（Entry/Standard/Advanced/Pro）+ 自訂
- 初始化從現有 `llm_model` 反推 tier（含 Entry alias 識別；未知值 → 自訂）
- 選 tier 自動填模型名稱並設為唯讀；選自訂可自由編輯
- 「下載所選模型」按鈕呼叫 `/api/ollama/pull`，含 SSE 進度顯示與防重入

Depends on #78a (PR A) and #78c (PR C)
Part of #78 (5/5)
🤖 Generated with [Claude Code](https://claude.com/claude-code)