### PR TITLE
feat(film): Film-ready Export MVP — scene extraction, YAML/JSON export, chapter page button

### DIFF
--- a/internal/checker/film.go
+++ b/internal/checker/film.go
@@ -1,0 +1,91 @@
+package checker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FilmScene represents one cinematic scene extracted from a chapter.
+type FilmScene struct {
+	SceneID     string          `yaml:"scene_id"     json:"scene_id"`
+	Location    string          `yaml:"location"     json:"location"`
+	Time        string          `yaml:"time"         json:"time"`
+	Mood        string          `yaml:"mood"         json:"mood"`
+	Characters  []FilmCharacter `yaml:"characters"   json:"characters"`
+	Dialogue    []FilmLine      `yaml:"dialogue"     json:"dialogue"`
+	VideoPrompt string          `yaml:"video_prompt" json:"video_prompt"`
+}
+
+// FilmCharacter describes one character's physical presence in a scene.
+type FilmCharacter struct {
+	Name       string `yaml:"name"                 json:"name"`
+	Appearance string `yaml:"appearance,omitempty" json:"appearance,omitempty"`
+	Action     string `yaml:"action"               json:"action"`
+	Emotion    string `yaml:"emotion"              json:"emotion"`
+}
+
+// FilmLine is one line of dialogue or narrated speech in a scene.
+type FilmLine struct {
+	Speaker string `yaml:"speaker" json:"speaker"`
+	Text    string `yaml:"text"    json:"text"`
+}
+
+// ExtractFilmScenes parses a chapter into a list of cinematic scenes.
+// Psychological descriptions are translated into visible physical actions.
+// The video_prompt field is written in English for direct use with video AI tools.
+func (c *Checker) ExtractFilmScenes(ctx context.Context, chapterFile, chapter string) ([]FilmScene, error) {
+	prompt := fmt.Sprintf(`分析以下小說章節，拆解成一個或多個電影場景。
+
+關鍵轉譯規則：
+- 「心理描寫」必須轉成「可視覺化動作」。例如：
+  「他感到後悔」→ action: "低下頭，手指不斷摩擦杯緣"
+  「她很憤怒」→ action: "緊握拳頭，轉身背對對方"
+  「他感到孤獨」→ action: "獨自坐在空蕩的車站，手裡握著一張揉皺的車票"
+- video_prompt 必須用英文，描述導演可以實際拍攝的畫面，包含光線、氣氛、鏡頭感
+- location 用中文描述具體地點
+- time 用中文（例：夜晚、清晨、下午）
+- mood 用中文（例：緊繃、哀傷、溫暖）
+- 每個 scene_id 格式：%s-S01、%s-S02 依此類推
+
+輸出嚴格 JSON 陣列，不加任何說明：
+[
+  {
+    "scene_id": "...",
+    "location": "...",
+    "time": "...",
+    "mood": "...",
+    "characters": [
+      {"name": "...", "appearance": "...", "action": "...", "emotion": "..."}
+    ],
+    "dialogue": [
+      {"speaker": "...", "text": "..."}
+    ],
+    "video_prompt": "..."
+  }
+]
+
+【章節內容】
+%s`, chapterFile, chapterFile, chapter)
+
+	var buf strings.Builder
+	if err := c.llm.Stream(ctx,
+		"你是專業電影前製導演，擅長把小說場景轉換成可拍攝的視覺化腳本。只輸出 JSON，不輸出任何說明。",
+		prompt, &buf); err != nil {
+		return nil, err
+	}
+
+	raw := strings.TrimSpace(buf.String())
+	start := strings.Index(raw, "[")
+	end := strings.LastIndex(raw, "]")
+	if start < 0 || end <= start {
+		return nil, fmt.Errorf("無法解析 film scenes 回應")
+	}
+
+	var scenes []FilmScene
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &scenes); err != nil {
+		return nil, fmt.Errorf("JSON 解析失敗：%w", err)
+	}
+	return scenes, nil
+}

--- a/internal/exporter/film.go
+++ b/internal/exporter/film.go
@@ -1,0 +1,32 @@
+package exporter
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"novel-assistant/internal/checker"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FilmFormat is the output format for film scene export.
+type FilmFormat string
+
+const (
+	FilmFormatYAML FilmFormat = "yaml"
+	FilmFormatJSON FilmFormat = "json"
+)
+
+// ExportFilmScenes serialises a list of FilmScene values to the requested format.
+func ExportFilmScenes(scenes []checker.FilmScene, format FilmFormat) ([]byte, error) {
+	switch format {
+	case FilmFormatJSON:
+		return json.MarshalIndent(scenes, "", "  ")
+	default:
+		out, err := yaml.Marshal(scenes)
+		if err != nil {
+			return nil, fmt.Errorf("yaml marshal: %w", err)
+		}
+		return out, nil
+	}
+}

--- a/internal/exporter/film_test.go
+++ b/internal/exporter/film_test.go
@@ -1,0 +1,68 @@
+package exporter
+
+import (
+	"strings"
+	"testing"
+
+	"novel-assistant/internal/checker"
+)
+
+func TestExportFilmScenes_YAML(t *testing.T) {
+	scenes := []checker.FilmScene{
+		{
+			SceneID:  "CH01-S01",
+			Location: "台北雨夜巷弄",
+			Time:     "夜晚",
+			Mood:     "緊繃",
+			Characters: []checker.FilmCharacter{
+				{Name: "志明", Action: "握緊拳頭", Emotion: "壓抑"},
+			},
+			Dialogue: []checker.FilmLine{
+				{Speaker: "志明", Text: "這債，我會還完。"},
+			},
+			VideoPrompt: "A tired man stands in a rain-soaked alley.",
+		},
+	}
+
+	out, err := ExportFilmScenes(scenes, FilmFormatYAML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "CH01-S01") {
+		t.Error("expected scene_id in YAML output")
+	}
+	if !strings.Contains(body, "video_prompt") {
+		t.Error("expected video_prompt in YAML output")
+	}
+}
+
+func TestExportFilmScenes_JSON(t *testing.T) {
+	scenes := []checker.FilmScene{
+		{SceneID: "CH01-S01", Location: "台北", VideoPrompt: "A man walks."},
+	}
+
+	out, err := ExportFilmScenes(scenes, FilmFormatJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, `"scene_id"`) {
+		t.Error("expected scene_id in JSON output")
+	}
+	if !strings.Contains(body, `"video_prompt"`) {
+		t.Error("expected video_prompt in JSON output")
+	}
+}
+
+func TestExportFilmScenes_DefaultsToYAML(t *testing.T) {
+	scenes := []checker.FilmScene{{SceneID: "S01"}}
+	out, err := ExportFilmScenes(scenes, "unknown")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// YAML does not use double-quoted keys like JSON
+	if strings.Contains(string(out), `"scene_id"`) {
+		t.Error("expected YAML format, got JSON-style output")
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1941,3 +1941,47 @@ func (s *Server) handleDemoData(c *gin.Context) {
 		"health":  health,
 	})
 }
+
+func (s *Server) handleFilmExport(c *gin.Context) {
+	name := c.Param("name")
+	if name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "章節名稱不可為空"})
+		return
+	}
+
+	var req struct {
+		Format string `json:"format"` // "yaml" | "json"; defaults to "yaml"
+	}
+	_ = c.ShouldBindJSON(&req)
+	format := exporter.FilmFormat(req.Format)
+	if format != exporter.FilmFormatJSON {
+		format = exporter.FilmFormatYAML
+	}
+
+	content, err := os.ReadFile(filepath.Join(chapterDirFor(s.cfg.DataDir), name))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "找不到章節檔案：" + name})
+		return
+	}
+
+	chapterFile := strings.TrimSuffix(name, ".md")
+	scenes, err := s.checker.ExtractFilmScenes(c.Request.Context(), chapterFile, string(content))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	out, err := exporter.ExportFilmScenes(scenes, format)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ext := "yaml"
+	if format == exporter.FilmFormatJSON {
+		ext = "json"
+	}
+	filename := fmt.Sprintf("film_%s.%s", chapterFile, ext)
+	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", out)
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1958,14 +1958,13 @@ func (s *Server) handleFilmExport(c *gin.Context) {
 		format = exporter.FilmFormatYAML
 	}
 
-	content, err := os.ReadFile(filepath.Join(chapterDirFor(s.cfg.DataDir), name))
+	cf, err := s.loadChapterFile(name)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "找不到章節檔案：" + name})
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
 	}
 
-	chapterFile := strings.TrimSuffix(name, ".md")
-	scenes, err := s.checker.ExtractFilmScenes(c.Request.Context(), chapterFile, string(content))
+	scenes, err := s.checker.ExtractFilmScenes(c.Request.Context(), strings.TrimSuffix(cf.Name, ".md"), cf.Content)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -1981,7 +1980,7 @@ func (s *Server) handleFilmExport(c *gin.Context) {
 	if format == exporter.FilmFormatJSON {
 		ext = "json"
 	}
-	filename := fmt.Sprintf("film_%s.%s", chapterFile, ext)
+	filename := fmt.Sprintf("film_%s.%s", strings.TrimSuffix(cf.Name, ".md"), ext)
 	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	c.Data(http.StatusOK, "text/plain; charset=utf-8", out)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,6 +157,7 @@ func (s *Server) setupRoutes() {
 	protected.GET("/api/backups/:name/preview", s.handleGetBackupPreview)
 	protected.GET("/api/projects", s.handleListProjects)
 	protected.GET("/api/chapters/:name/analysis", s.handleAnalyzeChapter)
+	protected.POST("/api/chapters/:name/film-export", s.handleFilmExport)
 	protected.GET("/api/chapters", s.handleListChapters)
 	protected.GET("/api/chapters/:name", s.handleGetChapter)
 	protected.GET("/api/settings", s.handleGetSettings)

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -91,6 +91,7 @@
             <button class="btn btn-ghost btn-sm" type="button" onclick="exportChapterBundle('{{.Name}}')">匯出完整報告</button>
             <button class="btn btn-ghost btn-sm" type="button" onclick="createWorldstateSnapshot('{{.Name}}')">產生狀態快照</button>
             <a class="btn btn-ghost btn-sm" href="/check?chapter={{.Name}}">載入到審查頁</a>
+            <button class="btn btn-ghost btn-sm" type="button" onclick="exportFilm('{{.Name}}','yaml')">匯出影片格式</button>
           </div>
         </div>
 
@@ -239,6 +240,37 @@ async function createCandidateDraft(type, name) {
     alert(data.message + '：' + data.file);
   } catch (e) {
     alert('建立草稿失敗：' + e.message);
+  }
+}
+
+async function exportFilm(name, format) {
+  const btn = event.target;
+  const orig = btn.textContent;
+  btn.disabled = true;
+  btn.textContent = '分析中…';
+  try {
+    const resp = await fetch(`/api/chapters/${encodeURIComponent(name)}/film-export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format }),
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({ error: resp.statusText }));
+      alert('匯出失敗：' + (err.error || resp.statusText));
+      return;
+    }
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `film_${name.replace(/\.md$/, '')}.${format}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    alert('匯出失敗：' + e.message);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = orig;
   }
 }
 

--- a/web/templates/chapters.html
+++ b/web/templates/chapters.html
@@ -91,7 +91,7 @@
             <button class="btn btn-ghost btn-sm" type="button" onclick="exportChapterBundle('{{.Name}}')">匯出完整報告</button>
             <button class="btn btn-ghost btn-sm" type="button" onclick="createWorldstateSnapshot('{{.Name}}')">產生狀態快照</button>
             <a class="btn btn-ghost btn-sm" href="/check?chapter={{.Name}}">載入到審查頁</a>
-            <button class="btn btn-ghost btn-sm" type="button" onclick="exportFilm('{{.Name}}','yaml')">匯出影片格式</button>
+            <button class="btn btn-ghost btn-sm" type="button" onclick="exportFilm(this,'{{.Name}}','yaml')">匯出影片格式</button>
           </div>
         </div>
 
@@ -243,8 +243,7 @@ async function createCandidateDraft(type, name) {
   }
 }
 
-async function exportFilm(name, format) {
-  const btn = event.target;
+async function exportFilm(btn, name, format) {
   const orig = btn.textContent;
   btn.disabled = true;
   btn.textContent = '分析中…';


### PR DESCRIPTION
## Summary

- **`internal/checker/film.go`** — `FilmScene` / `FilmCharacter` / `FilmLine` 結構體；`ExtractFilmScenes(ctx, chapterFile, chapter)` 呼叫 LLM，把心理描寫轉成可視覺化動作，`video_prompt` 輸出英文
- **`internal/exporter/film.go`** — `ExportFilmScenes(scenes, format)` 輸出 YAML（預設）或 JSON；未知格式 fallback YAML
- **`POST /api/chapters/:name/film-export`** — 讀取章節檔案 → `ExtractFilmScenes` → `ExportFilmScenes` → 下載附件
- **`chapters.html`** — 每個章節行加入「匯出影片格式」按鈕，呼叫 API 後觸發 YAML 下載

## Translation Layer prompt 設計

Prompt 明確要求 LLM 把心理描寫轉換成外顯動作：

| 輸入（小說文字） | 輸出（film action） |
|---|---|
| 他感到後悔 | 低下頭，手指不斷摩擦杯緣 |
| 她很憤怒 | 緊握拳頭，轉身背對對方 |
| 他感到孤獨 | 獨自坐在空蕩的車站，手裡握著一張揉皺的車票 |

## 範例輸出（YAML）

```yaml
- scene_id: 第一章_抵達-S01
  location: 霧山腳下客棧
  time: 黃昏
  mood: 懸疑
  characters:
    - name: 林逸
      action: 站在門口，掃視四周確認無異狀
      emotion: 戒備
  dialogue:
    - speaker: 林逸
      text: 住一晚。
  video_prompt: >
    A cautious man in a long black coat pauses at a tavern entrance,
    scanning the room before stepping inside. Warm lantern light.
    Dusk. Mountain fog visible through the window.
```

## Test plan

- [x] `go build ./...` 通過
- [x] `go test ./...` 通過（含 exporter YAML/JSON/fallback 三個測試）

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)