### PR TITLE
feat(ollama): POST /api/ollama/pull — SSE with boolean stream, dial timeout, scanner.Err

### DIFF
--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -119,4 +123,115 @@ func (s *Server) handleOllamaStatus(c *gin.Context) {
 	resp.EmbedReady = modelReady(embedModel, names)
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// inflight tracks models currently being pulled; value is a cancel func.
+var (
+	inflightMu sync.Mutex
+	inflight   = map[string]context.CancelFunc{}
+)
+
+func (s *Server) handleOllamaPull(c *gin.Context) {
+	var req struct {
+		Model string `json:"model"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "請求格式錯誤"})
+		return
+	}
+	model := strings.TrimSpace(req.Model)
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model 不可為空"})
+		return
+	}
+
+	inflightMu.Lock()
+	if _, ok := inflight[model]; ok {
+		inflightMu.Unlock()
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("模型 %s 已在下載中", model)})
+		return
+	}
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	inflight[model] = cancel
+	inflightMu.Unlock()
+
+	defer func() {
+		inflightMu.Lock()
+		delete(inflight, model)
+		inflightMu.Unlock()
+		cancel()
+	}()
+
+	body, _ := json.Marshal(map[string]any{"model": model, "stream": true})
+	pullReq, err := http.NewRequestWithContext(ctx, "POST", s.cfg.OllamaURL+"/api/pull",
+		strings.NewReader(string(body)))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	pullReq.Header.Set("Content-Type", "application/json")
+
+	// Dial timeout prevents hanging on unreachable hosts; response streaming follows client context.
+	client := &http.Client{Transport: &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 3 * time.Second}).DialContext,
+		ResponseHeaderTimeout: 5 * time.Second,
+	}}
+	pullResp, err := client.Do(pullReq)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "無法連線 Ollama：" + err.Error()})
+		return
+	}
+	defer pullResp.Body.Close()
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	flusher, _ := c.Writer.(http.Flusher)
+
+	scanner := bufio.NewScanner(pullResp.Body)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var frame map[string]any
+		if err := json.Unmarshal(line, &frame); err != nil {
+			continue
+		}
+		if errMsg, ok := frame["error"].(string); ok {
+			fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n",
+				mustJSON(map[string]string{"error": errMsg}))
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		if status, _ := frame["status"].(string); status == "success" {
+			fmt.Fprintf(c.Writer, "event: done\ndata: {}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+		fmt.Fprintf(c.Writer, "event: progress\ndata: %s\n\n", mustJSON(frame))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n",
+			mustJSON(map[string]string{"error": "stream read error: " + err.Error()}))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return
+	}
+	fmt.Fprintf(c.Writer, "event: done\ndata: {}\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
 }

--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -182,6 +183,13 @@ func (s *Server) handleOllamaPull(c *gin.Context) {
 		return
 	}
 	defer pullResp.Body.Close()
+
+	if pullResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(pullResp.Body, 4096))
+		c.JSON(http.StatusBadGateway, gin.H{"error": fmt.Sprintf("Ollama pull 失敗（%d）：%s",
+			pullResp.StatusCode, strings.TrimSpace(string(body)))})
+		return
+	}
 
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")

--- a/internal/server/ollama_test.go
+++ b/internal/server/ollama_test.go
@@ -255,6 +255,35 @@ func TestHandleOllamaPull_ForwardsError(t *testing.T) {
 	}
 }
 
+func TestHandleOllamaPull_Non200ReturnsError(t *testing.T) {
+	t.Parallel()
+	// Ollama returns 404 with plain-text body (not a JSON frame).
+	// The handler must not emit event:done after reading unparseable lines.
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			http.Error(w, "model not found", http.StatusNotFound)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"non200model"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK && strings.Contains(rec.Body.String(), "event: done") {
+		t.Errorf("non-200 pull should not emit event:done, got: %s", rec.Body.String())
+	}
+	// Should return a JSON error (not SSE), indicating the upstream failure
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected 502 for non-200 /api/pull, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestHandleOllamaPull_DuplicateReturns409(t *testing.T) {
 	t.Parallel()
 	started := make(chan struct{})

--- a/internal/server/ollama_test.go
+++ b/internal/server/ollama_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -199,4 +200,117 @@ func newTestRequest(t *testing.T, s *Server, method, path string, body interface
 	req := httptest.NewRequest(method, path, nil)
 	s.router.ServeHTTP(rec, req)
 	return rec
+}
+
+// ─── handleOllamaPull ────────────────────────────────────────────────────────��
+
+func TestHandleOllamaPull_ForwardsProgress(t *testing.T) {
+	t.Parallel()
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			fmt.Fprintln(w, `{"status":"pulling manifest","completed":0,"total":100}`)
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"llama3.2:3b"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+	resp := rec.Body.String()
+	if !strings.Contains(resp, "event: progress") {
+		t.Errorf("expected progress event, got: %s", resp)
+	}
+	if !strings.Contains(resp, "event: done") {
+		t.Errorf("expected done event, got: %s", resp)
+	}
+}
+
+func TestHandleOllamaPull_ForwardsError(t *testing.T) {
+	t.Parallel()
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			fmt.Fprintln(w, `{"error":"model not found"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"nosuchmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+	resp := rec.Body.String()
+	if !strings.Contains(resp, "event: error") {
+		t.Errorf("expected error event, got: %s", resp)
+	}
+	if strings.Contains(resp, "event: done") {
+		t.Errorf("should not emit done after error, got: %s", resp)
+	}
+}
+
+func TestHandleOllamaPull_DuplicateReturns409(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			close(started)
+			<-unblock
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+	defer close(unblock)
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	go func() {
+		body := strings.NewReader(`{"model":"slowmodel"}`)
+		req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+		req.Header.Set("Content-Type", "application/json")
+		s.router.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+	<-started
+	body := strings.NewReader(`{"model":"slowmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", rec.Code)
+	}
+}
+
+func TestHandleOllamaPull_ReleasesLockAfterCompletion(t *testing.T) {
+	t.Parallel()
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/pull" {
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			fmt.Fprintln(w, `{"status":"success"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer mock.Close()
+	s := newTestServerWithOllama(t, mock.URL, "llama3.2", "nomic-embed-text")
+	body := strings.NewReader(`{"model":"lockmodel"}`)
+	req := httptest.NewRequest("POST", "/api/ollama/pull", body)
+	req.Header.Set("Content-Type", "application/json")
+	s.router.ServeHTTP(httptest.NewRecorder(), req)
+	inflightMu.Lock()
+	_, locked := inflight["lockmodel"]
+	inflightMu.Unlock()
+	if locked {
+		t.Error("inflight lock not released after handler completion")
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,7 @@ func (s *Server) setupRoutes() {
 	protected.POST("/evaluate/stream", s.handleEvaluateStream)
 	protected.GET("/api/demo", s.handleDemoData)
 	protected.GET("/api/ollama/status", s.handleOllamaStatus)
+	protected.POST("/api/ollama/pull", s.handleOllamaPull)
 
 	protected.POST("/export", s.handleExport)
 }


### PR DESCRIPTION
## Summary

- 新增 `POST /api/ollama/pull`（protected group）
- 修正：`stream: true`（boolean）
- 修正：`net.Dialer{Timeout: 3s}` 真實 dial timeout
- 修正：`scanner.Err()` 檢查，stream 中途斷線 → `event:error`
- 防重入 409、client context 綁定

Depends on #88 (merged)
Part of #78 (3/5)
🤖 Generated with [Claude Code](https://claude.com/claude-code)