### PR TITLE
feat(focus): Focus Chat Mode — split-screen AI chat + manuscript editor

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -316,6 +316,25 @@ func (c *Checker) ChatWithCharacterStream(ctx context.Context, characterProfile,
 	return c.llm.Stream(ctx, system, prompt, w)
 }
 
+func (c *Checker) FocusChatStream(ctx context.Context, contextBlock, history, userMessage string, w io.Writer) error {
+	prompt := fmt.Sprintf(`【參考資料】
+%s
+
+【對話歷史】
+%s
+
+【使用者訊息】
+%s`, contextBlock, history, userMessage)
+
+	system := `你是小說創作助理。請根據提供的角色設定、世界觀、章節摘要與伏筆清單，協助作者發想、討論或生成段落。
+規則：
+- 直接針對使用者訊息回覆，不重複引用資料來源
+- 若生成段落，請確保與設定一致
+- 回覆使用繁體中文`
+
+	return c.llm.Stream(ctx, system, prompt, w)
+}
+
 func (c *Checker) GenerateWorldStateChanges(ctx context.Context, chapter string) ([]worldstate.Change, error) {
 	prompt := fmt.Sprintf(`
 分析以下章節內容，列出本章造成的「世界狀態變更」。

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1649,3 +1649,94 @@ func TestEvaluateStreamStaleForeshadowPenalty(t *testing.T) {
 		t.Errorf("expected final_score=base_score-5, got final=%d base=%d", finalEval.FinalScore, finalEval.BaseScore)
 	}
 }
+
+// ─── focus chat ───────────────────────────────────────────────────────────────
+
+func TestFocusStreamEmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/focus/stream", map[string]any{"message": ""})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("POST /focus/stream with empty message: want 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestFocusStreamBasic(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2}})
+		case "/api/generate":
+			_, _ = w.Write([]byte("{\"response\":\"好的，我來幫你。\",\"done\":true}\n"))
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/focus/stream", map[string]any{
+		"message": "請幫我繼續寫下一段",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /focus/stream: want 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+	body := string(resp.Body)
+	if !strings.Contains(body, "event:chunk") {
+		t.Errorf("expected event:chunk in SSE stream, got: %s", body)
+	}
+	if !strings.Contains(body, "event:sources") {
+		t.Errorf("expected event:sources in SSE stream, got: %s", body)
+	}
+}
+
+func TestFocusStreamWithChapterContent(t *testing.T) {
+	t.Parallel()
+
+	var capturedPrompt string
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2}})
+		case "/api/generate":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if p, ok := body["prompt"].(string); ok {
+				capturedPrompt = p
+			}
+			_, _ = w.Write([]byte("{\"response\":\"繼續。\",\"done\":true}\n"))
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	s := newE2ETestServer(t, dir, ollama.URL)
+	app := httptest.NewServer(s.router)
+	defer app.Close()
+
+	resp := performJSONRequest(t, app.URL, "POST", "/focus/stream", map[string]any{
+		"message":         "繼續寫",
+		"chapter_content": "第一段已完成：林昊踏入雨夜的長廊。",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST /focus/stream: want 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+	if !strings.Contains(capturedPrompt, "當前稿件") {
+		t.Errorf("expected prompt to contain '當前稿件', got: %s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "第一段已完成") {
+		t.Errorf("expected prompt to contain chapter content, got: %s", capturedPrompt)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1444,7 +1444,7 @@ func (s *Server) handleChatStream(c *gin.Context) {
 // ─── focus chat ───────────────────────────────────────────────────────────────
 
 type focusMessage struct {
-	Role    string `json:"role"`    // "user" | "assistant"
+	Role    string `json:"role"` // "user" | "assistant"
 	Content string `json:"content"`
 }
 
@@ -1480,9 +1480,13 @@ func (s *Server) handleFocusStream(c *gin.Context) {
 	go func() {
 		defer close(msgChan)
 
-		// 1. RAG 參考（傳入 message 作為 embedding query）
+		// 1. RAG 參考（query = message + 當前稿件片段，讓 retrieval 能命中稿件內的角色/地名）
 		defaultOpts := retrievalOptions{}
-		references, refErr := s.buildReferenceContext(ctx, req.Message, req.ChapterFile, mergeRetrieval(s.rules.PresetFor("rewrite"), defaultOpts))
+		ragQuery := req.Message
+		if trimmed := strings.TrimSpace(req.ChapterContent); trimmed != "" {
+			ragQuery = req.Message + "\n" + trimmed
+		}
+		references, refErr := s.buildReferenceContext(ctx, ragQuery, req.ChapterFile, mergeRetrieval(s.rules.PresetFor("rewrite"), defaultOpts))
 		if refErr != nil {
 			msgChan <- streamEvent{Event: "chunk", Text: fmt.Sprintf("\n> RAG 載入失敗，使用基礎模式：%s\n", refErr.Error())}
 		} else {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1441,6 +1441,129 @@ func (s *Server) handleChatStream(c *gin.Context) {
 	}
 }
 
+// ─── focus chat ───────────────────────────────────────────────────────────────
+
+type focusMessage struct {
+	Role    string `json:"role"`    // "user" | "assistant"
+	Content string `json:"content"`
+}
+
+type focusRequest struct {
+	Message        string         `json:"message"`
+	History        []focusMessage `json:"history"`
+	ChapterFile    string         `json:"chapter_file"`    // optional，用於 beforeChapter 篩選
+	ChapterContent string         `json:"chapter_content"` // optional，右側 textarea 當前內容
+}
+
+func (s *Server) handleFocusPage(c *gin.Context) {
+	chapters, err := s.listChapterFiles()
+	if err != nil {
+		log.Printf("focus: list chapters: %v", err)
+	}
+	c.HTML(http.StatusOK, "focus.html", gin.H{
+		"Title":    "Focus Chat Mode",
+		"Chapters": chapters,
+	})
+}
+
+func (s *Server) handleFocusStream(c *gin.Context) {
+	var req focusRequest
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.Message) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "訊息不可為空"})
+		return
+	}
+
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+	msgChan := make(chan streamEvent, 256)
+
+	go func() {
+		defer close(msgChan)
+
+		// 1. RAG 參考（傳入 message 作為 embedding query）
+		defaultOpts := retrievalOptions{}
+		references, refErr := s.buildReferenceContext(ctx, req.Message, req.ChapterFile, mergeRetrieval(s.rules.PresetFor("rewrite"), defaultOpts))
+		if refErr != nil {
+			msgChan <- streamEvent{Event: "chunk", Text: fmt.Sprintf("\n> RAG 載入失敗，使用基礎模式：%s\n", refErr.Error())}
+		} else {
+			msgChan <- streamEvent{Event: "sources", Sources: summarizeReferences(references)}
+		}
+
+		// 2. 章節摘要
+		beforeChapter := resolveBeforeChapter(req.ChapterFile, defaultOpts)
+		summaryDocs := s.store.QueryChapterSummaries(beforeChapter)
+		var summaryLines []string
+		for _, d := range summaryDocs {
+			summaryLines = append(summaryLines, fmt.Sprintf("- 第%d章：%s", d.ChapterIndex, d.Content))
+		}
+
+		// 3. 待解決伏筆
+		pendingHooks := s.foreshadow.GetPending()
+		var hookLines []string
+		for _, h := range pendingHooks {
+			hookLines = append(hookLines, fmt.Sprintf("- %s（偵測：第%d章）", h.Description, h.ChapterIndex))
+		}
+
+		// 4. contextBlock
+		var parts []string
+		if len(references) > 0 {
+			parts = append(parts, "【角色／世界觀／風格參考】\n"+joinProfiles(references))
+		}
+		if len(summaryLines) > 0 {
+			parts = append(parts, "【章節摘要】\n"+strings.Join(summaryLines, "\n"))
+		}
+		if len(hookLines) > 0 {
+			parts = append(parts, "【待解決伏筆】\n"+strings.Join(hookLines, "\n"))
+		}
+		if strings.TrimSpace(req.ChapterContent) != "" {
+			parts = append(parts, "【當前稿件】\n"+req.ChapterContent)
+		}
+		contextBlock := strings.Join(parts, "\n\n")
+
+		// 5. 對話歷史
+		var histLines []string
+		for _, h := range req.History {
+			role := "使用者"
+			if h.Role == "assistant" {
+				role = "AI助理"
+			}
+			histLines = append(histLines, role+"："+h.Content)
+		}
+		historyText := strings.Join(histLines, "\n")
+
+		// 6. 串流
+		cw := &chanWriter{ch: msgChan}
+		if err := s.checker.FocusChatStream(ctx, contextBlock, historyText, req.Message, cw); err != nil {
+			if ctx.Err() == nil {
+				msgChan <- streamEvent{Event: "chunk", Text: fmt.Sprintf("\n> 錯誤：%s\n", err.Error())}
+			}
+		}
+	}()
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-msgChan:
+			if !ok {
+				return
+			}
+			switch msg.Event {
+			case "sources":
+				c.SSEvent("sources", gin.H{"items": msg.Sources})
+			case "chunk":
+				c.SSEvent("chunk", gin.H{"text": msg.Text})
+			}
+			c.Writer.Flush()
+		}
+	}
+}
+
 // ─── relationships ────────────────────────────────────────────────────────────
 
 func (s *Server) handleAddRelationship(c *gin.Context) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,6 +209,8 @@ func (s *Server) setupRoutes() {
 
 	protected.GET("/evaluate", s.handleEvaluatePage)
 	protected.POST("/evaluate/stream", s.handleEvaluateStream)
+	protected.GET("/focus", s.handleFocusPage)
+	protected.POST("/focus/stream", s.handleFocusStream)
 	protected.GET("/api/demo", s.handleDemoData)
 	protected.GET("/api/ollama/status", s.handleOllamaStatus)
 	protected.POST("/api/ollama/pull", s.handleOllamaPull)

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -17,6 +17,7 @@
       <li><a href="/chat"         {{if eq .Title "角色對談室"}}class="active"{{end}}>角色對談室</a></li>
       <li><a href="/narrative"    {{if eq .Title "敘事記憶抽取"}}class="active"{{end}}>敘事記憶抽取</a></li>
       <li><a href="/evaluate"     {{if eq .Title "章節健康評分"}}class="active"{{end}}>章節健康評分</a></li>
+      <li><a href="/focus"        {{if eq .Title "Focus Chat Mode"}}class="active"{{end}}>Focus Chat</a></li>
     </ul>
   </nav>
   <div class="sidebar-footer">

--- a/web/templates/focus.html
+++ b/web/templates/focus.html
@@ -223,7 +223,12 @@ function insertAtCursor(text) {
 
 async function loadChapter() {
   const name = document.getElementById('chapter-select').value;
-  if (!name) return;
+  if (!name) {
+    document.getElementById('chapter-name').value = '';
+    document.getElementById('manuscript-editor').value = '';
+    document.getElementById('save-status').textContent = '';
+    return;
+  }
   document.getElementById('chapter-name').value = name;
   try {
     const resp = await fetch('/api/chapters/' + encodeURIComponent(name));

--- a/web/templates/focus.html
+++ b/web/templates/focus.html
@@ -1,0 +1,260 @@
+{{define "focus.html"}}
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Focus Chat Mode — 小說助手</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <style>
+    .focus-layout {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      height: calc(100vh - 160px);
+      min-height: 500px;
+    }
+    .focus-panel { display: flex; flex-direction: column; overflow: hidden; }
+    .focus-panel .card { flex: 1; display: flex; flex-direction: column; overflow: hidden; padding: 14px; }
+    .focus-panel h2 { margin-bottom: 10px; font-size: 1rem; flex-shrink: 0; }
+
+    .chat-messages {
+      flex: 1; overflow-y: auto; padding: 12px;
+      background: #0f0d14; border: 1px solid #2d2540;
+      border-radius: 8px; margin-bottom: 10px;
+    }
+    .chat-bubble { margin-bottom: 10px; max-width: 85%; }
+    .chat-bubble.user { margin-left: auto; text-align: right; }
+    .chat-bubble.assistant { margin-right: auto; }
+    .bubble-inner {
+      display: inline-block; padding: 9px 13px; border-radius: 10px;
+      font-size: 0.88rem; line-height: 1.65; white-space: pre-wrap;
+    }
+    .user .bubble-inner { background: #3b82f6; color: #fff; border-bottom-right-radius: 3px; }
+    .assistant .bubble-inner { background: #1a1628; border: 1px solid #2d2540; color: #e2e8f0; border-bottom-left-radius: 3px; }
+    .bubble-meta { font-size: 0.72rem; color: #64748b; margin-bottom: 3px; }
+    .insert-btn {
+      display: block; margin-top: 5px; padding: 3px 10px;
+      background: transparent; border: 1px solid #3b82f6; color: #3b82f6;
+      border-radius: 5px; font-size: 0.75rem; cursor: pointer;
+    }
+    .insert-btn:hover { background: rgba(59,130,246,0.08); }
+    .sources-bar {
+      font-size: 0.75rem; color: #64748b; padding: 4px 0 6px;
+      border-bottom: 1px solid #2d2540; margin-bottom: 6px; flex-shrink: 0;
+    }
+    .chat-input-row { display: flex; gap: 8px; flex-shrink: 0; }
+    .chat-input-row textarea { flex: 1; min-height: 50px; max-height: 110px; resize: vertical; }
+    .chat-hint { margin-top: 6px; font-size: 0.75rem; color: #64748b; flex-shrink: 0; }
+
+    .editor-toolbar {
+      display: flex; gap: 8px; align-items: center;
+      margin-bottom: 10px; flex-wrap: wrap; flex-shrink: 0;
+    }
+    .editor-toolbar input[type="text"] { flex: 1; min-width: 160px; }
+    .save-status { font-size: 0.75rem; color: #64748b; }
+    #manuscript-editor { flex: 1; resize: none; width: 100%; font-family: monospace; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+<div class="layout">
+  {{template "nav" .}}
+  <main class="main-content">
+    <div class="page-header" style="margin-bottom:12px">
+      <h1>Focus Chat Mode</h1>
+      <p>左側與 AI 寫作夥伴對話，右側直接編輯稿件。點「▼ 插入稿件」可將 AI 回覆貼入游標位置。</p>
+    </div>
+
+    <div class="focus-layout">
+      <!-- 左側：AI 對話 -->
+      <div class="focus-panel">
+        <div class="card">
+          <h2>AI 寫作夥伴</h2>
+          <div id="sources-bar" class="sources-bar" style="display:none"></div>
+          <div class="chat-messages" id="chat-messages">
+            <p style="color:#94a3b8;text-align:center;font-size:0.85rem">開始輸入，AI 將自動參考角色設定、章節摘要、伏筆清單與右側稿件</p>
+          </div>
+          <div class="chat-input-row">
+            <textarea id="chat-input" placeholder="輸入你的問題或創作需求…" onkeydown="handleKey(event)"></textarea>
+            <button class="btn" id="send-btn" type="button" onclick="sendMessage()">送出</button>
+          </div>
+          <div class="chat-hint">Enter 送出，Shift+Enter 換行</div>
+        </div>
+      </div>
+
+      <!-- 右側：稿件編輯器 -->
+      <div class="focus-panel">
+        <div class="card">
+          <h2>稿件編輯器</h2>
+          <div class="editor-toolbar">
+            <select id="chapter-select" onchange="loadChapter()">
+              <option value="">— 新稿件 —</option>
+              {{range .Chapters}}
+              <option value="{{.Name}}">{{.Title}}</option>
+              {{end}}
+            </select>
+            <input type="text" id="chapter-name" placeholder="章節檔名（例：第二章-主角覺醒.md）">
+            <button class="btn btn-ghost btn-sm" type="button" onclick="saveChapter()">儲存</button>
+            <span class="save-status" id="save-status"></span>
+          </div>
+          <textarea id="manuscript-editor" placeholder="在此撰寫或貼入章節內容…"></textarea>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script>
+const chatHistory = [];
+let isStreaming = false;
+
+function escHTML(t) {
+  return String(t || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function showSources(items) {
+  const bar = document.getElementById('sources-bar');
+  if (!items || items.length === 0) { bar.style.display = 'none'; return; }
+  const names = items.map(i => i.name || i.id || '').filter(Boolean).join('、');
+  bar.textContent = `本次參考：${names}`;
+  bar.style.display = 'block';
+}
+
+function addInsertButton(bubbleWrap, text) {
+  const btn = document.createElement('button');
+  btn.className = 'insert-btn';
+  btn.textContent = '▼ 插入稿件';
+  btn.onclick = () => insertAtCursor(text);
+  bubbleWrap.appendChild(btn);
+}
+
+async function sendMessage() {
+  if (isStreaming) return;
+  const input = document.getElementById('chat-input');
+  const message = input.value.trim();
+  if (!message) return;
+  input.value = '';
+
+  // 使用者泡泡
+  const box = document.getElementById('chat-messages');
+  box.querySelector('p')?.remove();
+  const userWrap = document.createElement('div');
+  userWrap.className = 'chat-bubble user';
+  userWrap.innerHTML = `<div class="bubble-meta">作者</div><div class="bubble-inner">${escHTML(message)}</div>`;
+  box.appendChild(userWrap);
+  box.scrollTop = box.scrollHeight;
+
+  const chapterFile = document.getElementById('chapter-select').value;
+  const chapterContent = document.getElementById('manuscript-editor').value;
+
+  isStreaming = true;
+  document.getElementById('send-btn').disabled = true;
+
+  // AI 泡泡（串流中）
+  const aiWrap = document.createElement('div');
+  aiWrap.className = 'chat-bubble assistant';
+  aiWrap.innerHTML = '<div class="bubble-meta">AI助理</div><div class="bubble-inner"></div>';
+  box.appendChild(aiWrap);
+  box.scrollTop = box.scrollHeight;
+  const bubbleEl = aiWrap.querySelector('.bubble-inner');
+  let replyText = '';
+
+  try {
+    const resp = await fetch('/focus/stream', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message, history: chatHistory, chapter_file: chapterFile, chapter_content: chapterContent })
+    });
+    if (!resp.ok) throw new Error(await resp.text());
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const lines = buf.split('\n');
+      buf = lines.pop();
+
+      let eventType = '';
+      for (const line of lines) {
+        if (line.startsWith('event:')) {
+          eventType = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          try {
+            const payload = JSON.parse(line.slice(5).trim());
+            if (eventType === 'chunk') {
+              replyText += payload.text || '';
+              bubbleEl.textContent = replyText;
+              box.scrollTop = box.scrollHeight;
+            } else if (eventType === 'sources') {
+              showSources(payload.items);
+            }
+          } catch (_) {}
+          eventType = '';
+        }
+      }
+    }
+
+    chatHistory.push({ role: 'user', content: message });
+    chatHistory.push({ role: 'assistant', content: replyText });
+    addInsertButton(aiWrap, replyText);
+  } catch (e) {
+    bubbleEl.textContent = '⚠️ 發生錯誤：' + e.message;
+  } finally {
+    isStreaming = false;
+    document.getElementById('send-btn').disabled = false;
+  }
+}
+
+function handleKey(e) {
+  if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+}
+
+function insertAtCursor(text) {
+  const ta = document.getElementById('manuscript-editor');
+  const start = ta.selectionStart;
+  const end = ta.selectionEnd;
+  ta.setRangeText(text, start, end, 'end');
+  ta.focus();
+}
+
+async function loadChapter() {
+  const name = document.getElementById('chapter-select').value;
+  if (!name) return;
+  document.getElementById('chapter-name').value = name;
+  try {
+    const resp = await fetch('/api/chapters/' + encodeURIComponent(name));
+    const data = await resp.json();
+    document.getElementById('manuscript-editor').value = data.content || '';
+  } catch (e) {
+    alert('載入失敗：' + e.message);
+  }
+}
+
+async function saveChapter() {
+  const name = document.getElementById('chapter-name').value.trim();
+  const content = document.getElementById('manuscript-editor').value;
+  if (!name) { alert('請輸入章節檔名'); return; }
+  const status = document.getElementById('save-status');
+  status.textContent = '儲存中…';
+  try {
+    const resp = await fetch('/api/chapters', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, content })
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || '儲存失敗');
+    status.textContent = `已儲存：${data.title || name}`;
+    setTimeout(() => { status.textContent = ''; }, 3000);
+  } catch (e) {
+    status.textContent = '錯誤：' + e.message;
+  }
+}
+</script>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary

- 新增 `GET /focus` + `POST /focus/stream` 路由，實作左右分割畫面寫作夥伴模式
- 左側：AI 對話，自動注入 RAG 參考（角色/世界觀/風格）、章節摘要、待解決伏筆、右側當前稿件內容；SSE 串流 + 顯示本次參考來源
- 右側：Markdown textarea 編輯器，可選擇載入現有章節，點「▼ 插入稿件」將 AI 回覆插入游標位置，支援儲存為章節檔案
- 新增 3 個 e2e 測試：空訊息 400、基本 SSE chunk+sources、chapter_content 注入驗證
- 修正：`defer cancel()` 移至 handler 層，SSE loop 改用 `select` 形式，避免 buffered channel 中的 chunk 被提前丟棄

## Test plan

- [ ] `go test ./...` 全部通過（已驗證）
- [ ] 啟動 server，訪問 `/focus`，確認左右分割版面正常
- [ ] 輸入訊息，確認 AI 串流回應並顯示「本次參考：...」
- [ ] 點「▼ 插入稿件」，確認文字插入右側 textarea 游標位置
- [ ] 右側選擇現有章節後儲存，確認 `POST /api/chapters` 成功

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)