### PR TITLE
[desktop] Phase 3 Wails bindings — LoadChapter, SaveChapter, Reindex

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -71,3 +71,21 @@ func (a *App) Startup(ctx context.Context) {
 func (a *App) Handler() http.Handler {
 	return a.srv.Handler()
 }
+
+// LoadChapter returns the raw text content of a chapter by filename.
+func (a *App) LoadChapter(name string) (string, error) {
+	return a.srv.ChapterContent(name)
+}
+
+// SaveChapter writes a chapter file and returns the normalised title.
+func (a *App) SaveChapter(name, content string) (string, error) {
+	return a.srv.SaveChapterContent(name, content)
+}
+
+// Reindex triggers a full re-index and returns a summary message.
+func (a *App) Reindex() (string, error) {
+	if err := a.srv.Ingest(a.ctx); err != nil {
+		return "", err
+	}
+	return "索引完成", nil
+}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -84,7 +84,7 @@ func (a *App) SaveChapter(name, content string) (string, error) {
 
 // Reindex triggers a full re-index and returns a summary message.
 func (a *App) Reindex() (string, error) {
-	if err := a.srv.Ingest(a.ctx); err != nil {
+	if err := a.srv.IngestWithDiagnostics(a.ctx); err != nil {
 		return "", err
 	}
 	return "索引完成", nil

--- a/internal/server/chapters.go
+++ b/internal/server/chapters.go
@@ -246,6 +246,25 @@ func (s *Server) handleListChapters(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": files})
 }
 
+// ChapterContent returns the raw text of a chapter. Used by the desktop binding layer.
+func (s *Server) ChapterContent(name string) (string, error) {
+	f, err := s.loadChapterFile(name)
+	if err != nil {
+		return "", err
+	}
+	return f.Content, nil
+}
+
+// SaveChapterContent writes a chapter file and returns the normalised title.
+// Used by the desktop binding layer.
+func (s *Server) SaveChapterContent(name, content string) (string, error) {
+	f, err := s.saveChapterFile(name, content)
+	if err != nil {
+		return "", err
+	}
+	return f.Title, nil
+}
+
 func (s *Server) handleGetChapter(c *gin.Context) {
 	file, err := s.loadChapterFile(c.Param("name"))
 	if err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -858,8 +858,10 @@ func (s *Server) handleForeshadowPage(c *gin.Context) {
 
 // ─── ingest ───────────────────────────────────────────────────────────────────
 
-func (s *Server) handleIngest(c *gin.Context) {
-	ctx := c.Request.Context()
+// IngestWithDiagnostics runs Ingest and records timing and result to diagnostics.
+// Use this instead of Ingest directly so that any caller (HTTP or Wails binding)
+// keeps the diagnostics page up to date.
+func (s *Server) IngestWithDiagnostics(ctx context.Context) error {
 	startedAt := time.Now()
 	err := s.Ingest(ctx)
 	finishedAt := time.Now()
@@ -883,11 +885,16 @@ func (s *Server) handleIngest(c *gin.Context) {
 	}
 	if err != nil {
 		status.Error = err.Error()
-		s.diagnostics.recordReindex(status)
+	}
+	s.diagnostics.recordReindex(status)
+	return err
+}
+
+func (s *Server) handleIngest(c *gin.Context) {
+	if err := s.IngestWithDiagnostics(c.Request.Context()); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	s.diagnostics.recordReindex(status)
 	c.JSON(http.StatusOK, gin.H{
 		"message":    "索引完成",
 		"characters": len(s.profiles.Characters),

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -37,6 +37,12 @@
 <script src="/static/workspace.js"></script>
 <script>
 function reindex() {
+  if (window.go && window.go.desktop && window.go.desktop.App) {
+    window.go.desktop.App.Reindex()
+      .then(msg => alert(msg))
+      .catch(e => alert('索引失敗：' + e.message));
+    return;
+  }
   fetch('/ingest', {method:'POST'})
     .then(async r => {
       const data = await r.json();

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -40,7 +40,7 @@ function reindex() {
   if (window.go && window.go.desktop && window.go.desktop.App) {
     window.go.desktop.App.Reindex()
       .then(msg => alert(msg))
-      .catch(e => alert('索引失敗：' + e.message));
+      .catch(e => alert('索引失敗：' + (e.message ?? e)));
     return;
   }
   fetch('/ingest', {method:'POST'})

--- a/web/templates/focus.html
+++ b/web/templates/focus.html
@@ -231,9 +231,15 @@ async function loadChapter() {
   }
   document.getElementById('chapter-name').value = name;
   try {
-    const resp = await fetch('/api/chapters/' + encodeURIComponent(name));
-    const data = await resp.json();
-    document.getElementById('manuscript-editor').value = data.content || '';
+    let content = '';
+    if (window.go && window.go.desktop && window.go.desktop.App) {
+      content = await window.go.desktop.App.LoadChapter(name);
+    } else {
+      const resp = await fetch('/api/chapters/' + encodeURIComponent(name));
+      const data = await resp.json();
+      content = data.content || '';
+    }
+    document.getElementById('manuscript-editor').value = content;
   } catch (e) {
     alert('載入失敗：' + e.message);
   }
@@ -246,14 +252,20 @@ async function saveChapter() {
   const status = document.getElementById('save-status');
   status.textContent = '儲存中…';
   try {
-    const resp = await fetch('/api/chapters', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, content })
-    });
-    const data = await resp.json();
-    if (!resp.ok) throw new Error(data.error || '儲存失敗');
-    status.textContent = `已儲存：${data.title || name}`;
+    let title = name;
+    if (window.go && window.go.desktop && window.go.desktop.App) {
+      title = await window.go.desktop.App.SaveChapter(name, content);
+    } else {
+      const resp = await fetch('/api/chapters', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, content })
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error || '儲存失敗');
+      title = data.title || name;
+    }
+    status.textContent = `已儲存：${title}`;
     setTimeout(() => { status.textContent = ''; }, 3000);
   } catch (e) {
     status.textContent = '錯誤：' + e.message;


### PR DESCRIPTION
## Summary

- 新增 `Server.ChapterContent` / `SaveChapterContent` exported wrapper，供桌面 binding 複用既有章節讀寫邏輯
- 在 `desktop.App` 暴露 `LoadChapter`、`SaveChapter`、`Reindex` 三個 Wails binding
- 更新 `_nav.html` 與 `focus.html`，優先走 `window.go?.desktop?.App`，不支援時 fallback 到原本 fetch API

## Test plan

- [ ] `go test ./...`
- [ ] `go build ./...`
- [ ] `CGO_ENABLED=1 go build -tags desktop ./cmd/desktop/`

refs #93