### PR TITLE
[ci] Add desktop build smoke test (CGO_ENABLED=1 -tags desktop)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install CGO dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Desktop smoke build
-        run: CGO_ENABLED=1 go build -tags desktop ./cmd/desktop/
+        run: CGO_ENABLED=1 go build -tags "desktop webkit2_41" ./cmd/desktop/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
           sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev
 
       - name: Desktop smoke build
-        run: CGO_ENABLED=1 go build -tags "desktop webkit2_41" ./cmd/desktop/
+        run: CGO_ENABLED=1 go build -tags "desktop webkit2_41" -o /tmp/novel-assistant-desktop ./cmd/desktop/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,20 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+  desktop-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install CGO dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: Desktop smoke build
+        run: CGO_ENABLED=1 go build -tags desktop ./cmd/desktop/


### PR DESCRIPTION
## Summary

- 新增 `desktop-build` job 至 `ci.yml`，與現有 `test` job 並行執行
- 安裝 CGO 依賴（gcc、libgtk-3-dev、libwebkit2gtk-4.0-dev）後執行 `CGO_ENABLED=1 go build -tags desktop ./cmd/desktop/`
- 不需要 Wails CLI，不需要 display，純 smoke build

## Test plan

- [ ] CI `desktop-build` check 在此 PR 通過
- [ ] CI `test` job 不受影響

Closes #107