### PR TITLE
[film] Visual Consistency Guard — inject character appearance into scene prompts

### DIFF
--- a/internal/exporter/film.go
+++ b/internal/exporter/film.go
@@ -36,6 +36,9 @@ func InjectVisualGuard(scenes []checker.FilmScene, characters []*profile.Charact
 
 	out := make([]checker.FilmScene, len(scenes))
 	for i, scene := range scenes {
+		chars := make([]checker.FilmCharacter, len(scene.Characters))
+		copy(chars, scene.Characters)
+		scene.Characters = chars
 		for j := range scene.Characters {
 			if app, ok := lookup[scene.Characters[j].Name]; ok {
 				scene.Characters[j].Appearance = app

--- a/internal/exporter/film.go
+++ b/internal/exporter/film.go
@@ -3,8 +3,10 @@ package exporter
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"novel-assistant/internal/checker"
+	"novel-assistant/internal/profile"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,6 +18,42 @@ const (
 	FilmFormatYAML FilmFormat = "yaml"
 	FilmFormatJSON FilmFormat = "json"
 )
+
+// InjectVisualGuard fills each FilmCharacter.Appearance from character profiles
+// and prepends appearance anchors to the scene's VideoPrompt, ensuring visual
+// consistency across independently generated scene prompts.
+// Characters without an Appearance in their profile are left unchanged.
+func InjectVisualGuard(scenes []checker.FilmScene, characters []*profile.Character) []checker.FilmScene {
+	lookup := make(map[string]string, len(characters))
+	for _, c := range characters {
+		if c.Appearance != "" {
+			lookup[c.Name] = c.Appearance
+		}
+	}
+	if len(lookup) == 0 {
+		return scenes
+	}
+
+	out := make([]checker.FilmScene, len(scenes))
+	for i, scene := range scenes {
+		for j := range scene.Characters {
+			if app, ok := lookup[scene.Characters[j].Name]; ok {
+				scene.Characters[j].Appearance = app
+			}
+		}
+		var anchors []string
+		for _, ch := range scene.Characters {
+			if ch.Appearance != "" {
+				anchors = append(anchors, ch.Name+": "+ch.Appearance)
+			}
+		}
+		if len(anchors) > 0 && scene.VideoPrompt != "" {
+			scene.VideoPrompt = "[" + strings.Join(anchors, "; ") + "] " + scene.VideoPrompt
+		}
+		out[i] = scene
+	}
+	return out
+}
 
 // ExportFilmScenes serialises a list of FilmScene values to the requested format.
 func ExportFilmScenes(scenes []checker.FilmScene, format FilmFormat) ([]byte, error) {

--- a/internal/exporter/film_test.go
+++ b/internal/exporter/film_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"novel-assistant/internal/checker"
+	"novel-assistant/internal/profile"
 )
 
 func TestExportFilmScenes_YAML(t *testing.T) {
@@ -52,6 +53,73 @@ func TestExportFilmScenes_JSON(t *testing.T) {
 	}
 	if !strings.Contains(body, `"video_prompt"`) {
 		t.Error("expected video_prompt in JSON output")
+	}
+}
+
+func TestInjectVisualGuard_FillsAppearanceAndPrependsPrompt(t *testing.T) {
+	t.Parallel()
+
+	scenes := []checker.FilmScene{
+		{
+			SceneID:     "CH01-S01",
+			VideoPrompt: "A tired man stands in a rain-soaked alley.",
+			Characters: []checker.FilmCharacter{
+				{Name: "林逸", Action: "低下頭"},
+			},
+		},
+	}
+	characters := []*profile.Character{
+		{Name: "林逸", Appearance: "黑色長外套；黑框眼鏡"},
+	}
+
+	out := InjectVisualGuard(scenes, characters)
+
+	if out[0].Characters[0].Appearance != "黑色長外套；黑框眼鏡" {
+		t.Fatalf("expected appearance injected into character, got %q", out[0].Characters[0].Appearance)
+	}
+	if !strings.HasPrefix(out[0].VideoPrompt, "[林逸: 黑色長外套；黑框眼鏡]") {
+		t.Fatalf("expected appearance anchor prepended to video_prompt, got %q", out[0].VideoPrompt)
+	}
+	if !strings.Contains(out[0].VideoPrompt, "A tired man") {
+		t.Fatalf("expected original prompt preserved, got %q", out[0].VideoPrompt)
+	}
+}
+
+func TestInjectVisualGuard_SkipsCharacterWithoutAppearance(t *testing.T) {
+	t.Parallel()
+
+	scenes := []checker.FilmScene{
+		{
+			SceneID:     "CH01-S01",
+			VideoPrompt: "A woman walks alone.",
+			Characters:  []checker.FilmCharacter{{Name: "陳靜", Action: "走路"}},
+		},
+	}
+	characters := []*profile.Character{
+		{Name: "陳靜", Appearance: ""},
+	}
+
+	out := InjectVisualGuard(scenes, characters)
+
+	if out[0].Characters[0].Appearance != "" {
+		t.Fatalf("expected empty appearance unchanged, got %q", out[0].Characters[0].Appearance)
+	}
+	if out[0].VideoPrompt != "A woman walks alone." {
+		t.Fatalf("expected video_prompt unchanged when no appearance, got %q", out[0].VideoPrompt)
+	}
+}
+
+func TestInjectVisualGuard_NoProfilesReturnsOriginal(t *testing.T) {
+	t.Parallel()
+
+	scenes := []checker.FilmScene{
+		{SceneID: "S01", VideoPrompt: "A man runs.", Characters: []checker.FilmCharacter{{Name: "志明"}}},
+	}
+
+	out := InjectVisualGuard(scenes, nil)
+
+	if out[0].VideoPrompt != "A man runs." {
+		t.Fatalf("expected original scenes returned unchanged, got %q", out[0].VideoPrompt)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2089,7 +2089,8 @@ func (s *Server) handleFilmExport(c *gin.Context) {
 	}
 
 	var req struct {
-		Format string `json:"format"` // "yaml" | "json"; defaults to "yaml"
+		Format        string `json:"format"`          // "yaml" | "json"; defaults to "yaml"
+		NoVisualGuard bool   `json:"no_visual_guard"` // set true to skip appearance injection
 	}
 	_ = c.ShouldBindJSON(&req)
 	format := exporter.FilmFormat(req.Format)
@@ -2107,6 +2108,10 @@ func (s *Server) handleFilmExport(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
+	}
+
+	if !req.NoVisualGuard {
+		scenes = exporter.InjectVisualGuard(scenes, s.profiles.Characters)
 	}
 
 	out, err := exporter.ExportFilmScenes(scenes, format)


### PR DESCRIPTION
## Summary

- 新增 `exporter.InjectVisualGuard(scenes, characters)`：從角色 profile 的 `Appearance` 欄位填入 `FilmCharacter.Appearance`，並在每個場景的 `VideoPrompt` 前綴加上外觀錨點 `[林逸: 黑色長外套；黑框眼鏡] ...`
- `handleFilmExport` 預設啟用 Guard，可透過請求欄位 `no_visual_guard: true` 關閉
- 無 `Appearance` 欄位的角色不影響其他場景輸出
- 三個測試：注入正確、缺外觀欄位跳過、空 profiles 回傳原始場景

**前置需求：** #94（已合入）

## Test plan

- [x] `go test ./...` 通過
- [x] `go build ./...` 通過

Closes #95