### PR TITLE
[test] Fix data race in TestE2EStyleAnalyzeApplyAndRewritePreset

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -781,7 +781,10 @@ func TestGetSettingsReturnsRetrievalDefaults(t *testing.T) {
 func TestE2EStyleAnalyzeApplyAndRewritePreset(t *testing.T) {
 	t.Parallel()
 
-	var prompts []string
+	var (
+		promptsMu sync.Mutex
+		prompts   []string
+	)
 	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/embeddings":
@@ -792,7 +795,9 @@ func TestE2EStyleAnalyzeApplyAndRewritePreset(t *testing.T) {
 				t.Fatalf("decode generate request: %v", err)
 			}
 			prompt, _ := req["prompt"].(string)
+			promptsMu.Lock()
 			prompts = append(prompts, prompt)
+			promptsMu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			switch {
 			case strings.Contains(prompt, "分析以下文字的寫作風格"):


### PR DESCRIPTION
## Summary

`httptest.Server` 的 handler 在 goroutine pool 中執行，style analysis 和 rewrite stream 可能同時送出 `/api/generate`，造成無保護的 `prompts` slice concurrent append（data race）。

修法：加 `promptsMu sync.Mutex`，在 handler 的 `append` 前後加鎖。`sync` 套件已在 import 中，無額外依賴。

## Test plan

- [x] `go test -run TestE2EStyleAnalyzeApplyAndRewritePreset ./internal/server/...` 通過
- [x] `go test ./...` 通過
- [ ] CI 上以 `-race` flag 驗證（本機無 CGO，無法執行 `-race`）

Closes #102