### PR TITLE
[feat] One-click download — release workflow and README download section

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Add MinGW to PATH
+        shell: bash
+        run: echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+
+      - name: Build Windows executable
+        shell: bash
+        env:
+          CGO_ENABLED: "1"
+        run: go build -tags desktop -ldflags "-H windowsgui" -o novel-assistant.exe ./cmd/desktop/
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: novel-assistant.exe
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build macOS binary
+        env:
+          CGO_ENABLED: "1"
+        run: go build -tags desktop -o novel-assistant ./cmd/desktop/
+
+      - name: Package as .app bundle
+        run: |
+          APP="Novel Assistant.app"
+          mkdir -p "$APP/Contents/MacOS"
+          mkdir -p "$APP/Contents/Resources"
+          cp novel-assistant "$APP/Contents/MacOS/novel-assistant"
+          chmod +x "$APP/Contents/MacOS/novel-assistant"
+          cat > "$APP/Contents/Info.plist" << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleExecutable</key>
+            <string>novel-assistant</string>
+            <key>CFBundleIdentifier</key>
+            <string>com.novel-assistant.app</string>
+            <key>CFBundleName</key>
+            <string>小說助手</string>
+            <key>CFBundleDisplayName</key>
+            <string>小說助手</string>
+            <key>CFBundleVersion</key>
+            <string>1.0</string>
+            <key>CFBundleShortVersionString</key>
+            <string>1.0</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>NSHighResolutionCapable</key>
+            <true/>
+          </dict>
+          </plist>
+          PLIST
+          printf 'APPL????' > "$APP/Contents/PkgInfo"
+          zip -r novel-assistant-macos.zip "$APP"
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: novel-assistant-macos.zip

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ The only local-first AI writing system that tracks your foreshadowing, detects i
 
 It runs entirely on your machine. Your manuscript never leaves your computer.
 
+---
+
+## Download
+
+| Platform | Download |
+|---|---|
+| 🪟 Windows 10 / 11 | [**novel-assistant.exe**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant.exe) |
+| 🍎 macOS | [**novel-assistant-macos.zip**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos.zip) |
+
+**Windows:** Download and double-click to run. Requires Windows 10 / 11 (WebView2 is pre-installed).
+
+**macOS:** Unzip, then right-click the app > Open. You'll need to click "Open" once to allow the app (standard Gatekeeper prompt for apps outside the App Store).
+
+> **Prerequisite:** [Ollama](https://ollama.com/) must be installed and running. The app will guide you through the rest on first launch.
+
+---
+
 ## Why This Project Exists
 
 Most writing tools are either:

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -11,6 +11,23 @@
 
 全程在你的電腦上執行。你的稿件永遠不會離開你的裝置。
 
+---
+
+## 下載
+
+| 平台 | 下載 |
+|---|---|
+| 🪟 Windows 10 / 11 | [**novel-assistant.exe**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant.exe) |
+| 🍎 macOS | [**novel-assistant-macos.zip**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos.zip) |
+
+**Windows：** 下載後直接雙擊執行。需要 Windows 10 / 11（已內建 WebView2）。
+
+**macOS：** 解壓縮後，右鍵點擊 app > 「打開」。第一次執行需點「打開」允許（macOS Gatekeeper 限制，非來自 App Store 的 app 皆需此步驟）。
+
+> **前置需求：** 需要先安裝並執行 [Ollama](https://ollama.com/)，啟動後 app 會引導你完成其餘設定。
+
+---
+
 ## 這個專案想解決什麼
 
 多數寫作工具通常落在兩端：


### PR DESCRIPTION
## Summary

讓使用者能直接在 README 點連結下載、雙擊開啟，不需要任何技術背景。

**`.github/workflows/release.yml`（新增）**
- 觸發條件：push `v*` tag
- `build-windows`：`windows-latest` runner，使用 MSYS2 MinGW64 gcc，`CGO_ENABLED=1 go build -tags desktop`，產出 `novel-assistant.exe`，附到 Release
- `build-macos`：`macos-latest` runner，同樣 CGO build，打包成 `.app` bundle + zip，附到 Release
- 使用 `softprops/action-gh-release@v2` 自動附加 assets

**`README.md` / `README.zh-TW.md`（更新）**
- 副標題下方加 `## Download / ## 下載` 區塊
- 連結指向 `releases/latest/download/novel-assistant.exe` 和 `novel-assistant-macos.zip`
- 附平台說明（Windows 直接雙擊；macOS 右鍵打開）
- 前置需求：Ollama

## Test plan

- [ ] Push `v0.2.0` tag 後，確認 `build-windows` 和 `build-macos` job 皆通過
- [ ] 確認 Release 頁出現 `novel-assistant.exe` 和 `novel-assistant-macos.zip`
- [ ] 確認 README 下載連結可點擊並正確導向