### PR TITLE
feat(setup): add internal/setup package for first-run detection

### DIFF
--- a/internal/setup/installer.go
+++ b/internal/setup/installer.go
@@ -1,0 +1,177 @@
+package setup
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ProgressFn receives install progress: percent 0–100 and a human-readable message.
+// percent == -1 means indeterminate.
+type ProgressFn func(percent int, msg string)
+
+// IsOllamaInstalled returns true if the ollama binary is findable.
+func IsOllamaInstalled() bool {
+	if _, err := exec.LookPath("ollama"); err == nil {
+		return true
+	}
+	// Windows: Ollama may not be on PATH right after a silent install.
+	if runtime.GOOS == "windows" {
+		candidates := []string{
+			filepath.Join(os.Getenv("LOCALAPPDATA"), "Programs", "Ollama", "ollama.exe"),
+			`C:\Program Files\Ollama\ollama.exe`,
+		}
+		for _, p := range candidates {
+			if _, err := os.Stat(p); err == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// InstallOllama downloads and silently installs Ollama for the current OS.
+func InstallOllama(progress ProgressFn) error {
+	switch runtime.GOOS {
+	case "windows":
+		return installWindows(progress)
+	case "darwin":
+		return installDarwin(progress)
+	case "linux":
+		return installLinux(progress)
+	default:
+		return fmt.Errorf("不支援的作業系統：%s", runtime.GOOS)
+	}
+}
+
+func installWindows(progress ProgressFn) error {
+	url := "https://ollama.com/download/OllamaSetup.exe"
+	tmp := filepath.Join(os.TempDir(), "OllamaSetup.exe")
+	defer os.Remove(tmp)
+
+	progress(5, "正在下載 Ollama 安裝程式...")
+	if err := downloadWithProgress(url, tmp, 5, 70, progress); err != nil {
+		return err
+	}
+
+	progress(75, "正在安裝 Ollama（背景靜默執行）...")
+	if out, err := exec.Command(tmp, "/S").CombinedOutput(); err != nil {
+		return fmt.Errorf("安裝失敗：%w\n%s", err, out)
+	}
+
+	progress(90, "等待 Ollama 服務啟動...")
+	for i := 0; i < 30; i++ {
+		time.Sleep(time.Second)
+		if IsOllamaInstalled() {
+			break
+		}
+	}
+	progress(100, "Ollama 安裝完成 ✓")
+	return nil
+}
+
+func installDarwin(progress ProgressFn) error {
+	url := "https://ollama.com/download/Ollama-darwin.zip"
+	tmp := filepath.Join(os.TempDir(), "Ollama-darwin.zip")
+	defer os.Remove(tmp)
+
+	progress(5, "正在下載 Ollama...")
+	if err := downloadWithProgress(url, tmp, 5, 65, progress); err != nil {
+		return err
+	}
+
+	extractDir := filepath.Join(os.TempDir(), "ollama-extract")
+	os.MkdirAll(extractDir, 0o755)
+	defer os.RemoveAll(extractDir)
+
+	progress(70, "正在解壓縮...")
+	if out, err := exec.Command("unzip", "-o", tmp, "-d", extractDir).CombinedOutput(); err != nil {
+		return fmt.Errorf("解壓縮失敗：%w\n%s", err, out)
+	}
+
+	progress(85, "正在安裝至 Applications...")
+	src := filepath.Join(extractDir, "Ollama.app")
+	if out, err := exec.Command("cp", "-rf", src, "/Applications/Ollama.app").CombinedOutput(); err != nil {
+		return fmt.Errorf("複製失敗：%w\n%s", err, out)
+	}
+
+	progress(95, "正在啟動 Ollama...")
+	exec.Command("open", "/Applications/Ollama.app").Start() //nolint:errcheck
+	time.Sleep(3 * time.Second)
+
+	progress(100, "Ollama 安裝完成 ✓")
+	return nil
+}
+
+func installLinux(progress ProgressFn) error {
+	progress(10, "正在安裝 Ollama（需要 sudo 權限）...")
+	cmd := exec.Command("bash", "-c", "curl -fsSL https://ollama.com/install.sh | sh")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("安裝失敗：%w", err)
+	}
+	progress(100, "Ollama 安裝完成 ✓")
+	return nil
+}
+
+// downloadWithProgress downloads url to dest, reporting progress between startPct and endPct.
+func downloadWithProgress(url, dest string, startPct, endPct int, progress ProgressFn) error {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("下載失敗：%w", err)
+	}
+	defer resp.Body.Close()
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	total := resp.ContentLength
+	var downloaded int64
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			f.Write(buf[:n]) //nolint:errcheck
+			downloaded += int64(n)
+			if total > 0 {
+				pct := startPct + int(float64(downloaded)/float64(total)*float64(endPct-startPct))
+				progress(pct, fmt.Sprintf("已下載 %.1f / %.1f MB",
+					float64(downloaded)/1024/1024, float64(total)/1024/1024))
+			} else {
+				progress(-1, fmt.Sprintf("已下載 %.1f MB", float64(downloaded)/1024/1024))
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ParseOllamaPullLine extracts a percent value from an ollama pull output line.
+// Returns -1 when the line carries no percentage.
+func ParseOllamaPullLine(line string) int {
+	line = strings.TrimSpace(line)
+	if idx := strings.Index(line, "%"); idx > 0 {
+		start := strings.LastIndex(line[:idx], " ")
+		numStr := strings.TrimSpace(line[start+1 : idx])
+		var pct int
+		if _, err := fmt.Sscanf(numStr, "%d", &pct); err == nil {
+			return pct
+		}
+	}
+	return -1
+}

--- a/internal/setup/installer.go
+++ b/internal/setup/installer.go
@@ -129,6 +129,10 @@ func downloadWithProgress(url, dest string, startPct, endPct int, progress Progr
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("下載失敗：伺服器回應 %d", resp.StatusCode)
+	}
+
 	f, err := os.Create(dest)
 	if err != nil {
 		return err
@@ -141,7 +145,9 @@ func downloadWithProgress(url, dest string, startPct, endPct int, progress Progr
 	for {
 		n, err := resp.Body.Read(buf)
 		if n > 0 {
-			f.Write(buf[:n]) //nolint:errcheck
+			if _, werr := f.Write(buf[:n]); werr != nil {
+				return fmt.Errorf("寫入失敗：%w", werr)
+			}
 			downloaded += int64(n)
 			if total > 0 {
 				pct := startPct + int(float64(downloaded)/float64(total)*float64(endPct-startPct))

--- a/internal/setup/manager.go
+++ b/internal/setup/manager.go
@@ -1,0 +1,22 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const setupDoneMarker = ".setup_complete"
+
+// IsComplete returns true if the one-time setup wizard has been finished.
+func IsComplete(dataDir string) bool {
+	_, err := os.Stat(filepath.Join(dataDir, setupDoneMarker))
+	return err == nil
+}
+
+// MarkComplete writes the marker file so future launches skip the wizard.
+func MarkComplete(dataDir string) error {
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dataDir, setupDoneMarker), []byte("1"), 0o644)
+}

--- a/internal/setup/models.go
+++ b/internal/setup/models.go
@@ -1,0 +1,146 @@
+package setup
+
+// IsAllowedModel reports whether name is in the known LLM or embed model list.
+func IsAllowedModel(name string) bool {
+	for _, m := range LLMModels {
+		if m.Name == name {
+			return true
+		}
+	}
+	for _, m := range EmbedModels {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ModelRole distinguishes language models from embedding models.
+type ModelRole string
+
+const (
+	RoleLLM   ModelRole = "llm"
+	RoleEmbed ModelRole = "embed"
+)
+
+// ModelTier is a rough quality/size tier for display purposes.
+type ModelTier string
+
+const (
+	TierUltraLight  ModelTier = "ultra_light"
+	TierLight       ModelTier = "light"
+	TierBalanced    ModelTier = "balanced"
+	TierHighQuality ModelTier = "high_quality"
+)
+
+// ModelOption describes an available Ollama model with its requirements.
+type ModelOption struct {
+	Name        string    `json:"name"`
+	DisplayName string    `json:"display_name"`
+	SizeGB      float64   `json:"size_gb"`
+	MinRAMGB    float64   `json:"min_ram_gb"`
+	Role        ModelRole `json:"role"`
+	Tier        ModelTier `json:"tier"`
+	Description string    `json:"description"`
+}
+
+// LLMModels is the ordered list of supported language models.
+var LLMModels = []ModelOption{
+	{
+		Name:        "llama3.2:1b",
+		DisplayName: "LLaMA 3.2 1B",
+		SizeGB:      1.3,
+		MinRAMGB:    4,
+		Role:        RoleLLM,
+		Tier:        TierUltraLight,
+		Description: "超輕量，速度最快，適合 4 GB 記憶體，寫作品質基本",
+	},
+	{
+		Name:        "phi3:mini",
+		DisplayName: "Phi-3 Mini",
+		SizeGB:      2.3,
+		MinRAMGB:    4,
+		Role:        RoleLLM,
+		Tier:        TierLight,
+		Description: "Microsoft 輕量模型，4 GB 可用，品質比 1B 好",
+	},
+	{
+		Name:        "llama3.2",
+		DisplayName: "LLaMA 3.2 3B",
+		SizeGB:      2.0,
+		MinRAMGB:    8,
+		Role:        RoleLLM,
+		Tier:        TierBalanced,
+		Description: "均衡推薦，速度與品質兼顧，需 8 GB",
+	},
+	{
+		Name:        "llama3.1:8b",
+		DisplayName: "LLaMA 3.1 8B",
+		SizeGB:      4.7,
+		MinRAMGB:    16,
+		Role:        RoleLLM,
+		Tier:        TierHighQuality,
+		Description: "高品質寫作分析，需 16 GB，效果最佳",
+	},
+	{
+		Name:        "mistral",
+		DisplayName: "Mistral 7B",
+		SizeGB:      4.1,
+		MinRAMGB:    16,
+		Role:        RoleLLM,
+		Tier:        TierHighQuality,
+		Description: "高品質替代方案，支援多語言，需 16 GB",
+	},
+}
+
+// EmbedModels is the list of supported embedding models (currently only one).
+var EmbedModels = []ModelOption{
+	{
+		Name:        "nomic-embed-text",
+		DisplayName: "Nomic Embed Text",
+		SizeGB:      0.27,
+		MinRAMGB:    2,
+		Role:        RoleEmbed,
+		Tier:        TierBalanced,
+		Description: "向量搜尋核心元件，體積小，必須安裝",
+	},
+}
+
+// Recommendation holds the suggested models for a given machine.
+type Recommendation struct {
+	LLMModelName   string `json:"llm_model_name"`
+	EmbedModelName string `json:"embed_model_name"`
+	Note           string `json:"note"`
+}
+
+// Recommend picks the best LLM for the detected specs.
+func Recommend(specs SystemSpecs) Recommendation {
+	// Use GPU VRAM as effective memory when a dedicated GPU is present.
+	effective := specs.RAMGB
+	if specs.VRAMGB >= 8 {
+		effective = specs.VRAMGB
+	}
+
+	var llm string
+	var note string
+	switch {
+	case effective >= 16:
+		llm = "llama3.1:8b"
+		note = "你的規格優秀，推薦高品質模型以獲得最佳寫作分析效果"
+	case effective >= 8:
+		llm = "llama3.2"
+		note = "推薦均衡模型，速度與品質兼顧"
+	case effective >= 4:
+		llm = "llama3.2:1b"
+		note = "記憶體較少，推薦輕量模型，仍可正常使用所有功能"
+	default:
+		llm = "llama3.2:1b"
+		note = "記憶體低於 4 GB，建議關閉其他應用程式後再使用"
+	}
+
+	return Recommendation{
+		LLMModelName:   llm,
+		EmbedModelName: "nomic-embed-text",
+		Note:           note,
+	}
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,118 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ── Recommend ────────────────────────────────────────────────────────────────
+
+func TestRecommend_LowRAM(t *testing.T) {
+	rec := Recommend(SystemSpecs{RAMGB: 3.5})
+	if rec.LLMModelName != "llama3.2:1b" {
+		t.Errorf("< 4 GB RAM: want llama3.2:1b, got %s", rec.LLMModelName)
+	}
+	if rec.EmbedModelName != "nomic-embed-text" {
+		t.Errorf("embed model: want nomic-embed-text, got %s", rec.EmbedModelName)
+	}
+}
+
+func TestRecommend_MidRAM(t *testing.T) {
+	rec := Recommend(SystemSpecs{RAMGB: 8})
+	if rec.LLMModelName != "llama3.2" {
+		t.Errorf("8 GB RAM: want llama3.2, got %s", rec.LLMModelName)
+	}
+}
+
+func TestRecommend_HighRAM(t *testing.T) {
+	rec := Recommend(SystemSpecs{RAMGB: 32})
+	if rec.LLMModelName != "llama3.1:8b" {
+		t.Errorf(">= 16 GB RAM: want llama3.1:8b, got %s", rec.LLMModelName)
+	}
+}
+
+func TestRecommend_GPUVRAMOverridesRAM(t *testing.T) {
+	// Low system RAM but high GPU VRAM → should recommend the high-quality model.
+	rec := Recommend(SystemSpecs{RAMGB: 6, VRAMGB: 16})
+	if rec.LLMModelName != "llama3.1:8b" {
+		t.Errorf("VRAM 16 GB: want llama3.1:8b, got %s", rec.LLMModelName)
+	}
+}
+
+func TestRecommend_NoteNonEmpty(t *testing.T) {
+	specs := []SystemSpecs{
+		{RAMGB: 2},
+		{RAMGB: 8},
+		{RAMGB: 32},
+	}
+	for _, s := range specs {
+		rec := Recommend(s)
+		if rec.Note == "" {
+			t.Errorf("Recommend(%+v): Note should not be empty", s)
+		}
+	}
+}
+
+// ── IsAllowedModel ───────────────────────────────────────────────────────────
+
+func TestIsAllowedModel_KnownLLM(t *testing.T) {
+	known := []string{"llama3.2:1b", "phi3:mini", "llama3.2", "llama3.1:8b", "mistral"}
+	for _, name := range known {
+		if !IsAllowedModel(name) {
+			t.Errorf("IsAllowedModel(%q): want true", name)
+		}
+	}
+}
+
+func TestIsAllowedModel_KnownEmbed(t *testing.T) {
+	if !IsAllowedModel("nomic-embed-text") {
+		t.Error("IsAllowedModel(nomic-embed-text): want true")
+	}
+}
+
+func TestIsAllowedModel_Unknown(t *testing.T) {
+	unknown := []string{"", "evil-model", "llama3.2:latest", "../etc/passwd"}
+	for _, name := range unknown {
+		if IsAllowedModel(name) {
+			t.Errorf("IsAllowedModel(%q): want false", name)
+		}
+	}
+}
+
+// ── MarkComplete / IsComplete ────────────────────────────────────────────────
+
+func TestMarkComplete_CreatesMarker(t *testing.T) {
+	dir := t.TempDir()
+	if IsComplete(dir) {
+		t.Fatal("IsComplete: want false before MarkComplete")
+	}
+	if err := MarkComplete(dir); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if !IsComplete(dir) {
+		t.Error("IsComplete: want true after MarkComplete")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".setup_complete")); err != nil {
+		t.Errorf("marker file not found: %v", err)
+	}
+}
+
+func TestMarkComplete_IdempotentOnRepeat(t *testing.T) {
+	dir := t.TempDir()
+	if err := MarkComplete(dir); err != nil {
+		t.Fatalf("first MarkComplete: %v", err)
+	}
+	if err := MarkComplete(dir); err != nil {
+		t.Fatalf("second MarkComplete: %v", err)
+	}
+	if !IsComplete(dir) {
+		t.Error("IsComplete: want true after two MarkComplete calls")
+	}
+}
+
+func TestIsComplete_MissingDir(t *testing.T) {
+	if IsComplete(filepath.Join(t.TempDir(), "nonexistent")) {
+		t.Error("IsComplete on missing dir: want false")
+	}
+}

--- a/internal/setup/specs.go
+++ b/internal/setup/specs.go
@@ -1,0 +1,127 @@
+package setup
+
+import (
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// SystemSpecs holds detected hardware information.
+type SystemSpecs struct {
+	RAMGB    float64 `json:"ram_gb"`
+	CPUCores int     `json:"cpu_cores"`
+	GPUName  string  `json:"gpu_name"`
+	VRAMGB   float64 `json:"vram_gb"`
+	OS       string  `json:"os"`
+	Arch     string  `json:"arch"`
+}
+
+// DetectSpecs reads RAM, CPU, and GPU information from the current machine.
+func DetectSpecs() SystemSpecs {
+	return SystemSpecs{
+		RAMGB:    detectRAMGB(),
+		CPUCores: runtime.NumCPU(),
+		OS:       runtime.GOOS,
+		Arch:     runtime.GOARCH,
+		GPUName:  detectGPUName(),
+		VRAMGB:   detectVRAMGB(),
+	}
+}
+
+func detectRAMGB() float64 {
+	switch runtime.GOOS {
+	case "linux":
+		out, err := exec.Command("grep", "MemTotal", "/proc/meminfo").Output()
+		if err != nil {
+			return 0
+		}
+		fields := strings.Fields(string(out))
+		if len(fields) >= 2 {
+			kb, _ := strconv.ParseFloat(fields[1], 64)
+			return roundGB(kb / 1024 / 1024)
+		}
+	case "darwin":
+		out, err := exec.Command("sysctl", "-n", "hw.memsize").Output()
+		if err != nil {
+			return 0
+		}
+		b, _ := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+		return roundGB(b / 1024 / 1024 / 1024)
+	case "windows":
+		out, err := exec.Command("wmic", "ComputerSystem", "get", "TotalPhysicalMemory", "/value").Output()
+		if err != nil {
+			return 0
+		}
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "TotalPhysicalMemory=") {
+				val := strings.TrimPrefix(line, "TotalPhysicalMemory=")
+				b, _ := strconv.ParseFloat(strings.TrimSpace(val), 64)
+				return roundGB(b / 1024 / 1024 / 1024)
+			}
+		}
+	}
+	return 0
+}
+
+func detectGPUName() string {
+	// NVIDIA
+	if out, err := exec.Command("nvidia-smi", "--query-gpu=name", "--format=csv,noheader").Output(); err == nil {
+		name := strings.TrimSpace(strings.Split(string(out), "\n")[0])
+		if name != "" {
+			return name
+		}
+	}
+	// macOS — Apple Silicon or discrete GPU
+	if runtime.GOOS == "darwin" {
+		out, _ := exec.Command("system_profiler", "SPDisplaysDataType").Output()
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "Chipset Model:") {
+				return strings.TrimSpace(strings.TrimPrefix(line, "Chipset Model:"))
+			}
+		}
+	}
+	return ""
+}
+
+func detectVRAMGB() float64 {
+	// NVIDIA
+	if out, err := exec.Command("nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits").Output(); err == nil {
+		mb, _ := strconv.ParseFloat(strings.TrimSpace(strings.Split(string(out), "\n")[0]), 64)
+		if mb > 0 {
+			return roundGB(mb / 1024)
+		}
+	}
+	// macOS — unified memory reported as VRAM
+	if runtime.GOOS == "darwin" {
+		out, _ := exec.Command("system_profiler", "SPDisplaysDataType").Output()
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, "VRAM") && strings.Contains(line, ":") {
+				parts := strings.SplitN(line, ":", 2)
+				fields := strings.Fields(parts[1])
+				if len(fields) >= 1 {
+					mb, _ := strconv.ParseFloat(fields[0], 64)
+					unit := ""
+					if len(fields) >= 2 {
+						unit = strings.ToUpper(fields[1])
+					}
+					if unit == "GB" {
+						return roundGB(mb)
+					}
+					if mb > 0 {
+						return roundGB(mb / 1024)
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func roundGB(v float64) float64 {
+	// round to one decimal
+	return float64(int(v*10+0.5)) / 10
+}

--- a/internal/setup/specs.go
+++ b/internal/setup/specs.go
@@ -49,20 +49,42 @@ func detectRAMGB() float64 {
 		b, _ := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
 		return roundGB(b / 1024 / 1024 / 1024)
 	case "windows":
-		out, err := exec.Command("wmic", "ComputerSystem", "get", "TotalPhysicalMemory", "/value").Output()
-		if err != nil {
-			return 0
+		// Try wmic first (available on Windows 10 and older).
+		if gb := windowsRAMViaWmic(); gb > 0 {
+			return gb
 		}
-		for _, line := range strings.Split(string(out), "\n") {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "TotalPhysicalMemory=") {
-				val := strings.TrimPrefix(line, "TotalPhysicalMemory=")
-				b, _ := strconv.ParseFloat(strings.TrimSpace(val), 64)
-				return roundGB(b / 1024 / 1024 / 1024)
-			}
+		// Fallback: PowerShell Get-CimInstance (available when wmic is absent).
+		return windowsRAMViaPowerShell()
+	}
+	return 0
+}
+
+func windowsRAMViaWmic() float64 {
+	out, err := exec.Command("wmic", "ComputerSystem", "get", "TotalPhysicalMemory", "/value").Output()
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "TotalPhysicalMemory=") {
+			val := strings.TrimPrefix(line, "TotalPhysicalMemory=")
+			b, _ := strconv.ParseFloat(strings.TrimSpace(val), 64)
+			return roundGB(b / 1024 / 1024 / 1024)
 		}
 	}
 	return 0
+}
+
+func windowsRAMViaPowerShell() float64 {
+	out, err := exec.Command(
+		"powershell", "-NoProfile", "-NonInteractive", "-Command",
+		"(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+	).Output()
+	if err != nil {
+		return 0
+	}
+	b, _ := strconv.ParseFloat(strings.TrimSpace(string(out)), 64)
+	return roundGB(b / 1024 / 1024 / 1024)
 }
 
 func detectGPUName() string {


### PR DESCRIPTION
## Summary

新增 `internal/setup/` 套件，供後續 PR 使用。純新增程式碼，不改動現有檔案。

- `manager.go`: `IsComplete()` / `MarkComplete()` 讀寫 `data/.setup_complete` marker
- `specs.go`: `DetectSpecs()` 讀取 RAM（/proc/meminfo、sysctl、wmic）、CPU 核心數、GPU 名稱與 VRAM（nvidia-smi、system_profiler）
- `models.go`: LLMModels 目錄（5 個模型）、EmbedModels、`Recommend()` 依 RAM/VRAM 推薦、`IsAllowedModel()` allowlist 安全驗證
- `installer.go`: `IsOllamaInstalled()`、`InstallOllama()` 各平台靜默安裝（Windows /S、macOS zip+cp、Linux curl sh）、`ProgressFn` 進度回呼

Closes part of #115

## Test plan
- [ ] `go build ./...` 通過
- [ ] `go test ./internal/setup` 通過