### PR TITLE
feat(server): setup routes, middleware, and ollama refactor

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -934,9 +934,16 @@ func newE2ETestServer(t *testing.T, dataDir, ollamaURL string) *Server {
 		Port:       "8080",
 	}
 
+	// Mark setup as complete so the requireSetupComplete middleware does not
+	// redirect all protected routes to /setup during tests.
+	if err := os.WriteFile(filepath.Join(dataDir, ".setup_complete"), []byte("1"), 0o644); err != nil {
+		t.Fatalf("write setup marker: %v", err)
+	}
+
 	gin.SetMode(gin.TestMode)
 	s := &Server{
 		cfg:           cfg,
+		globalDataDir: dataDir,
 		auth:          newAuthManager(cfg),
 		project:       projectsettings.New(filepath.Join(dataDir, "project_settings.json"), projectsettings.Settings{OllamaURL: cfg.OllamaURL, LLMModel: cfg.LLMModel, EmbedModel: cfg.EmbedModel, Port: cfg.Port, DataDir: cfg.DataDir}),
 		profiles:      profile.NewManager(dataDir),

--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -145,7 +145,12 @@ func (s *Server) handleOllamaPull(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "model 不可為空"})
 		return
 	}
+	s.streamOllamaPull(c, model)
+}
 
+// streamOllamaPull is the shared implementation used by both the protected
+// /api/ollama/pull handler and the public /api/setup/pull-model handler.
+func (s *Server) streamOllamaPull(c *gin.Context, model string) {
 	inflightMu.Lock()
 	if _, ok := inflight[model]; ok {
 		inflightMu.Unlock()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"novel-assistant/internal/retriever"
 	"novel-assistant/internal/reviewhistory"
 	"novel-assistant/internal/reviewrules"
+	"novel-assistant/internal/setup"
 	"novel-assistant/internal/tracker"
 	"novel-assistant/internal/vectorstore"
 	"novel-assistant/internal/workspace"
@@ -217,15 +218,45 @@ func (s *Server) setupRouter(webFS fs.FS) error {
 	return nil
 }
 
+// requireSetupComplete redirects browsers to /setup when the one-time wizard
+// has not yet been finished. API callers receive 503 instead.
+func (s *Server) requireSetupComplete() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		dataDir := s.globalDataDir
+		if dataDir == "" {
+			dataDir = "data"
+		}
+		if setup.IsComplete(dataDir) {
+			c.Next()
+			return
+		}
+		if strings.HasPrefix(c.Request.URL.Path, "/api/") {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "setup not complete"})
+			return
+		}
+		c.Redirect(http.StatusFound, "/setup")
+		c.Abort()
+	}
+}
+
 func (s *Server) setupRoutes() {
 	r := s.router
 
 	r.GET("/login", s.handleLoginPage)
 	r.POST("/login", s.handleLogin)
 	r.POST("/logout", s.handleLogout)
+
+	// Setup wizard — public, no auth or setup-complete check required.
+	// install-ollama and pull-model are GET so they work with the browser
+	// EventSource API (which only issues GET requests).
 	r.GET("/setup", s.handleSetupPage)
+	r.GET("/api/setup/specs", s.handleSetupSpecs)
+	r.GET("/api/setup/install-ollama", s.handleSetupInstallOllama)
+	r.GET("/api/setup/pull-model", s.handleSetupPullModel)
+	r.POST("/api/setup/complete", s.handleSetupComplete)
 
 	protected := r.Group("/")
+	protected.Use(s.requireSetupComplete())
 	protected.Use(s.requireAuth())
 
 	protected.GET("/", s.handleIndex)

--- a/internal/server/setup_handlers.go
+++ b/internal/server/setup_handlers.go
@@ -1,0 +1,147 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"novel-assistant/internal/setup"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// handleSetupSpecs returns detected system specs, model list, and recommendation.
+func (s *Server) handleSetupSpecs(c *gin.Context) {
+	specs := setup.DetectSpecs()
+	rec := setup.Recommend(specs)
+	c.JSON(http.StatusOK, gin.H{
+		"specs":            specs,
+		"recommendation":   rec,
+		"llm_models":       setup.LLMModels,
+		"embed_models":     setup.EmbedModels,
+		"ollama_installed": setup.IsOllamaInstalled(),
+	})
+}
+
+// handleSetupInstallOllama streams Ollama installation progress via SSE (GET,
+// so it is compatible with the browser's EventSource API).
+func (s *Server) handleSetupInstallOllama(c *gin.Context) {
+	dataDir := s.globalDataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	if setup.IsComplete(dataDir) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "setup already complete"})
+		return
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+
+	send := func(percent int, msg string) {
+		data, _ := json.Marshal(gin.H{"percent": percent, "msg": msg})
+		fmt.Fprintf(c.Writer, "data: %s\n\n", data)
+		c.Writer.Flush()
+	}
+
+	if setup.IsOllamaInstalled() {
+		send(100, "Ollama 已安裝")
+		return
+	}
+
+	if err := setup.InstallOllama(send); err != nil {
+		data, _ := json.Marshal(gin.H{"error": err.Error()})
+		fmt.Fprintf(c.Writer, "data: %s\n\n", data)
+		c.Writer.Flush()
+	}
+}
+
+// handleSetupPullModel is a public GET endpoint that streams an ollama model
+// pull via SSE during the setup wizard. It is disabled once setup is complete
+// (callers should use the auth-protected /api/ollama/pull instead). The model
+// name must be in the known allowlist to prevent arbitrary pulls.
+func (s *Server) handleSetupPullModel(c *gin.Context) {
+	dataDir := s.globalDataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	if setup.IsComplete(dataDir) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "setup already complete; use /api/ollama/pull"})
+		return
+	}
+
+	model := strings.TrimSpace(c.Query("model"))
+	if model == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "model query param is required"})
+		return
+	}
+	if !setup.IsAllowedModel(model) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown model: " + model})
+		return
+	}
+	s.streamOllamaPull(c, model)
+}
+
+// handleSetupComplete persists the chosen models and marks setup as done.
+func (s *Server) handleSetupComplete(c *gin.Context) {
+	dataDir := s.globalDataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	// Reject once setup is complete — callers should use the auth-protected
+	// settings API to change models after initial setup.
+	if setup.IsComplete(dataDir) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "setup already complete"})
+		return
+	}
+
+	var req struct {
+		LLMModel   string `json:"llm_model"`
+		EmbedModel string `json:"embed_model"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	req.LLMModel = strings.TrimSpace(req.LLMModel)
+	req.EmbedModel = strings.TrimSpace(req.EmbedModel)
+	if req.LLMModel == "" {
+		req.LLMModel = "llama3.2"
+	}
+	if req.EmbedModel == "" {
+		req.EmbedModel = "nomic-embed-text"
+	}
+
+	// Validate against the known model allowlist.
+	if !setup.IsAllowedModel(req.LLMModel) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown llm_model: " + req.LLMModel})
+		return
+	}
+	if !setup.IsAllowedModel(req.EmbedModel) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown embed_model: " + req.EmbedModel})
+		return
+	}
+
+	// Persist the model choices into the project settings store so they
+	// survive restart. applyProjectSettings() reads from s.project.Get(),
+	// so we must update the store first.
+	existing := s.project.Get()
+	existing.LLMModel = req.LLMModel
+	existing.EmbedModel = req.EmbedModel
+	s.project.Update(existing)
+	if err := s.project.Save(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "儲存設定失敗：" + err.Error()})
+		return
+	}
+	s.applyProjectSettings()
+
+	if err := setup.MarkComplete(dataDir); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}

--- a/internal/server/setup_handlers.go
+++ b/internal/server/setup_handlers.go
@@ -11,7 +11,16 @@ import (
 )
 
 // handleSetupSpecs returns detected system specs, model list, and recommendation.
+// Returns 403 once setup is complete to avoid exposing hardware info unnecessarily.
 func (s *Server) handleSetupSpecs(c *gin.Context) {
+	dataDir := s.globalDataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	if setup.IsComplete(dataDir) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "setup already complete"})
+		return
+	}
 	specs := setup.DetectSpecs()
 	rec := setup.Recommend(specs)
 	c.JSON(http.StatusOK, gin.H{


### PR DESCRIPTION
## Summary

在 server 層接入 `internal/setup`，實作 setup wizard 的後端 API。

- `server.go`: 加 `requireSetupComplete()` middleware + 四條公開 setup routes
- `ollama.go`: 抽出 `streamOllamaPull()` 共用函式
- `setup_handlers.go`: specs / install / pull / complete 四個 handler，setup 完成後均回 403，pull 與 complete 加 allowlist 驗證
- `e2e_test.go`: `newE2ETestServer` 補 `globalDataDir` 與 `.setup_complete` marker，修復 `TestHandleOllamaPull_*` 回歸

Closes part of #115

## Test plan
- [ ] `go build ./...` 通過
- [ ] `go test ./internal/server -run TestHandleOllamaPull -count=1` 通過
- [ ] `go test ./...` 通過