### PR TITLE
docs: add 4-platform download section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@ The only local-first AI writing system that tracks your foreshadowing, detects i
 
 It runs entirely on your machine. Your manuscript never leaves your computer.
 
+---
+
+## Download
+
+| Platform | Download |
+|---|---|
+| 🪟 Windows 10 / 11 | [**novel-assistant-windows-amd64-setup.exe**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-windows-amd64-setup.exe) |
+| 🍎 macOS (Apple Silicon) | [**novel-assistant-macos-arm64.dmg**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos-arm64.dmg) |
+| 🍎 macOS (Intel) | [**novel-assistant-macos-amd64.dmg**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos-amd64.dmg) |
+| 🐧 Linux x64 | [**novel-assistant-linux-amd64.tar.gz**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-linux-amd64.tar.gz) |
+
+**Windows:** Run the installer and follow the prompts. Requires Windows 10 / 11 (WebView2 is pre-installed).
+
+**macOS:** Open the DMG, drag the app to Applications, then right-click > Open for the first launch (standard Gatekeeper prompt for apps outside the App Store).
+
+**Linux:** Extract the tarball and run `./novel-assistant-linux-amd64` directly.
+
+> **Prerequisite:** [Ollama](https://ollama.com/) must be installed and running. The app will guide you through model selection on first launch.
+
+---
+
 ## Why This Project Exists
 
 Most writing tools are either:

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -11,6 +11,27 @@
 
 全程在你的電腦上執行。你的稿件永遠不會離開你的裝置。
 
+---
+
+## 下載
+
+| 平台 | 下載 |
+|---|---|
+| 🪟 Windows 10 / 11 | [**novel-assistant-windows-amd64-setup.exe**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-windows-amd64-setup.exe) |
+| 🍎 macOS（Apple Silicon）| [**novel-assistant-macos-arm64.dmg**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos-arm64.dmg) |
+| 🍎 macOS（Intel）| [**novel-assistant-macos-amd64.dmg**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-macos-amd64.dmg) |
+| 🐧 Linux x64 | [**novel-assistant-linux-amd64.tar.gz**](https://github.com/easonchiang07-ship-it/novel-assistant/releases/latest/download/novel-assistant-linux-amd64.tar.gz) |
+
+**Windows：** 執行安裝精靈，依提示完成安裝。需要 Windows 10 / 11（已內建 WebView2）。
+
+**macOS：** 開啟 DMG，將 app 拖入 Applications，第一次啟動請右鍵 > 「打開」（macOS Gatekeeper 限制，非來自 App Store 的 app 皆需此步驟）。
+
+**Linux：** 解壓縮後直接執行 `./novel-assistant-linux-amd64`。
+
+> **前置需求：** 需要先安裝 [Ollama](https://ollama.com/)。首次啟動時，app 會引導你選擇並下載 AI 模型。
+
+---
+
 ## 這個專案想解決什麼
 
 多數寫作工具通常落在兩端：


### PR DESCRIPTION
## Summary

新增 README.md / README.zh-TW.md 的下載區塊，補上 PR #121 合入的四平台 release workflow 對應的下載連結。

- Windows: `novel-assistant-windows-amd64-setup.exe`（Inno Setup 安裝精靈）
- macOS Apple Silicon: `novel-assistant-macos-arm64.dmg`
- macOS Intel: `novel-assistant-macos-amd64.dmg`
- Linux x64: `novel-assistant-linux-amd64.tar.gz`

取代 PR #114 和 PR #122（舊版連結對不上 artifact 名稱，且 release.yml 改動已由 PR #121 完成）。

Closes #115

## Test plan

- [ ] README 連結格式正確
- [ ] 繁中版內容與英文版一致