### PR TITLE
fix(wizard): resolve pullModel promise on onerror to prevent UI hang

### DIFF
--- a/web/templates/setup.html
+++ b/web/templates/setup.html
@@ -587,13 +587,19 @@ function pullModel(name) {
       es.close();
       let msg = '未知錯誤';
       try { msg = JSON.parse(e.data).error; } catch (_) {}
-      document.getElementById('pullError').classList.remove('hidden');
-      document.getElementById('pullError').textContent = name + ' 下載失敗：' + msg;
+      const errBox = document.getElementById('pullError');
+      errBox.classList.remove('hidden');
+      errBox.innerHTML = name + ' 下載失敗：' + msg +
+        ' <button onclick="runModelPull()" style="margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;">重試</button>';
       resolve(false);
     });
     es.onerror = () => {
-      // EventSource will retry automatically; show indeterminate
-      document.getElementById('bar-' + id).classList.add('indeterminate');
+      es.close();
+      const errBox = document.getElementById('pullError');
+      errBox.classList.remove('hidden');
+      errBox.innerHTML = '無法連線 Ollama，請確認 Ollama 已開啟後點「重試」' +
+        ' <button onclick="runModelPull()" style="margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;">重試</button>';
+      resolve(false);
     };
   });
 }

--- a/web/templates/setup.html
+++ b/web/templates/setup.html
@@ -562,6 +562,25 @@ function pullModel(name) {
   return new Promise(resolve => {
     const id = cssId(name);
     document.getElementById('msg-' + id).textContent = '連接中…';
+    let settled = false;
+
+    function settle(val) {
+      if (settled) return;
+      settled = true;
+      resolve(val);
+    }
+
+    function showPullError(text) {
+      const errBox = document.getElementById('pullError');
+      errBox.classList.remove('hidden');
+      errBox.textContent = '';
+      errBox.appendChild(document.createTextNode(text + ' '));
+      const btn = document.createElement('button');
+      btn.textContent = '重試';
+      btn.style.cssText = 'margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;';
+      btn.onclick = runModelPull;
+      errBox.appendChild(btn);
+    }
 
     const es = new EventSource('/api/setup/pull-model?model=' + encodeURIComponent(name));
     es.addEventListener('progress', e => {
@@ -581,25 +600,20 @@ function pullModel(name) {
       document.getElementById('bar-' + id).style.width = '100%';
       document.getElementById('bar-' + id).classList.remove('indeterminate');
       document.getElementById('msg-' + id).textContent = '下載完成';
-      resolve(true);
+      settle(true);
     });
     es.addEventListener('error', e => {
       es.close();
       let msg = '未知錯誤';
       try { msg = JSON.parse(e.data).error; } catch (_) {}
-      const errBox = document.getElementById('pullError');
-      errBox.classList.remove('hidden');
-      errBox.innerHTML = name + ' 下載失敗：' + msg +
-        ' <button onclick="runModelPull()" style="margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;">重試</button>';
-      resolve(false);
+      showPullError(name + ' 下載失敗：' + msg);
+      settle(false);
     });
     es.onerror = () => {
+      if (settled) return;
       es.close();
-      const errBox = document.getElementById('pullError');
-      errBox.classList.remove('hidden');
-      errBox.innerHTML = '無法連線 Ollama，請確認 Ollama 已開啟後點「重試」' +
-        ' <button onclick="runModelPull()" style="margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;">重試</button>';
-      resolve(false);
+      showPullError('無法連線 Ollama，請確認 Ollama 已開啟後點「重試」');
+      settle(false);
     };
   });
 }


### PR DESCRIPTION
## 問題

Setup wizard step 4 下載模型時，若 Ollama 未啟動或連線中斷，後端回傳 HTTP 502，EventSource 觸發 `es.onerror`。原本 `onerror` handler 只加了 indeterminate spinner，Promise 永遠不 resolve，UI 永久轉圈無路可走。

## 修改內容

- `es.onerror` 現在會關閉 EventSource、`resolve(false)`、顯示友善錯誤訊息與重試按鈕
- 錯誤訊息：「無法連線 Ollama，請確認 Ollama 已開啟後點「重試」」
- 重試按鈕呼叫 `runModelPull()`

## 測試計畫

- [ ] 確認 Ollama 未啟動時點下載，顯示錯誤訊息 + 重試按鈕，不再永久轉圈
- [ ] 啟動 Ollama 後點重試，下載流程正常進行

closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)