### PR TITLE
feat(wizard): add Ollama health check before model pull

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -261,7 +261,6 @@ func (s *Server) setupRoutes() {
 	protected.Use(s.requireAuth())
 
 	protected.GET("/", s.handleIndex)
-	protected.GET("/app", s.handleAppPage)
 	protected.GET("/chapters", s.handleChaptersPage)
 	protected.GET("/characters", s.handleCharacters)
 	protected.GET("/history", s.handleHistoryPage)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -253,6 +253,7 @@ func (s *Server) setupRoutes() {
 	r.GET("/api/setup/specs", s.handleSetupSpecs)
 	r.GET("/api/setup/install-ollama", s.handleSetupInstallOllama)
 	r.GET("/api/setup/pull-model", s.handleSetupPullModel)
+	r.GET("/api/setup/check-ollama", s.handleSetupCheckOllama)
 	r.POST("/api/setup/complete", s.handleSetupComplete)
 
 	protected := r.Group("/")
@@ -260,6 +261,7 @@ func (s *Server) setupRoutes() {
 	protected.Use(s.requireAuth())
 
 	protected.GET("/", s.handleIndex)
+	protected.GET("/app", s.handleAppPage)
 	protected.GET("/chapters", s.handleChaptersPage)
 	protected.GET("/characters", s.handleCharacters)
 	protected.GET("/history", s.handleHistoryPage)

--- a/internal/server/setup_handlers.go
+++ b/internal/server/setup_handlers.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"novel-assistant/internal/setup"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -91,6 +93,39 @@ func (s *Server) handleSetupPullModel(c *gin.Context) {
 		return
 	}
 	s.streamOllamaPull(c, model)
+}
+
+// handleSetupCheckOllama pings Ollama's /api/tags and returns {"ok": true/false}.
+func (s *Server) handleSetupCheckOllama(c *gin.Context) {
+	dataDir := s.globalDataDir
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	if setup.IsComplete(dataDir) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "setup already complete"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", s.cfg.OllamaURL+"/api/tags", nil)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"ok": false, "error": err.Error()})
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"ok": false, "error": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.JSON(http.StatusOK, gin.H{"ok": false, "error": fmt.Sprintf("Ollama 回應 %d", resp.StatusCode)})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // handleSetupComplete persists the chosen models and marks setup as done.

--- a/web/templates/setup.html
+++ b/web/templates/setup.html
@@ -328,6 +328,8 @@ h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: .5rem; }
       <h1>下載 AI 模型</h1>
       <p class="subtitle">首次下載需要一些時間，請耐心等待。</p>
 
+      <div id="ollamaCheckMsg" class="hidden" style="text-align:center;padding:.75rem;color:#6b7280;font-size:.95rem;"></div>
+
       <div id="pullItems"></div>
 
       <div id="pullError" class="hidden error-box"></div>
@@ -509,6 +511,39 @@ async function runOllamaInstall() {
 
 // ── Step 4: Pull models ─────────────────────────────────────────────────
 async function runModelPull() {
+  const checkMsg = document.getElementById('ollamaCheckMsg');
+  const errBox = document.getElementById('pullError');
+
+  // Reset state from any previous attempt
+  document.getElementById('pullItems').textContent = '';
+  errBox.classList.add('hidden');
+  checkMsg.textContent = '偵測 Ollama 中…';
+  checkMsg.classList.remove('hidden');
+
+  // Health check before downloading
+  let ollamaOk = false;
+  try {
+    const resp = await fetch('/api/setup/check-ollama');
+    const data = await resp.json();
+    ollamaOk = data.ok === true;
+  } catch (_) {}
+
+  checkMsg.classList.add('hidden');
+
+  if (!ollamaOk) {
+    errBox.classList.remove('hidden');
+    errBox.textContent = '';
+    errBox.appendChild(document.createTextNode(
+      '請先確認 Ollama 已開啟（Windows：從開始選單啟動 Ollama；macOS：從應用程式開啟） '
+    ));
+    const btn = document.createElement('button');
+    btn.textContent = '偵測並繼續';
+    btn.style.cssText = 'margin-left:.75rem;padding:.2rem .75rem;background:#667eea;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:.8rem;';
+    btn.onclick = runModelPull;
+    errBox.appendChild(btn);
+    return;
+  }
+
   const modelsToInstall = [
     { name: selectedLLM, label: selectedLLM },
     { name: 'nomic-embed-text', label: 'Nomic Embed Text' },
@@ -527,8 +562,6 @@ async function runModelPull() {
        <div class="progress-msg" id="msg-${cssId(m.name)}">排隊中…</div>
      </div>`
   ).join('');
-
-  document.getElementById('pullError').classList.add('hidden');
 
   for (const m of modelsToInstall) {
     const ok = await pullModel(m.name);


### PR DESCRIPTION
## 問題

Setup wizard step 4 在安裝完 Ollama 後直接拉模型，但 Windows 上安裝完不代表 Ollama service 已啟動，新手完全不知道需要先開 Ollama，導致下載直接失敗。

## 修改內容

**後端**
- 新增 `GET /api/setup/check-ollama`：ping Ollama 的 `/api/tags`，timeout 3 秒，回傳 `{"ok": true/false}`
- 在 `setup_handlers.go` 實作 `handleSetupCheckOllama`，在 `server.go` 註冊路由

**前端**
- `runModelPull()` 執行前先呼叫健康檢查，顯示「偵測 Ollama 中…」
- Ollama 未啟動時顯示操作說明（Windows / macOS 分別提示）+ 「偵測並繼續」按鈕
- 「偵測並繼續」重新呼叫 `runModelPull()`，重新 check，確認在線才開始下載
- 重試時完整 reset 畫面狀態，避免殘留訊息

## 測試計畫

- [ ] Ollama 未啟動時進入 step 4，顯示「偵測 Ollama 中…」後改為說明 + 「偵測並繼續」按鈕
- [ ] 點「偵測並繼續」，Ollama 仍未啟動：再次顯示說明
- [ ] 啟動 Ollama 後點「偵測並繼續」，開始正常下載流程
- [ ] Ollama 已啟動時進入 step 4，直接開始下載，不顯示錯誤

closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)