### PR TITLE
fix(ui): widen review sidebar and add ellipsis + tooltip for long titles

### DIFF
--- a/web/templates/novel-assistant.html
+++ b/web/templates/novel-assistant.html
@@ -532,8 +532,9 @@
 
     /* Left: history list */
     .review-history {
-      width: 230px;
-      min-width: 230px;
+      width: 280px;
+      min-width: 220px;
+      max-width: 320px;
       border-right: 1px solid var(--border);
       display: flex;
       flex-direction: column;
@@ -582,7 +583,7 @@
       border-color: var(--border-md);
     }
 
-    .rli-title { font-size: 12px; font-weight: 500; color: var(--text-primary); }
+    .rli-title { font-size: 12px; font-weight: 500; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .rli-meta  { font-size: 10px; color: var(--text-muted); margin-top: 2px; }
     .rli-tags  { display: flex; gap: 4px; margin-top: 6px; flex-wrap: wrap; }
 
@@ -1432,7 +1433,7 @@
 
           <div class="review-list-scroll">
             <div class="review-list-item active">
-              <div class="rli-title">第 03 章 審查 #2</div>
+              <div class="rli-title" title="第 03 章 審查 #2">第 03 章 審查 #2</div>
               <div class="rli-meta">今天 14:32 · llama3.2</div>
               <div class="rli-tags">
                 <span class="badge badge-red">2 錯誤</span>
@@ -1441,24 +1442,24 @@
               </div>
             </div>
             <div class="review-list-item">
-              <div class="rli-title">第 03 章 審查 #1</div>
+              <div class="rli-title" title="第 03 章 審查 #1">第 03 章 審查 #1</div>
               <div class="rli-meta">昨天 09:15 · llama3.2</div>
               <div class="rli-tags"><span class="badge badge-teal">通過</span></div>
             </div>
             <div class="review-list-item">
-              <div class="rli-title">第 02 章 審查 #3</div>
+              <div class="rli-title" title="第 02 章 審查 #3">第 02 章 審查 #3</div>
               <div class="rli-meta">3 天前 · llama3.2</div>
               <div class="rli-tags"><span class="badge badge-teal">通過</span></div>
             </div>
             <div class="review-list-item">
-              <div class="rli-title">第 02 章 審查 #2</div>
+              <div class="rli-title" title="第 02 章 審查 #2">第 02 章 審查 #2</div>
               <div class="rli-meta">4 天前 · llama3.2</div>
               <div class="rli-tags">
                 <span class="badge badge-amber">1 警告</span>
               </div>
             </div>
             <div class="review-list-item">
-              <div class="rli-title">第 01 章 審查 #1</div>
+              <div class="rli-title" title="第 01 章 審查 #1">第 01 章 審查 #1</div>
               <div class="rli-meta">1 週前 · llama3.2</div>
               <div class="rli-tags"><span class="badge badge-teal">通過</span></div>
             </div>


### PR DESCRIPTION
## 問題

審查 / 修改稿頁左側審查記錄欄寬度固定 230px，遇到較長標題（如「第 03 章 審查 #2」後面帶有更多說明文字時）會直接截斷，沒有任何視覺提示，使用者無法辨識完整資訊。

## 修改內容

- `.review-history` 欄寬 230px → 280px，`min-width` 保留 220px 防止過窄，`max-width` 限制 320px 避免佔用過多空間
- `.rli-title` 加入 `white-space: nowrap; overflow: hidden; text-overflow: ellipsis;`，截斷時顯示 `…` 而非直接切掉
- 所有 `.rli-title` 元素加上 `title` 屬性，hover 可看到完整標題

## 測試計畫

- [ ] 常見長度標題（「第 03 章 審查 #2」等）在 280px 欄寬下完整顯示
- [ ] 更長的標題顯示省略號 `…`，不會直接被隱藏
- [ ] hover 省略號標題時 tooltip 顯示完整文字
- [ ] 視窗縮窄時左側欄不與右側主內容重疊

closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)