### PR TITLE
fix(ui): add semantic label and tooltip to progress bar column

### DIFF
--- a/web/templates/novel-assistant.html
+++ b/web/templates/novel-assistant.html
@@ -1338,7 +1338,7 @@
               <th>字數</th>
               <th>狀態</th>
               <th>候選訊號</th>
-              <th>進度</th>
+              <th><abbr title="審查完成度（示範資料）">進度</abbr></th>
               <th></th>
             </tr>
           </thead>
@@ -1349,7 +1349,7 @@
               <td>3,820</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">陳晨</span><span class="signal-tag">Kael</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 1 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1358,7 +1358,7 @@
               <td>4,150</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">陳晨</span><span class="signal-tag warn">伏筆#2</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 2 章報告')">報告</button></td>
             </tr>
             <tr class="ch-current">
@@ -1376,7 +1376,7 @@
                   <span class="signal-tag err">新伏筆</span>
                 </div>
               </td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:58%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：58%（示範資料）"><div class="progress-mini-fill" style="width:58%"></div></div></td>
               <td>
                 <button class="btn btn-primary" style="padding:3px 8px;font-size:11px" onclick="navigate(document.querySelector('[data-page=review]'),'review')">審查</button>
               </td>
@@ -1387,7 +1387,7 @@
               <td>3,900</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">Kael</span><span class="signal-tag">追蹤者</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 4 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1396,7 +1396,7 @@
               <td>4,600</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">陳晨</span><span class="signal-tag">聯盟</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 5 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1405,7 +1405,7 @@
               <td>3,750</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">Kael</span><span class="signal-tag warn">伏筆#5</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 6 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1414,7 +1414,7 @@
               <td>4,200</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">陳晨</span><span class="signal-tag">聯盟</span><span class="signal-tag warn">伏筆#2 回收</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 7 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1423,7 +1423,7 @@
               <td>4,800</td>
               <td><span class="badge badge-teal">已審查</span></td>
               <td><div class="signal-list"><span class="signal-tag">陳晨</span><span class="signal-tag err">身份謎題</span></div></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:100%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：100%（示範資料）"><div class="progress-mini-fill" style="width:100%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('匯出第 8 章報告')">報告</button></td>
             </tr>
             <tr>
@@ -1432,7 +1432,7 @@
               <td style="color:var(--text-ghost)">—</td>
               <td><span class="badge badge-ghost">未建立</span></td>
               <td></td>
-              <td><div class="progress-mini"><div class="progress-mini-fill" style="width:0%"></div></div></td>
+              <td><div class="progress-mini" title="審查完成度：0%（示範資料）"><div class="progress-mini-fill" style="width:0%"></div></div></td>
               <td><button class="btn" style="padding:3px 8px;font-size:11px" onclick="toast('新增第 9 章')">+ 新增</button></td>
             </tr>
           </tbody>


### PR DESCRIPTION
## 問題

章節總覽的「進度」欄位只有一條細橫條，使用者無法判斷代表字數進度、審查進度或其他指標。

## 修改內容

**欄位 header（1 行）**
- `<th>進度</th>` → `<th><abbr title="審查完成度（示範資料）">進度</abbr></th>`
- `<abbr>` 提供 hover tooltip 且帶語意，不影響版面密度

**各列進度條（9 行）**
- 每個 `.progress-mini` 加上 `title` 屬性，顯示具體百分比與語意
  - 已審查章節：`審查完成度：100%（示範資料）`
  - 進行中章節：`審查完成度：58%（示範資料）`
  - 未建立章節：`審查完成度：0%（示範資料）`
- 所有 tooltip 明確標注「示範資料」，不暗示已接真實後端

## 驗收確認

- [x] hover 欄位 header 可看到「審查完成度（示範資料）」說明
- [x] hover 各進度條可看到對應百分比與語意
- [x] 版面完全不受影響，僅 HTML attribute 異動
- [x] 所有 tooltip 標注示範資料，不誤導使用者

closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)