### PR TITLE
fix(ui): extract timeline foreshadow annotations into signal-tag badges

### DIFF
--- a/web/templates/novel-assistant.html
+++ b/web/templates/novel-assistant.html
@@ -1048,6 +1048,8 @@
 
     .timeline-title { font-size: 13px; font-weight: 500; color: var(--text-primary); }
     .timeline-body  { font-size: 12px; color: var(--text-secondary); margin-top: 3px; line-height: 1.6; }
+    .timeline-tags  { display: flex; gap: 4px; margin-top: 5px; flex-wrap: wrap; }
+    .signal-tag.ok  { background: var(--teal-light); color: var(--teal-text); border-color: rgba(13,140,101,.2); }
 
     /* ════════════════════════════════════
        PAGE: 關係圖 (SVG)
@@ -2017,7 +2019,8 @@
             <div class="timeline-dot teal"></div>
             <div class="timeline-ch">第 01 章</div>
             <div class="timeline-title">Kael 通訊中的奇怪停頓</div>
-            <div class="timeline-body">陳晨無意間聽到 Kael 與不明對象的通訊，話中有話，Kael 察覺後立刻切斷。（伏筆#Kael身份）</div>
+            <div class="timeline-body">陳晨無意間聽到 Kael 與不明對象的通訊，話中有話，Kael 察覺後立刻切斷。</div>
+            <div class="timeline-tags"><span class="signal-tag warn">伏筆 · Kael身份</span></div>
           </div>
           <div class="timeline-item">
             <div class="timeline-dot amber"></div>
@@ -2029,19 +2032,22 @@
             <div class="timeline-dot"></div>
             <div class="timeline-ch">第 02 章</div>
             <div class="timeline-title">發現「第七號艙」塗鴉</div>
-            <div class="timeline-body">牆上的塗鴉被 Kael 斥為廢話，但陳晨暗中拍照存檔。（伏筆#塗鴉 → 已收線，第 07 章）</div>
+            <div class="timeline-body">牆上的塗鴉被 Kael 斥為廢話，但陳晨暗中拍照存檔。</div>
+            <div class="timeline-tags"><span class="signal-tag ok">伏筆 · 塗鴉 ✓ 第07章收線</span></div>
           </div>
           <div class="timeline-item">
             <div class="timeline-dot red"></div>
             <div class="timeline-ch">第 03 章</div>
             <div class="timeline-title">發現數據晶體</div>
-            <div class="timeline-body">陳晨獨自在廢棄站台深處發現神秘晶體，決定隱瞞 Kael。晶體顯示她出生前 17 年的臉。（伏筆#身份謎題）</div>
+            <div class="timeline-body">陳晨獨自在廢棄站台深處發現神秘晶體，決定隱瞞 Kael。晶體顯示她出生前 17 年的臉。</div>
+            <div class="timeline-tags"><span class="signal-tag warn">伏筆 · 身份謎題</span></div>
           </div>
           <div class="timeline-item">
             <div class="timeline-dot teal"></div>
             <div class="timeline-ch">第 04 章</div>
             <div class="timeline-title">追蹤器揭露</div>
-            <div class="timeline-body">飛船被聯盟鎖定，Kael 找到並摧毀追蹤器，拒絕解釋如何知道其位置。（伏筆#追蹤者 → 已收線）</div>
+            <div class="timeline-body">飛船被聯盟鎖定，Kael 找到並摧毀追蹤器，拒絕解釋如何知道其位置。</div>
+            <div class="timeline-tags"><span class="signal-tag ok">伏筆 · 追蹤者 ✓ 已收線</span></div>
           </div>
           <div class="timeline-item">
             <div class="timeline-dot amber"></div>


### PR DESCRIPTION
## 問題

時間軸的伏筆標注（例如 `（伏筆#Kael身份）`、`（伏筆#塗鴉 → 已收線，第 07 章）`）混在 `.timeline-body` 主要敘述文字內，括號讓文字變擠，掃描事件時難以區分主敘述與 metadata。

## 修改內容

**CSS（2 行）**
- 新增 `.timeline-tags`：flex row，gap 4px，margin-top 5px，flex-wrap
- 新增 `.signal-tag.ok`（teal）：給「已收線」伏筆，沿用現有 signal-tag 色系

**HTML（4 個 timeline-item）**
- 移除 `.timeline-body` 內的括號標注文字
- 各自加 `div.timeline-tags` + `span.signal-tag`：
  - 開放中伏筆 → `.signal-tag.warn`（amber）
  - 已收線伏筆 → `.signal-tag.ok`（teal）

| 章節 | 標注 | 狀態 |
|---|---|---|
| 第01章 | 伏筆 · Kael身份 | 開放（amber）|
| 第02章 | 伏筆 · 塗鴉 ✓ 第07章收線 | 已收線（teal）|
| 第03章 | 伏筆 · 身份謎題 | 開放（amber）|
| 第04章 | 伏筆 · 追蹤者 ✓ 已收線 | 已收線（teal）|

## 驗收確認

- [x] 伏筆標注與主要敘述視覺上明確區分（不同行、不同色）
- [x] 多個伏筆標注時 flex-wrap 不擠壓主要敘述
- [x] 窄寬度下 tag 自動換行，不與主文重疊

closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)