### PR TITLE
[infra] fix Windows release: switch from Wine to windows-latest runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - goos: windows
             goarch: amd64
-            runner: ubuntu-latest
+            runner: windows-latest
             asset_name: novel-assistant-windows-amd64
             ext: .exe
 
@@ -49,6 +49,7 @@ jobs:
           cache: true
 
       - name: Build binary
+        shell: bash
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -62,18 +63,15 @@ jobs:
       # ── Windows: wrap with Inno Setup installer ──────────────────────
       - name: Package Windows installer
         if: matrix.goos == 'windows'
+        shell: pwsh
         run: |
-          # Install Inno Setup via wine
-          sudo apt-get install -y wine-stable
-          wget -q "https://jrsoftware.org/download.php/is.exe" -O /tmp/is.exe
-          wine /tmp/is.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
-          # Copy binary for the .iss script
-          cp dist/${{ matrix.asset_name }}.exe scripts/novel-assistant.exe
-          wine "$HOME/.wine/drive_c/Program Files (x86)/Inno Setup 6/ISCC.exe" \
-            /DMyAppVersion=${{ github.ref_name }} \
-            scripts/windows.iss
-          mv scripts/Output/NovelAssistantSetup.exe \
-            dist/${{ matrix.asset_name }}-setup.exe
+          choco install innosetup --yes --no-progress
+          Copy-Item dist\${{ matrix.asset_name }}.exe scripts\novel-assistant.exe
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            /DMyAppVersion=${{ github.ref_name }} `
+            scripts\windows.iss
+          Move-Item scripts\Output\NovelAssistantSetup.exe `
+            dist\${{ matrix.asset_name }}-setup.exe
 
       # ── macOS: create .dmg ────────────────────────────────────────────
       - name: Package macOS DMG


### PR DESCRIPTION
## 問題

v0.2.0 release 的 Windows job 失敗，導致 `novel-assistant-windows-amd64-setup.exe` 沒有上傳到 release assets，使用者下載到 404。

失敗原因：Ubuntu 24.04 的 Wine 9.0 在 experimental wow64 mode 下跑 Inno Setup 安裝程式會直接 exit code 1：

```
012c:err:environ:init_peb starting L"Z:\\tmp\\is.exe" in experimental wow64 mode
Process completed with exit code 1.
```

另外 `jrsoftware.org/download.php/is.exe` 是 redirect 頁面，wget 下載到的不是直接的二進位。

## 修法

- Windows job runner 從 `ubuntu-latest` 改為 `windows-latest`
- Packaging 步驟改用 PowerShell + Chocolatey 原生安裝 Inno Setup（不需要 Wine）
- Build binary 步驟加 `shell: bash`（確保 `mkdir -p` 和 `\` 換行在 Windows runner 上也能跑）

## 其他平台

Linux / macOS 完全不受影響，只改了 Windows 那個 matrix job。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
