### PR TITLE
[backend] Phase 3 收尾 — 將 scene_index 傳遞至 tracker 寫回

### DIFF
--- a/internal/server/writeback.go
+++ b/internal/server/writeback.go
@@ -12,6 +12,7 @@ import (
 
 type timelineWritebackRequest struct {
 	Chapter      int      `json:"chapter"`
+	SceneIndex   int      `json:"scene_index,omitempty"`
 	Scene        string   `json:"scene"`
 	Description  string   `json:"description"`
 	Characters   []string `json:"characters"`
@@ -20,6 +21,7 @@ type timelineWritebackRequest struct {
 
 type foreshadowWritebackRequest struct {
 	Chapter     int    `json:"chapter"`
+	SceneIndex  int    `json:"scene_index,omitempty"`
 	Description string `json:"description"`
 	PlantedIn   string `json:"planted_in"`
 }
@@ -30,6 +32,8 @@ type relationshipWritebackRequest struct {
 	Status       string `json:"status"`
 	Note         string `json:"note"`
 	TriggerEvent string `json:"trigger_event"`
+	Chapter      int    `json:"chapter,omitempty"`
+	SceneIndex   int    `json:"scene_index,omitempty"`
 }
 
 func saveTrackerAsJSON(c *gin.Context, action string, err error) bool {
@@ -58,6 +62,7 @@ func (s *Server) handleWritebackTimeline(c *gin.Context) {
 
 	s.timeline.Add(&tracker.TimelineEvent{
 		Chapter:      req.Chapter,
+		SceneIndex:   req.SceneIndex,
 		Scene:        strings.TrimSpace(req.Scene),
 		Description:  strings.TrimSpace(req.Description),
 		Characters:   req.Characters,
@@ -86,6 +91,7 @@ func (s *Server) handleWritebackForeshadow(c *gin.Context) {
 
 	s.foreshadow.Add(&tracker.Foreshadowing{
 		Chapter:     req.Chapter,
+		SceneIndex:  req.SceneIndex,
 		Description: strings.TrimSpace(req.Description),
 		PlantedIn:   strings.TrimSpace(req.PlantedIn),
 	})
@@ -116,6 +122,8 @@ func (s *Server) handleWritebackRelationship(c *gin.Context) {
 		Status:       strings.TrimSpace(req.Status),
 		Note:         strings.TrimSpace(req.Note),
 		TriggerEvent: strings.TrimSpace(req.TriggerEvent),
+		Chapter:      req.Chapter,
+		SceneIndex:   req.SceneIndex,
 	})
 	if !saveTrackerAsJSON(c, "save relationship", s.relationships.Save()) {
 		return

--- a/internal/server/writeback_test.go
+++ b/internal/server/writeback_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func newWritebackTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(ollama.Close)
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "characters", ".keep"), "")
+	s := newE2ETestServer(t, dir, ollama.URL)
+	srv := httptest.NewServer(s.router)
+	t.Cleanup(srv.Close)
+	return s, srv.URL
+}
+
+func TestWritebackTimelineStoresSceneIndex(t *testing.T) {
+	t.Parallel()
+	s, baseURL := newWritebackTestServer(t)
+
+	resp := performJSONRequest(t, baseURL, "POST", "/api/writeback/timeline", map[string]any{
+		"chapter":      2,
+		"scene_index":  3,
+		"scene":        "廢棄站台",
+		"description":  "林昊發現線索",
+		"characters":   []string{"林昊"},
+		"consequences": "調查深入",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+
+	events := s.timeline.GetSorted()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 timeline event, got %d", len(events))
+	}
+	if events[0].SceneIndex != 3 {
+		t.Errorf("SceneIndex: got %d, want 3", events[0].SceneIndex)
+	}
+	if events[0].Chapter != 2 {
+		t.Errorf("Chapter: got %d, want 2", events[0].Chapter)
+	}
+}
+
+func TestWritebackTimelineZeroSceneIndexWhenOmitted(t *testing.T) {
+	t.Parallel()
+	s, baseURL := newWritebackTestServer(t)
+
+	resp := performJSONRequest(t, baseURL, "POST", "/api/writeback/timeline", map[string]any{
+		"chapter":     1,
+		"scene":       "序章",
+		"description": "故事開始",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+
+	events := s.timeline.GetSorted()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].SceneIndex != 0 {
+		t.Errorf("SceneIndex: got %d, want 0 when omitted", events[0].SceneIndex)
+	}
+}
+
+func TestWritebackForeshadowStoresSceneIndex(t *testing.T) {
+	t.Parallel()
+	s, baseURL := newWritebackTestServer(t)
+
+	resp := performJSONRequest(t, baseURL, "POST", "/api/writeback/foreshadow", map[string]any{
+		"chapter":     1,
+		"scene_index": 2,
+		"description": "神秘信件",
+		"planted_in":  "林昊看了一眼桌上的信，沒有打開",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+
+	items := s.foreshadow.GetAll()
+	if len(items) != 1 {
+		t.Fatalf("expected 1 foreshadow, got %d", len(items))
+	}
+	if items[0].SceneIndex != 2 {
+		t.Errorf("SceneIndex: got %d, want 2", items[0].SceneIndex)
+	}
+}
+
+func TestWritebackRelationshipStoresChapterAndSceneIndex(t *testing.T) {
+	t.Parallel()
+	s, baseURL := newWritebackTestServer(t)
+
+	resp := performJSONRequest(t, baseURL, "POST", "/api/writeback/relationship", map[string]any{
+		"from":          "林昊",
+		"to":            "陳晨",
+		"status":        "盟友",
+		"note":          "共同調查",
+		"trigger_event": "廢棄站台會面",
+		"chapter":       3,
+		"scene_index":   1,
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, resp.Body)
+	}
+
+	rels := s.relationships.GetAll()
+	if len(rels) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(rels))
+	}
+	if rels[0].Chapter != 3 {
+		t.Errorf("Chapter: got %d, want 3", rels[0].Chapter)
+	}
+	if rels[0].SceneIndex != 1 {
+		t.Errorf("SceneIndex: got %d, want 1", rels[0].SceneIndex)
+	}
+}

--- a/internal/tracker/foreshadow.go
+++ b/internal/tracker/foreshadow.go
@@ -12,6 +12,7 @@ import (
 type Foreshadowing struct {
 	ID              string    `json:"id"`
 	Chapter         int       `json:"chapter"`
+	SceneIndex      int       `json:"scene_index,omitempty"`
 	Description     string    `json:"description"`
 	PlantedIn       string    `json:"planted_in"`
 	ResolvedIn      string    `json:"resolved_in"`

--- a/internal/tracker/relationship.go
+++ b/internal/tracker/relationship.go
@@ -13,6 +13,8 @@ type Relationship struct {
 	Status       string    `json:"status"`
 	Note         string    `json:"note"`
 	TriggerEvent string    `json:"trigger_event"`
+	Chapter      int       `json:"chapter,omitempty"`
+	SceneIndex   int       `json:"scene_index,omitempty"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 

--- a/internal/tracker/timeline.go
+++ b/internal/tracker/timeline.go
@@ -12,6 +12,7 @@ import (
 type TimelineEvent struct {
 	ID           string    `json:"id"`
 	Chapter      int       `json:"chapter"`
+	SceneIndex   int       `json:"scene_index,omitempty"`
 	Scene        string    `json:"scene"`
 	Description  string    `json:"description"`
 	Characters   []string  `json:"characters"`


### PR DESCRIPTION
closes #149

## 變更內容

### tracker struct 新增欄位

| Struct | 新增欄位 |
|---|---|
| `TimelineEvent` | `SceneIndex int` (`scene_index,omitempty`) |
| `Foreshadowing` | `SceneIndex int` (`scene_index,omitempty`) |
| `Relationship` | `SceneIndex int` + `Chapter int` (`omitempty`) |

### writeback request struct 新增欄位

| Request | 新增欄位 |
|---|---|
| `timelineWritebackRequest` | `SceneIndex int` |
| `foreshadowWritebackRequest` | `SceneIndex int` |
| `relationshipWritebackRequest` | `SceneIndex int` + `Chapter int` |

### handlers 接線

三個 `handleWriteback*` handler 現在都把 `SceneIndex`（和 relationship 的 `Chapter`）傳入 tracker。

## 向下相容

所有欄位都是 `omitempty`——現有資料不受影響，不帶 `scene_index` 的舊請求正常運作（值為 0）。

## 測試

新增 `writeback_test.go`，4 個測試覆蓋：
- timeline 帶 `scene_index` 正確儲存
- timeline 不帶 `scene_index` 預設 0
- foreshadow 帶 `scene_index` 正確儲存
- relationship 帶 `chapter` + `scene_index` 正確儲存

全套 `go test ./...` 通過（19 個套件）。

## Phase 3 完成

本 PR 補上 ROADMAP Phase 3 最後一個 `待完成` 項目，Scene-based 資料模型現在可以標記為 ✅。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
