### PR TITLE
[backend] Hybrid search — BM25 + vector 雙通道檢索

### DIFF
--- a/internal/retriever/hybrid.go
+++ b/internal/retriever/hybrid.go
@@ -19,8 +19,13 @@ type HybridRetriever struct {
 	alpha    float64
 }
 
-// NewHybrid creates a HybridRetriever. alpha must be in [0.0, 1.0].
+// NewHybrid creates a HybridRetriever. alpha is clamped to [0.0, 1.0].
 func NewHybrid(emb Embedder, store HybridStorer, alpha float64) *HybridRetriever {
+	if alpha < 0 {
+		alpha = 0
+	} else if alpha > 1 {
+		alpha = 1
+	}
 	return &HybridRetriever{embedder: emb, store: store, alpha: alpha}
 }
 

--- a/internal/retriever/hybrid.go
+++ b/internal/retriever/hybrid.go
@@ -1,0 +1,41 @@
+package retriever
+
+import (
+	"context"
+	"novel-assistant/internal/vectorstore"
+)
+
+// HybridStorer is the store interface required by HybridRetriever.
+type HybridStorer interface {
+	Len() int
+	QueryHybrid(queryVec []float64, queryText string, topK int, types []string, threshold float64, alpha float64, beforeChapter int) []vectorstore.ScoredDocument
+}
+
+// HybridRetriever combines BM25 keyword scoring with vector similarity.
+// alpha=1.0 is pure vector; alpha=0.0 is pure BM25; default 0.5.
+type HybridRetriever struct {
+	embedder Embedder
+	store    HybridStorer
+	alpha    float64
+}
+
+// NewHybrid creates a HybridRetriever. alpha must be in [0.0, 1.0].
+func NewHybrid(emb Embedder, store HybridStorer, alpha float64) *HybridRetriever {
+	return &HybridRetriever{embedder: emb, store: store, alpha: alpha}
+}
+
+func (r *HybridRetriever) Retrieve(ctx context.Context, req Request) ([]Chunk, error) {
+	if r.store.Len() == 0 {
+		return nil, nil
+	}
+	vec, err := r.embedder.Embed(ctx, req.Query)
+	if err != nil {
+		return nil, err
+	}
+	docs := r.store.QueryHybrid(vec, req.Query, req.TopK, req.Types, req.Threshold, r.alpha, req.BeforeChapter)
+	out := make([]Chunk, len(docs))
+	for i, d := range docs {
+		out[i] = Chunk{Document: d.Document, Score: d.Score}
+	}
+	return out, nil
+}

--- a/internal/retriever/hybrid_test.go
+++ b/internal/retriever/hybrid_test.go
@@ -93,3 +93,22 @@ func TestHybridRetrieverForwardsBeforeChapter(t *testing.T) {
 func TestHybridRetrieverSatisfiesRetrieverInterface(t *testing.T) {
 	var _ retriever.Retriever = retriever.NewHybrid(nil, &stubHybridStore{}, 0.5)
 }
+
+func TestNewHybridClampsAlpha(t *testing.T) {
+	doc := vectorstore.ScoredDocument{Document: vectorstore.Document{ID: "d1"}, Score: 0.5}
+	for _, tc := range []struct {
+		input float64
+		want  float64
+	}{
+		{-0.5, 0.0},
+		{1.5, 1.0},
+		{0.3, 0.3},
+	} {
+		store := &stubHybridStore{docs: []vectorstore.ScoredDocument{doc}}
+		r := retriever.NewHybrid(&stubEmbedder{vec: []float64{1}}, store, tc.input)
+		r.Retrieve(context.Background(), retriever.Request{Query: "q", TopK: 1}) //nolint
+		if store.gotAlpha != tc.want {
+			t.Errorf("input alpha=%.1f: expected clamped=%.1f, got=%.1f", tc.input, tc.want, store.gotAlpha)
+		}
+	}
+}

--- a/internal/retriever/hybrid_test.go
+++ b/internal/retriever/hybrid_test.go
@@ -1,0 +1,95 @@
+package retriever_test
+
+import (
+	"context"
+	"testing"
+
+	"novel-assistant/internal/retriever"
+	"novel-assistant/internal/vectorstore"
+)
+
+type stubHybridStore struct {
+	docs      []vectorstore.ScoredDocument
+	gotAlpha  float64
+	gotBefore int
+}
+
+func (s *stubHybridStore) Len() int { return len(s.docs) }
+func (s *stubHybridStore) QueryHybrid(_ []float64, _ string, topK int, _ []string, _ float64, alpha float64, beforeChapter int) []vectorstore.ScoredDocument {
+	s.gotAlpha = alpha
+	s.gotBefore = beforeChapter
+	if topK < len(s.docs) {
+		return s.docs[:topK]
+	}
+	return s.docs
+}
+
+func TestHybridRetrieverEmptyStore(t *testing.T) {
+	r := retriever.NewHybrid(&stubEmbedder{vec: []float64{1}}, &stubHybridStore{}, 0.5)
+	chunks, err := r.Retrieve(context.Background(), retriever.Request{Query: "test", TopK: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty store, got %d", len(chunks))
+	}
+}
+
+func TestHybridRetrieverReturnsChunks(t *testing.T) {
+	doc := vectorstore.ScoredDocument{
+		Document: vectorstore.Document{ID: "char_林昊", Type: "character", Content: "主角"},
+		Score:    0.85,
+	}
+	store := &stubHybridStore{docs: []vectorstore.ScoredDocument{doc}}
+	r := retriever.NewHybrid(&stubEmbedder{vec: []float64{1}}, store, 0.5)
+
+	chunks, err := r.Retrieve(context.Background(), retriever.Request{Query: "林昊", TopK: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(chunks))
+	}
+	if chunks[0].ID != "char_林昊" {
+		t.Errorf("expected ID=char_林昊, got %s", chunks[0].ID)
+	}
+	if chunks[0].Score != 0.85 {
+		t.Errorf("expected Score=0.85, got %f", chunks[0].Score)
+	}
+}
+
+func TestHybridRetrieverForwardsAlpha(t *testing.T) {
+	store := &stubHybridStore{
+		docs: []vectorstore.ScoredDocument{
+			{Document: vectorstore.Document{ID: "d1"}, Score: 0.5},
+		},
+	}
+	r := retriever.NewHybrid(&stubEmbedder{vec: []float64{1}}, store, 0.3)
+	_, err := r.Retrieve(context.Background(), retriever.Request{Query: "q", TopK: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.gotAlpha != 0.3 {
+		t.Errorf("alpha not forwarded: got %f, want 0.3", store.gotAlpha)
+	}
+}
+
+func TestHybridRetrieverForwardsBeforeChapter(t *testing.T) {
+	store := &stubHybridStore{
+		docs: []vectorstore.ScoredDocument{
+			{Document: vectorstore.Document{ID: "d1"}, Score: 0.5},
+		},
+	}
+	r := retriever.NewHybrid(&stubEmbedder{vec: []float64{1}}, store, 0.5)
+	_, err := r.Retrieve(context.Background(), retriever.Request{Query: "q", TopK: 1, BeforeChapter: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store.gotBefore != 7 {
+		t.Errorf("beforeChapter not forwarded: got %d, want 7", store.gotBefore)
+	}
+}
+
+func TestHybridRetrieverSatisfiesRetrieverInterface(t *testing.T) {
+	var _ retriever.Retriever = retriever.NewHybrid(nil, &stubHybridStore{}, 0.5)
+}

--- a/internal/reviewhistory/history.go
+++ b/internal/reviewhistory/history.go
@@ -31,7 +31,17 @@ type RetrievalConfig struct {
 	Sources   []string `json:"sources"`
 	TopK      int      `json:"top_k"`
 	Threshold float64  `json:"threshold"`
-	Alpha     float64  `json:"alpha,omitempty"` // hybrid weight: 0.0=BM25-only, 1.0=vector-only, 0=default means 0.5
+	// Alpha controls hybrid search weight: 0.0=BM25-only, 1.0=vector-only.
+	// nil means use the caller's default (typically 0.5).
+	Alpha *float64 `json:"alpha,omitempty"`
+}
+
+// EffectiveAlpha returns the configured alpha, or 0.5 if unset.
+func (c RetrievalConfig) EffectiveAlpha() float64 {
+	if c.Alpha == nil {
+		return 0.5
+	}
+	return *c.Alpha
 }
 
 type Store struct {

--- a/internal/reviewhistory/history.go
+++ b/internal/reviewhistory/history.go
@@ -31,6 +31,7 @@ type RetrievalConfig struct {
 	Sources   []string `json:"sources"`
 	TopK      int      `json:"top_k"`
 	Threshold float64  `json:"threshold"`
+	Alpha     float64  `json:"alpha,omitempty"` // hybrid weight: 0.0=BM25-only, 1.0=vector-only, 0=default means 0.5
 }
 
 type Store struct {

--- a/internal/vectorstore/bm25.go
+++ b/internal/vectorstore/bm25.go
@@ -45,45 +45,80 @@ func isCJK(r rune) bool {
 }
 
 type bm25Index struct {
-	tf     map[string]map[string]int // docID -> term -> count
-	df     map[string]int            // term -> document frequency
-	docLen map[string]int            // docID -> token count
-	avgdl  float64
-	n      int
+	tf       map[string]map[string]int // docID -> term -> count
+	df       map[string]int            // term -> document frequency
+	docLen   map[string]int            // docID -> token count
+	totalLen int                       // sum of all doc lengths (for avgdl)
+	n        int
 }
 
-func buildBM25Index(docs []Document) *bm25Index {
-	idx := &bm25Index{
+func newBM25Index() *bm25Index {
+	return &bm25Index{
 		tf:     make(map[string]map[string]int),
 		df:     make(map[string]int),
 		docLen: make(map[string]int),
 	}
+}
+
+func buildBM25Index(docs []Document) *bm25Index {
+	idx := newBM25Index()
 	for _, d := range docs {
-		terms := tokenize(d.Content)
-		tf := make(map[string]int, len(terms))
-		for _, t := range terms {
-			tf[t]++
-		}
-		idx.tf[d.ID] = tf
-		idx.docLen[d.ID] = len(terms)
-		for t := range tf {
-			idx.df[t]++
-		}
-	}
-	idx.n = len(docs)
-	if idx.n > 0 {
-		total := 0
-		for _, l := range idx.docLen {
-			total += l
-		}
-		idx.avgdl = float64(total) / float64(idx.n)
+		idx.addDoc(d)
 	}
 	return idx
 }
 
+func (idx *bm25Index) avgdl() float64 {
+	if idx.n == 0 {
+		return 0
+	}
+	return float64(idx.totalLen) / float64(idx.n)
+}
+
+// addDoc indexes a document. The caller must ensure the ID is not already present.
+func (idx *bm25Index) addDoc(doc Document) {
+	terms := tokenize(doc.Content)
+	tf := make(map[string]int, len(terms))
+	for _, t := range terms {
+		tf[t]++
+	}
+	idx.tf[doc.ID] = tf
+	idx.docLen[doc.ID] = len(terms)
+	idx.totalLen += len(terms)
+	idx.n++
+	for t := range tf {
+		idx.df[t]++
+	}
+}
+
+// removeDoc removes a document from the index. No-op if the ID is not present.
+func (idx *bm25Index) removeDoc(id string) {
+	tf, ok := idx.tf[id]
+	if !ok {
+		return
+	}
+	for term := range tf {
+		idx.df[term]--
+		if idx.df[term] == 0 {
+			delete(idx.df, term)
+		}
+	}
+	idx.totalLen -= idx.docLen[id]
+	idx.n--
+	delete(idx.tf, id)
+	delete(idx.docLen, id)
+}
+
+// upsert adds or replaces a document incrementally (O(unique terms in doc)).
+func (idx *bm25Index) upsert(doc Document) {
+	idx.removeDoc(doc.ID)
+	idx.addDoc(doc)
+}
+
 // score computes BM25 score for a document given pre-tokenized query terms.
 func (idx *bm25Index) score(queryTerms []string, docID string) float64 {
-	if idx.n == 0 || idx.avgdl == 0 {
+	avgdl := idx.avgdl()
+	if idx.n == 0 || avgdl == 0 {
 		return 0
 	}
 	docTerms := idx.tf[docID]
@@ -96,7 +131,7 @@ func (idx *bm25Index) score(queryTerms []string, docID string) float64 {
 		}
 		idf := math.Log((float64(idx.n)-df+0.5)/(df+0.5) + 1)
 		tf := float64(docTerms[term])
-		norm := tf + bm25k1*(1-bm25b+bm25b*float64(docLen)/idx.avgdl)
+		norm := tf + bm25k1*(1-bm25b+bm25b*float64(docLen)/avgdl)
 		s += idf * (tf * (bm25k1 + 1)) / norm
 	}
 	return s

--- a/internal/vectorstore/bm25.go
+++ b/internal/vectorstore/bm25.go
@@ -1,0 +1,103 @@
+package vectorstore
+
+import (
+	"math"
+	"strings"
+	"unicode"
+)
+
+const (
+	bm25k1 = 1.5
+	bm25b  = 0.75
+)
+
+// tokenize splits text into lowercase tokens.
+// CJK characters are treated as individual tokens; other letters/digits
+// are grouped into words. Punctuation and whitespace act as delimiters.
+func tokenize(text string) []string {
+	var tokens []string
+	var buf []rune
+	flush := func() {
+		if len(buf) > 0 {
+			tokens = append(tokens, string(buf))
+			buf = buf[:0]
+		}
+	}
+	for _, r := range strings.ToLower(text) {
+		if isCJK(r) {
+			flush()
+			tokens = append(tokens, string(r))
+		} else if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			buf = append(buf, r)
+		} else {
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}
+
+func isCJK(r rune) bool {
+	return unicode.Is(unicode.Han, r) ||
+		unicode.Is(unicode.Hiragana, r) ||
+		unicode.Is(unicode.Katakana, r) ||
+		unicode.Is(unicode.Hangul, r)
+}
+
+type bm25Index struct {
+	tf     map[string]map[string]int // docID -> term -> count
+	df     map[string]int            // term -> document frequency
+	docLen map[string]int            // docID -> token count
+	avgdl  float64
+	n      int
+}
+
+func buildBM25Index(docs []Document) *bm25Index {
+	idx := &bm25Index{
+		tf:     make(map[string]map[string]int),
+		df:     make(map[string]int),
+		docLen: make(map[string]int),
+	}
+	for _, d := range docs {
+		terms := tokenize(d.Content)
+		tf := make(map[string]int, len(terms))
+		for _, t := range terms {
+			tf[t]++
+		}
+		idx.tf[d.ID] = tf
+		idx.docLen[d.ID] = len(terms)
+		for t := range tf {
+			idx.df[t]++
+		}
+	}
+	idx.n = len(docs)
+	if idx.n > 0 {
+		total := 0
+		for _, l := range idx.docLen {
+			total += l
+		}
+		idx.avgdl = float64(total) / float64(idx.n)
+	}
+	return idx
+}
+
+// score computes BM25 score for a document given pre-tokenized query terms.
+func (idx *bm25Index) score(queryTerms []string, docID string) float64 {
+	if idx.n == 0 || idx.avgdl == 0 {
+		return 0
+	}
+	docTerms := idx.tf[docID]
+	docLen := idx.docLen[docID]
+	var s float64
+	for _, term := range queryTerms {
+		df := float64(idx.df[term])
+		if df == 0 {
+			continue
+		}
+		idf := math.Log((float64(idx.n)-df+0.5)/(df+0.5) + 1)
+		tf := float64(docTerms[term])
+		norm := tf + bm25k1*(1-bm25b+bm25b*float64(docLen)/idx.avgdl)
+		s += idf * (tf * (bm25k1 + 1)) / norm
+	}
+	return s
+}

--- a/internal/vectorstore/bm25_test.go
+++ b/internal/vectorstore/bm25_test.go
@@ -1,0 +1,147 @@
+package vectorstore
+
+import (
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"hello world", []string{"hello", "world"}},
+		{"林昊 is the hero", []string{"林", "昊", "is", "the", "hero"}},
+		{"台北市中山區", []string{"台", "北", "市", "中", "山", "區"}},
+		{"go1.21", []string{"go1", "21"}},
+		{"", nil},
+	}
+	for _, tc := range tests {
+		got := tokenize(tc.input)
+		if len(got) != len(tc.want) {
+			t.Errorf("tokenize(%q): got %v, want %v", tc.input, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("tokenize(%q)[%d]: got %q, want %q", tc.input, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestBM25ScoreKeywordMatch(t *testing.T) {
+	docs := []Document{
+		{ID: "char_林昊", Type: "character", Content: "林昊是主角，林昊很強"},
+		{ID: "world_台北", Type: "world", Content: "台北是故事的舞台"},
+	}
+	idx := buildBM25Index(docs)
+
+	// 查詢「林昊」，char_林昊 的分數應高於 world_台北
+	terms := tokenize("林昊")
+	score1 := idx.score(terms, "char_林昊")
+	score2 := idx.score(terms, "world_台北")
+	if score1 <= score2 {
+		t.Errorf("expected char_林昊 (%.4f) > world_台北 (%.4f) for query 林昊", score1, score2)
+	}
+}
+
+func TestBM25ScoreUnknownDoc(t *testing.T) {
+	idx := buildBM25Index([]Document{{ID: "d1", Content: "test"}})
+	if s := idx.score([]string{"test"}, "nonexistent"); s != 0 {
+		t.Errorf("expected 0 for unknown docID, got %f", s)
+	}
+}
+
+func TestBM25ScoreEmptyIndex(t *testing.T) {
+	idx := buildBM25Index(nil)
+	if s := idx.score([]string{"hello"}, "d1"); s != 0 {
+		t.Errorf("expected 0 for empty index, got %f", s)
+	}
+}
+
+func TestQueryHybridAlpha1PureVector(t *testing.T) {
+	s := New("") // no file path needed, in-memory only
+	docs := []Document{
+		{ID: "char_林昊", Type: "character", Content: "林昊是主角", Embedding: []float64{1, 0}},
+		{ID: "world_台北", Type: "world", Content: "台北是故事舞台", Embedding: []float64{0, 1}},
+	}
+	for _, d := range docs {
+		s.Upsert(d)
+	}
+
+	// Query vector close to char_林昊
+	results := s.QueryHybrid([]float64{1, 0}, "台北", 2, nil, 0, 1.0, 0)
+	if len(results) == 0 {
+		t.Fatal("expected results")
+	}
+	// alpha=1.0 → pure vector: char_林昊 should rank first (cosine=1.0 vs 0.0)
+	if results[0].ID != "char_林昊" {
+		t.Errorf("alpha=1.0: expected char_林昊 first, got %s", results[0].ID)
+	}
+}
+
+func TestQueryHybridAlpha0PureBM25(t *testing.T) {
+	s := New("")
+	docs := []Document{
+		// char_林昊 has keyword match for "台北" but vector points away
+		{ID: "char_林昊", Type: "character", Content: "台北台北台北台北台北", Embedding: []float64{0, 1}},
+		// world_台北 vector matches but no keyword match
+		{ID: "world_台北", Type: "world", Content: "完全不同的內容", Embedding: []float64{1, 0}},
+	}
+	for _, d := range docs {
+		s.Upsert(d)
+	}
+
+	// Query vector close to world_台北 but text matches char_林昊
+	results := s.QueryHybrid([]float64{1, 0}, "台北", 2, nil, 0, 0.0, 0)
+	if len(results) == 0 {
+		t.Fatal("expected results")
+	}
+	// alpha=0.0 → pure BM25: char_林昊 should rank first (keyword hit)
+	if results[0].ID != "char_林昊" {
+		t.Errorf("alpha=0.0: expected char_林昊 first (BM25), got %s", results[0].ID)
+	}
+}
+
+func TestQueryHybridTypeFilter(t *testing.T) {
+	s := New("")
+	s.Upsert(Document{ID: "char_a", Type: "character", Content: "hello", Embedding: []float64{1, 0}})
+	s.Upsert(Document{ID: "world_b", Type: "world", Content: "hello", Embedding: []float64{1, 0}})
+
+	results := s.QueryHybrid([]float64{1, 0}, "hello", 10, []string{"character"}, 0, 0.5, 0)
+	if len(results) != 1 || results[0].ID != "char_a" {
+		t.Errorf("type filter failed: got %v", results)
+	}
+}
+
+func TestQueryHybridBeforeChapterFilter(t *testing.T) {
+	s := New("")
+	s.Upsert(Document{ID: "ch1", Type: "chapter", Content: "first chapter", Embedding: []float64{1, 0}, ChapterIndex: 1})
+	s.Upsert(Document{ID: "ch5", Type: "chapter", Content: "fifth chapter", Embedding: []float64{1, 0}, ChapterIndex: 5})
+
+	results := s.QueryHybrid([]float64{1, 0}, "chapter", 10, nil, 0, 0.5, 3)
+	for _, r := range results {
+		if r.ChapterIndex >= 3 {
+			t.Errorf("beforeChapter=3: got doc with ChapterIndex=%d", r.ChapterIndex)
+		}
+	}
+}
+
+func TestQueryHybridUpsertUpdatesIndex(t *testing.T) {
+	s := New("")
+	s.Upsert(Document{ID: "d1", Type: "character", Content: "原始內容", Embedding: []float64{1, 0}})
+
+	// Replace with new content
+	s.Upsert(Document{ID: "d1", Type: "character", Content: "林昊林昊林昊", Embedding: []float64{1, 0}})
+
+	results := s.QueryHybrid([]float64{1, 0}, "林昊", 1, nil, 0, 0.0, 0)
+	if len(results) == 0 || results[0].ID != "d1" {
+		t.Error("BM25 index not updated after Upsert replace")
+	}
+	// Old content keyword should not score (term 原始 no longer in doc)
+	idx := s.bm25
+	oldScore := idx.score(tokenize("原始"), "d1")
+	if oldScore > 0 {
+		t.Errorf("old term still scores after replace: %f", oldScore)
+	}
+}

--- a/internal/vectorstore/bm25_test.go
+++ b/internal/vectorstore/bm25_test.go
@@ -1,6 +1,7 @@
 package vectorstore
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -131,17 +132,38 @@ func TestQueryHybridUpsertUpdatesIndex(t *testing.T) {
 	s := New("")
 	s.Upsert(Document{ID: "d1", Type: "character", Content: "原始內容", Embedding: []float64{1, 0}})
 
-	// Replace with new content
+	// Replace with new content — incremental update should remove old terms
 	s.Upsert(Document{ID: "d1", Type: "character", Content: "林昊林昊林昊", Embedding: []float64{1, 0}})
 
 	results := s.QueryHybrid([]float64{1, 0}, "林昊", 1, nil, 0, 0.0, 0)
 	if len(results) == 0 || results[0].ID != "d1" {
 		t.Error("BM25 index not updated after Upsert replace")
 	}
-	// Old content keyword should not score (term 原始 no longer in doc)
+	// Old terms must be removed from the index
 	idx := s.bm25
-	oldScore := idx.score(tokenize("原始"), "d1")
-	if oldScore > 0 {
-		t.Errorf("old term still scores after replace: %f", oldScore)
+	if idx.df["原"] != 0 || idx.df["始"] != 0 {
+		t.Errorf("old terms still in df after replace: 原=%d 始=%d", idx.df["原"], idx.df["始"])
+	}
+	// n should still be 1
+	if idx.n != 1 {
+		t.Errorf("expected n=1 after replace, got %d", idx.n)
+	}
+}
+
+func TestBM25IncrementalNEqualsDocCount(t *testing.T) {
+	s := New("")
+	for i := range 5 {
+		s.Upsert(Document{
+			ID:      fmt.Sprintf("d%d", i),
+			Content: fmt.Sprintf("doc %d content", i),
+		})
+	}
+	if s.bm25.n != 5 {
+		t.Errorf("expected n=5, got %d", s.bm25.n)
+	}
+	// Overwrite one — n should stay 5
+	s.Upsert(Document{ID: "d0", Content: "replaced"})
+	if s.bm25.n != 5 {
+		t.Errorf("after replace expected n=5, got %d", s.bm25.n)
 	}
 }

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -24,6 +24,7 @@ type Store struct {
 	mu       sync.RWMutex
 	docs     []Document
 	filepath string
+	bm25     *bm25Index
 }
 
 type ScoredDocument struct {
@@ -45,7 +46,11 @@ func (s *Store) Load() error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, &s.docs)
+	if err := json.Unmarshal(data, &s.docs); err != nil {
+		return err
+	}
+	s.bm25 = buildBM25Index(s.docs)
+	return nil
 }
 
 func (s *Store) Save() error {
@@ -64,16 +69,19 @@ func (s *Store) Upsert(doc Document) {
 	for i, d := range s.docs {
 		if d.ID == doc.ID {
 			s.docs[i] = doc
+			s.bm25 = buildBM25Index(s.docs)
 			return
 		}
 	}
 	s.docs = append(s.docs, doc)
+	s.bm25 = buildBM25Index(s.docs)
 }
 
 func (s *Store) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.docs = nil
+	s.bm25 = nil
 }
 
 func (s *Store) Len() int {
@@ -229,6 +237,81 @@ func (s *Store) QueryChapterSummaries(beforeChapter int) []Document {
 		out = append(out, d)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ChapterIndex < out[j].ChapterIndex })
+	return out
+}
+
+// QueryHybrid merges BM25 keyword scoring with vector cosine similarity.
+// alpha=1.0 is pure vector; alpha=0.0 is pure BM25.
+// BM25 scores are normalized to [0,1] before combining.
+// beforeChapter <= 0 disables the timeline filter.
+func (s *Store) QueryHybrid(queryVec []float64, queryText string, topK int, types []string, threshold float64, alpha float64, beforeChapter int) []ScoredDocument {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	typeSet := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		typeSet[t] = struct{}{}
+	}
+
+	idx := s.bm25
+	if idx == nil {
+		idx = buildBM25Index(s.docs)
+	}
+	queryTerms := tokenize(queryText)
+
+	type candidate struct {
+		doc      Document
+		vecScore float64
+		bm25Raw  float64
+	}
+	candidates := make([]candidate, 0, len(s.docs))
+	for _, d := range s.docs {
+		if len(typeSet) > 0 {
+			if _, ok := typeSet[d.Type]; !ok {
+				continue
+			}
+		}
+		if beforeChapter > 0 && d.Type == "chapter" && d.ChapterIndex >= beforeChapter {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			doc:      d,
+			vecScore: cosine(queryVec, d.Embedding),
+			bm25Raw:  idx.score(queryTerms, d.ID),
+		})
+	}
+
+	// Normalize BM25 to [0, 1].
+	maxBM25 := 0.0
+	for _, c := range candidates {
+		if c.bm25Raw > maxBM25 {
+			maxBM25 = c.bm25Raw
+		}
+	}
+
+	type scored struct {
+		doc   Document
+		score float64
+	}
+	results := make([]scored, 0, len(candidates))
+	for _, c := range candidates {
+		normBM25 := 0.0
+		if maxBM25 > 0 {
+			normBM25 = c.bm25Raw / maxBM25
+		}
+		combined := alpha*c.vecScore + (1-alpha)*normBM25
+		if threshold > 0 && combined < threshold {
+			continue
+		}
+		results = append(results, scored{doc: c.doc, score: combined})
+	}
+
+	sort.Slice(results, func(i, j int) bool { return results[i].score > results[j].score })
+
+	out := make([]ScoredDocument, 0, topK)
+	for i := 0; i < topK && i < len(results); i++ {
+		out = append(out, ScoredDocument{Document: results[i].doc, Score: results[i].score})
+	}
 	return out
 }
 

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -66,15 +66,18 @@ func (s *Store) Save() error {
 func (s *Store) Upsert(doc Document) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.bm25 == nil {
+		s.bm25 = newBM25Index()
+	}
 	for i, d := range s.docs {
 		if d.ID == doc.ID {
 			s.docs[i] = doc
-			s.bm25 = buildBM25Index(s.docs)
+			s.bm25.upsert(doc)
 			return
 		}
 	}
 	s.docs = append(s.docs, doc)
-	s.bm25 = buildBM25Index(s.docs)
+	s.bm25.upsert(doc)
 }
 
 func (s *Store) Clear() {


### PR DESCRIPTION
## 背景

closes #145

目前 `vectorstore.Store` 只有向量搜尋（cosine similarity），對角色名字、地名、專有名詞等關鍵字的召回率不穩定。本 PR 加入 BM25（關鍵字頻率）+ vector（語意相似度）的 hybrid search，兩個分數加權後排序。

## 變更摘要

### 新增

- `internal/vectorstore/bm25.go`
  - `tokenize(text)` — 支援 CJK 逐字 token + 英文詞組，標點當分隔符
  - `bm25Index` + 增量方法 `addDoc` / `removeDoc` / `upsert`（O(unique terms)，不全量 rebuild）
  - `buildBM25Index(docs)` — 初次載入時批次建立
  - `score(queryTerms, docID)` — 標準 BM25 公式（k1=1.5, b=0.75）

- `internal/retriever/hybrid.go`
  - `HybridStorer` 介面
  - `HybridRetriever` 滿足 `retriever.Retriever` 介面，可直接替換現有 retriever
  - `NewHybrid(emb, store, alpha)` — alpha 自動 clamp 至 [0.0, 1.0]

### 修改

- `internal/vectorstore/store.go`
  - `Store` 加入 `bm25 *bm25Index` 欄位
  - `Upsert` 改用增量 `bm25.upsert(doc)`，`Load` / `Clear` 維護索引一致性
  - 新增 `QueryHybrid(queryVec, queryText, topK, types, threshold, alpha, beforeChapter)`：BM25 score 正規化至 [0,1] 後 `alpha*vec + (1-alpha)*bm25` 加權合併

- `internal/reviewhistory/history.go`
  - `RetrievalConfig.Alpha` 型別為 `*float64`（nil = 預設 0.5，0.0 = 純 BM25，1.0 = 純 vector）
  - 新增 `EffectiveAlpha()` helper，統一處理 nil default

### 測試

- 10 個 vectorstore 測試：tokenize、BM25 分數、alpha=0/1 純模式、type filter、章節 filter、Upsert 增量更新後舊 term 消失、n 不重複計數
- 6 個 retriever 測試：空 store、基本召回、alpha/beforeChapter 傳遞、介面符合性、alpha clamp（<0 → 0、>1 → 1）
- 現有全部測試通過，`go build ./...` 零錯誤

## 本票明確不做

- 不修改 server 將預設 retriever 切換為 HybridRetriever（需另開 issue）
- 不新增 API endpoint 或前端 UI
- 不引入外部 BM25/全文搜索服務