### PR TITLE
feat(retriever): Reranker — 二次排序過濾低品質 chunk (#146)

### DIFF
--- a/internal/retriever/export_test.go
+++ b/internal/retriever/export_test.go
@@ -1,0 +1,4 @@
+package retriever
+
+// ParseScoresForTest exposes the internal parseScores function for black-box tests.
+var ParseScoresForTest = parseScores

--- a/internal/retriever/reranker.go
+++ b/internal/retriever/reranker.go
@@ -8,14 +8,16 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-// Scorer scores the relevance of a chunk to a query, returning a value in [0, 1].
+// Scorer scores multiple chunks against a query in a single call,
+// returning one score in [0, 1] per chunk in the same order.
 type Scorer interface {
-	Score(ctx context.Context, query, chunk string) (float64, error)
+	ScoreBatch(ctx context.Context, query string, contents []string) ([]float64, error)
 }
 
 // Reranker reorders (and optionally trims) chunks after initial retrieval.
@@ -36,8 +38,9 @@ func (PassthroughReranker) Rerank(_ context.Context, _ string, chunks []Chunk) (
 	return chunks, nil
 }
 
-// LLMReranker scores each chunk with a Scorer and returns the top-N results sorted by score.
-// If a chunk fails to score, its original retrieval score is used as fallback.
+// LLMReranker scores all chunks in a single ScoreBatch call and returns the top-N results.
+// If scoring fails entirely, chunks are returned in their original order.
+// If the number of returned scores doesn't match, original scores are used as fallback.
 type LLMReranker struct {
 	scorer Scorer
 	topN   int
@@ -48,22 +51,33 @@ func NewLLMReranker(scorer Scorer, topN int) *LLMReranker {
 }
 
 func (r *LLMReranker) Rerank(ctx context.Context, query string, chunks []Chunk) ([]Chunk, error) {
+	contents := make([]string, len(chunks))
+	for i, c := range chunks {
+		contents[i] = c.Content
+	}
+
+	scores, err := r.scorer.ScoreBatch(ctx, query, contents)
+	if err != nil {
+		log.Printf("reranker scorer batch error: %v — using original order", err)
+		return chunks, nil
+	}
+	if len(scores) != len(chunks) {
+		log.Printf("reranker scorer returned %d scores for %d chunks — using original order", len(scores), len(chunks))
+		return chunks, nil
+	}
+
 	type scored struct {
 		chunk Chunk
 		score float64
 	}
-	results := make([]scored, 0, len(chunks))
-	for _, c := range chunks {
-		s, err := r.scorer.Score(ctx, query, c.Content)
-		if err != nil {
-			log.Printf("reranker scorer error (chunk %s): %v — using original score", c.ID, err)
-			s = c.Score
-		}
-		results = append(results, scored{chunk: c, score: s})
+	results := make([]scored, len(chunks))
+	for i, c := range chunks {
+		results[i] = scored{chunk: c, score: scores[i]}
 	}
 	sort.SliceStable(results, func(i, j int) bool {
 		return results[i].score > results[j].score
 	})
+
 	n := r.topN
 	if n <= 0 || n > len(results) {
 		n = len(results)
@@ -76,7 +90,59 @@ func (r *LLMReranker) Rerank(ctx context.Context, query string, chunks []Chunk) 
 	return out, nil
 }
 
-// OllamaScorer scores a query-chunk pair using Ollama's non-streaming generate API.
+// jsonArrayRe matches a JSON number array anywhere in a string, e.g. [0.9, 0.3, 1.0]
+var jsonArrayRe = regexp.MustCompile(`\[[\d.,\s]+\]`)
+
+// parseScores extracts a []float64 from an LLM response that should contain a JSON array.
+// It tries strict JSON parsing first, then regex extraction, then line-by-line fallback.
+// Each score is clamped to [0, 1].
+func parseScores(raw string) ([]float64, error) {
+	raw = strings.TrimSpace(raw)
+
+	// attempt 1: the whole response is a JSON array
+	var scores []float64
+	if err := json.Unmarshal([]byte(raw), &scores); err == nil {
+		return clamp(scores), nil
+	}
+
+	// attempt 2: find the first JSON array anywhere in the response
+	if m := jsonArrayRe.FindString(raw); m != "" {
+		if err := json.Unmarshal([]byte(m), &scores); err == nil {
+			return clamp(scores), nil
+		}
+	}
+
+	// attempt 3: one float per non-empty line
+	var fallback []float64
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		f, err := strconv.ParseFloat(line, 64)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse scores from response: %q", raw)
+		}
+		fallback = append(fallback, f)
+	}
+	if len(fallback) > 0 {
+		return clamp(fallback), nil
+	}
+	return nil, fmt.Errorf("no scores found in response: %q", raw)
+}
+
+func clamp(scores []float64) []float64 {
+	for i, s := range scores {
+		if s < 0 {
+			scores[i] = 0
+		} else if s > 1 {
+			scores[i] = 1
+		}
+	}
+	return scores
+}
+
+// OllamaScorer scores all chunks in a single Ollama /api/generate call (non-streaming).
 type OllamaScorer struct {
 	baseURL string
 	model   string
@@ -86,10 +152,17 @@ func NewOllamaScorer(baseURL, model string) *OllamaScorer {
 	return &OllamaScorer{baseURL: baseURL, model: model}
 }
 
-func (o *OllamaScorer) Score(ctx context.Context, query, chunk string) (float64, error) {
-	prompt := "Rate the relevance of the following passage to the query on a scale from 0.0 to 1.0.\n" +
-		"Respond with only a single decimal number between 0.0 and 1.0, nothing else.\n\n" +
-		"Query: " + query + "\n\nPassage: " + chunk
+func (o *OllamaScorer) ScoreBatch(ctx context.Context, query string, contents []string) ([]float64, error) {
+	var sb strings.Builder
+	sb.WriteString("Rate the relevance of each passage below to the query on a scale from 0.0 to 1.0.\n")
+	sb.WriteString("Respond with a JSON array of numbers only, one score per passage in the same order.\n")
+	sb.WriteString("Example for 3 passages: [0.9, 0.3, 0.75]\n\n")
+	sb.WriteString("Query: ")
+	sb.WriteString(query)
+	sb.WriteString("\n\nPassages:\n")
+	for i, c := range contents {
+		fmt.Fprintf(&sb, "%d. %s\n", i+1, c)
+	}
 
 	type scoreReq struct {
 		Model  string `json:"model"`
@@ -100,39 +173,34 @@ func (o *OllamaScorer) Score(ctx context.Context, query, chunk string) (float64,
 		Response string `json:"response"`
 	}
 
-	body, err := json.Marshal(scoreReq{Model: o.model, Prompt: prompt, Stream: false})
+	body, err := json.Marshal(scoreReq{Model: o.model, Prompt: sb.String(), Stream: false})
 	if err != nil {
-		return 0, fmt.Errorf("marshal score request: %w", err)
+		return nil, fmt.Errorf("marshal score request: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/api/generate", bytes.NewReader(body))
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("ollama scorer unavailable: %w", err)
+		return nil, fmt.Errorf("ollama scorer unavailable: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return 0, fmt.Errorf("ollama scorer failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+		return nil, fmt.Errorf("ollama scorer failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
 	}
 
 	var result scoreResp
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return 0, fmt.Errorf("decode score response: %w", err)
+		return nil, fmt.Errorf("decode score response: %w", err)
 	}
 
-	score, err := strconv.ParseFloat(strings.TrimSpace(result.Response), 64)
+	scores, err := parseScores(result.Response)
 	if err != nil {
-		return 0, fmt.Errorf("scorer returned non-numeric response: %q", result.Response)
+		return nil, err
 	}
-	if score < 0 {
-		score = 0
-	} else if score > 1 {
-		score = 1
-	}
-	return score, nil
+	return scores, nil
 }

--- a/internal/retriever/reranker.go
+++ b/internal/retriever/reranker.go
@@ -1,0 +1,138 @@
+package retriever
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Scorer scores the relevance of a chunk to a query, returning a value in [0, 1].
+type Scorer interface {
+	Score(ctx context.Context, query, chunk string) (float64, error)
+}
+
+// Reranker reorders (and optionally trims) chunks after initial retrieval.
+type Reranker interface {
+	Rerank(ctx context.Context, query string, chunks []Chunk) ([]Chunk, error)
+}
+
+// RerankConfig controls whether reranking is applied and how many results are kept.
+type RerankConfig struct {
+	Enabled bool
+	TopN    int // 0 means keep all
+}
+
+// PassthroughReranker is the default no-op; it returns chunks unchanged.
+type PassthroughReranker struct{}
+
+func (PassthroughReranker) Rerank(_ context.Context, _ string, chunks []Chunk) ([]Chunk, error) {
+	return chunks, nil
+}
+
+// LLMReranker scores each chunk with a Scorer and returns the top-N results sorted by score.
+// If a chunk fails to score, its original retrieval score is used as fallback.
+type LLMReranker struct {
+	scorer Scorer
+	topN   int
+}
+
+func NewLLMReranker(scorer Scorer, topN int) *LLMReranker {
+	return &LLMReranker{scorer: scorer, topN: topN}
+}
+
+func (r *LLMReranker) Rerank(ctx context.Context, query string, chunks []Chunk) ([]Chunk, error) {
+	type scored struct {
+		chunk Chunk
+		score float64
+	}
+	results := make([]scored, 0, len(chunks))
+	for _, c := range chunks {
+		s, err := r.scorer.Score(ctx, query, c.Content)
+		if err != nil {
+			log.Printf("reranker scorer error (chunk %s): %v — using original score", c.ID, err)
+			s = c.Score
+		}
+		results = append(results, scored{chunk: c, score: s})
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].score > results[j].score
+	})
+	n := r.topN
+	if n <= 0 || n > len(results) {
+		n = len(results)
+	}
+	out := make([]Chunk, n)
+	for i := 0; i < n; i++ {
+		out[i] = results[i].chunk
+		out[i].Score = results[i].score
+	}
+	return out, nil
+}
+
+// OllamaScorer scores a query-chunk pair using Ollama's non-streaming generate API.
+type OllamaScorer struct {
+	baseURL string
+	model   string
+}
+
+func NewOllamaScorer(baseURL, model string) *OllamaScorer {
+	return &OllamaScorer{baseURL: baseURL, model: model}
+}
+
+func (o *OllamaScorer) Score(ctx context.Context, query, chunk string) (float64, error) {
+	prompt := "Rate the relevance of the following passage to the query on a scale from 0.0 to 1.0.\n" +
+		"Respond with only a single decimal number between 0.0 and 1.0, nothing else.\n\n" +
+		"Query: " + query + "\n\nPassage: " + chunk
+
+	type scoreReq struct {
+		Model  string `json:"model"`
+		Prompt string `json:"prompt"`
+		Stream bool   `json:"stream"`
+	}
+	type scoreResp struct {
+		Response string `json:"response"`
+	}
+
+	body, err := json.Marshal(scoreReq{Model: o.model, Prompt: prompt, Stream: false})
+	if err != nil {
+		return 0, fmt.Errorf("marshal score request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", o.baseURL+"/api/generate", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("ollama scorer unavailable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return 0, fmt.Errorf("ollama scorer failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var result scoreResp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decode score response: %w", err)
+	}
+
+	score, err := strconv.ParseFloat(strings.TrimSpace(result.Response), 64)
+	if err != nil {
+		return 0, fmt.Errorf("scorer returned non-numeric response: %q", result.Response)
+	}
+	if score < 0 {
+		score = 0
+	} else if score > 1 {
+		score = 1
+	}
+	return score, nil
+}

--- a/internal/retriever/reranker_test.go
+++ b/internal/retriever/reranker_test.go
@@ -18,21 +18,38 @@ func makeChunk(id string, score float64) retriever.Chunk {
 	}
 }
 
+// fixedScorer maps chunk content → score for deterministic tests.
 type fixedScorer struct {
 	scores map[string]float64
 	err    error
 }
 
-func (s *fixedScorer) Score(_ context.Context, _, chunk string) (float64, error) {
+func (s *fixedScorer) ScoreBatch(_ context.Context, _ string, contents []string) ([]float64, error) {
 	if s.err != nil {
-		return 0, s.err
+		return nil, s.err
 	}
-	for id, sc := range s.scores {
-		if chunk == "content of "+id {
-			return sc, nil
+	out := make([]float64, len(contents))
+	for i, c := range contents {
+		matched := false
+		for id, sc := range s.scores {
+			if c == "content of "+id {
+				out[i] = sc
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out[i] = 0.5
 		}
 	}
-	return 0.5, nil
+	return out, nil
+}
+
+// wrongCountScorer returns a slice of the wrong length.
+type wrongCountScorer struct{}
+
+func (wrongCountScorer) ScoreBatch(_ context.Context, _ string, _ []string) ([]float64, error) {
+	return []float64{0.9}, nil // always returns 1 score regardless of input count
 }
 
 type stubBaseRetriever struct {
@@ -117,19 +134,30 @@ func TestLLMRerankerTopNLargerThanInput(t *testing.T) {
 	}
 }
 
-func TestLLMRerankerScorerErrorFallsBackToOriginalScore(t *testing.T) {
-	chunks := []retriever.Chunk{makeChunk("x", 0.77)}
+// Scorer batch error → return chunks in original order, no error propagated.
+func TestLLMRerankerBatchErrorFallsBackToOriginalOrder(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.9), makeChunk("b", 0.1)}
 	scorer := &fixedScorer{err: errors.New("scorer unavailable")}
 	r := retriever.NewLLMReranker(scorer, 0)
 	got, err := r.Rerank(context.Background(), "q", chunks)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("expected 1 chunk, got %d", len(got))
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Errorf("expected original order preserved, got %v", got)
 	}
-	if got[0].Score != 0.77 {
-		t.Errorf("expected fallback score 0.77, got %f", got[0].Score)
+}
+
+// Scorer returns wrong number of scores → fall back to original order.
+func TestLLMRerankerWrongScoreCountFallsBackToOriginalOrder(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.9), makeChunk("b", 0.5), makeChunk("c", 0.1)}
+	r := retriever.NewLLMReranker(wrongCountScorer{}, 0)
+	got, err := r.Rerank(context.Background(), "q", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0].ID != "a" {
+		t.Errorf("expected original order, got %v", got)
 	}
 }
 
@@ -140,6 +168,42 @@ func TestLLMRerankerUpdatesScoreField(t *testing.T) {
 	got, _ := r.Rerank(context.Background(), "q", chunks)
 	if got[0].Score != 0.99 {
 		t.Errorf("expected Score updated to 0.99, got %f", got[0].Score)
+	}
+}
+
+// ── parseScores (exported for testing via ParseScoresForTest) ─────────────────
+// We test parseScores indirectly through a mock scorer that calls it.
+
+func TestParseScores(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantN   int
+		wantErr bool
+	}{
+		{"bare JSON array", "[0.9, 0.3, 0.75]", 3, false},
+		{"JSON array with surrounding text", "Sure, here are the scores: [0.9, 0.3, 0.75]\nDone.", 3, false},
+		{"one per line", "0.9\n0.3\n0.75", 3, false},
+		{"JSON array with trailing period", "[0.82.]", 0, true},
+		{"empty string", "", 0, true},
+		{"non-numeric", "high medium low", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scores, err := retriever.ParseScoresForTest(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got scores %v", scores)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(scores) != tc.wantN {
+				t.Errorf("expected %d scores, got %d: %v", tc.wantN, len(scores), scores)
+			}
+		})
 	}
 }
 
@@ -187,7 +251,8 @@ func TestRerankingRetrieverEmptyBaseResult(t *testing.T) {
 	}
 }
 
-// compile-time interface check
+// compile-time interface checks
 var _ retriever.Reranker = retriever.PassthroughReranker{}
 var _ retriever.Reranker = (*retriever.LLMReranker)(nil)
 var _ retriever.Retriever = (*retriever.RerankingRetriever)(nil)
+var _ retriever.Scorer = (*retriever.OllamaScorer)(nil)

--- a/internal/retriever/reranker_test.go
+++ b/internal/retriever/reranker_test.go
@@ -1,0 +1,193 @@
+package retriever_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"novel-assistant/internal/retriever"
+	"novel-assistant/internal/vectorstore"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func makeChunk(id string, score float64) retriever.Chunk {
+	return retriever.Chunk{
+		Document: vectorstore.Document{ID: id, Content: "content of " + id},
+		Score:    score,
+	}
+}
+
+type fixedScorer struct {
+	scores map[string]float64
+	err    error
+}
+
+func (s *fixedScorer) Score(_ context.Context, _, chunk string) (float64, error) {
+	if s.err != nil {
+		return 0, s.err
+	}
+	for id, sc := range s.scores {
+		if chunk == "content of "+id {
+			return sc, nil
+		}
+	}
+	return 0.5, nil
+}
+
+type stubBaseRetriever struct {
+	chunks []retriever.Chunk
+}
+
+func (r *stubBaseRetriever) Retrieve(_ context.Context, _ retriever.Request) ([]retriever.Chunk, error) {
+	return r.chunks, nil
+}
+
+// ── PassthroughReranker ───────────────────────────────────────────────────────
+
+func TestPassthroughRerankerReturnsSameChunks(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.9), makeChunk("b", 0.5)}
+	pr := retriever.PassthroughReranker{}
+	got, err := pr.Rerank(context.Background(), "query", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Errorf("expected unchanged chunks, got %v", got)
+	}
+}
+
+func TestPassthroughRerankerEmptyInput(t *testing.T) {
+	pr := retriever.PassthroughReranker{}
+	got, err := pr.Rerank(context.Background(), "query", nil)
+	if err != nil || len(got) != 0 {
+		t.Errorf("expected nil slice and no error, got %v / %v", got, err)
+	}
+}
+
+// ── LLMReranker ───────────────────────────────────────────────────────────────
+
+func TestLLMRerankerSortsByScore(t *testing.T) {
+	chunks := []retriever.Chunk{
+		makeChunk("low", 0.9),
+		makeChunk("high", 0.3),
+		makeChunk("mid", 0.6),
+	}
+	scorer := &fixedScorer{scores: map[string]float64{
+		"low":  0.1,
+		"high": 0.95,
+		"mid":  0.5,
+	}}
+	r := retriever.NewLLMReranker(scorer, 0)
+	got, err := r.Rerank(context.Background(), "q", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(got))
+	}
+	if got[0].ID != "high" || got[1].ID != "mid" || got[2].ID != "low" {
+		t.Errorf("wrong order: %v", []string{got[0].ID, got[1].ID, got[2].ID})
+	}
+}
+
+func TestLLMRerankerTrimsToTopN(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.9), makeChunk("b", 0.8), makeChunk("c", 0.7)}
+	scorer := &fixedScorer{scores: map[string]float64{"a": 0.9, "b": 0.8, "c": 0.7}}
+	r := retriever.NewLLMReranker(scorer, 2)
+	got, err := r.Rerank(context.Background(), "q", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 chunks (topN=2), got %d", len(got))
+	}
+}
+
+func TestLLMRerankerTopNLargerThanInput(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.5)}
+	scorer := &fixedScorer{scores: map[string]float64{"a": 0.5}}
+	r := retriever.NewLLMReranker(scorer, 10)
+	got, err := r.Rerank(context.Background(), "q", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 chunk, got %d", len(got))
+	}
+}
+
+func TestLLMRerankerScorerErrorFallsBackToOriginalScore(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("x", 0.77)}
+	scorer := &fixedScorer{err: errors.New("scorer unavailable")}
+	r := retriever.NewLLMReranker(scorer, 0)
+	got, err := r.Rerank(context.Background(), "q", chunks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 chunk, got %d", len(got))
+	}
+	if got[0].Score != 0.77 {
+		t.Errorf("expected fallback score 0.77, got %f", got[0].Score)
+	}
+}
+
+func TestLLMRerankerUpdatesScoreField(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.3)}
+	scorer := &fixedScorer{scores: map[string]float64{"a": 0.99}}
+	r := retriever.NewLLMReranker(scorer, 0)
+	got, _ := r.Rerank(context.Background(), "q", chunks)
+	if got[0].Score != 0.99 {
+		t.Errorf("expected Score updated to 0.99, got %f", got[0].Score)
+	}
+}
+
+// ── RerankingRetriever ────────────────────────────────────────────────────────
+
+func TestRerankingRetrieverAppliesReranker(t *testing.T) {
+	base := &stubBaseRetriever{chunks: []retriever.Chunk{
+		makeChunk("low", 0.9),
+		makeChunk("high", 0.1),
+	}}
+	scorer := &fixedScorer{scores: map[string]float64{"low": 0.1, "high": 0.9}}
+	rr := retriever.NewRerankingRetriever(base, retriever.NewLLMReranker(scorer, 0))
+
+	got, err := rr.Retrieve(context.Background(), retriever.Request{Query: "test", TopK: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "high" {
+		t.Errorf("expected high-scored chunk first, got %v", got)
+	}
+}
+
+func TestRerankingRetrieverPassthroughNilReranker(t *testing.T) {
+	chunks := []retriever.Chunk{makeChunk("a", 0.5), makeChunk("b", 0.3)}
+	base := &stubBaseRetriever{chunks: chunks}
+	rr := retriever.NewRerankingRetriever(base, nil) // nil → PassthroughReranker
+
+	got, err := rr.Retrieve(context.Background(), retriever.Request{Query: "q", TopK: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "a" {
+		t.Errorf("expected passthrough order preserved, got %v", got)
+	}
+}
+
+func TestRerankingRetrieverEmptyBaseResult(t *testing.T) {
+	base := &stubBaseRetriever{chunks: nil}
+	scorer := &fixedScorer{}
+	rr := retriever.NewRerankingRetriever(base, retriever.NewLLMReranker(scorer, 0))
+
+	got, err := rr.Retrieve(context.Background(), retriever.Request{Query: "q", TopK: 5})
+	if err != nil || len(got) != 0 {
+		t.Errorf("expected empty result, got %v / %v", got, err)
+	}
+}
+
+// compile-time interface check
+var _ retriever.Reranker = retriever.PassthroughReranker{}
+var _ retriever.Reranker = (*retriever.LLMReranker)(nil)
+var _ retriever.Retriever = (*retriever.RerankingRetriever)(nil)

--- a/internal/retriever/reranking_retriever.go
+++ b/internal/retriever/reranking_retriever.go
@@ -5,7 +5,7 @@ import "context"
 // RerankingRetriever wraps a base Retriever and applies a Reranker to its results.
 // Use PassthroughReranker (the default) for zero-overhead passthrough.
 type RerankingRetriever struct {
-	base    Retriever
+	base     Retriever
 	reranker Reranker
 }
 

--- a/internal/retriever/reranking_retriever.go
+++ b/internal/retriever/reranking_retriever.go
@@ -1,0 +1,26 @@
+package retriever
+
+import "context"
+
+// RerankingRetriever wraps a base Retriever and applies a Reranker to its results.
+// Use PassthroughReranker (the default) for zero-overhead passthrough.
+type RerankingRetriever struct {
+	base    Retriever
+	reranker Reranker
+}
+
+// NewRerankingRetriever creates a RerankingRetriever. If reranker is nil, PassthroughReranker is used.
+func NewRerankingRetriever(base Retriever, reranker Reranker) *RerankingRetriever {
+	if reranker == nil {
+		reranker = PassthroughReranker{}
+	}
+	return &RerankingRetriever{base: base, reranker: reranker}
+}
+
+func (r *RerankingRetriever) Retrieve(ctx context.Context, req Request) ([]Chunk, error) {
+	chunks, err := r.base.Retrieve(ctx, req)
+	if err != nil || len(chunks) == 0 {
+		return chunks, err
+	}
+	return r.reranker.Rerank(ctx, req.Query, chunks)
+}


### PR DESCRIPTION
## Summary

- 定義 `Reranker` 介面與 `Scorer` 介面（`internal/retriever/reranker.go`）
- `PassthroughReranker`：預設 no-op，不啟用時零效能損耗
- `LLMReranker`：單次呼叫 `ScoreBatch` 傳入全部 chunk，一個 Ollama round-trip 完成批次評分，依分數降序排列，取 top-N；scorer 回傳錯誤或數量不符時 fallback 回原始順序
- `OllamaScorer.ScoreBatch`：一次 Ollama `/api/generate` 呼叫，要求模型回傳 JSON array；`parseScores` 三層容錯（嚴格 JSON → regex 抽取 JSON array → 逐行解析），容忍模型在數字前後附加說明文字
- `RerankConfig{Enabled, TopN}`：供呼叫端設定
- `RerankingRetriever`：包裝任意 `Retriever`，在 `Retrieve` 後套用 `Reranker`
- 27 個單元測試：排序、topN 截斷、batch 錯誤 fallback、分數數量不符 fallback、parseScores 多格式、passthrough、空輸入

## Test plan

- [x] `go test ./internal/retriever/...` — 27 passed
- [x] `go build ./...` — 零錯誤

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)