### PR TITLE
feat(server): 增量索引 — 只重索引有改動的章節 (#148)

### DIFF
--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1908,3 +1908,48 @@ func TestIngestIncrementalClearsByChapterOnChange(t *testing.T) {
 		t.Errorf("expected fewer docs after reducing chapter scenes (%d → %d)", countAfterFirst, countAfterSecond)
 	}
 }
+
+func TestIngestIncrementalSummaryFailureDoesNotRecordManifest(t *testing.T) {
+	t.Parallel()
+
+	var generateFail atomic.Bool
+	var embedCalls atomic.Int64
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			embedCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			if generateFail.Load() {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(`{"response":"summary","done":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第01章.md"), "## Scene 1\nContent.")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+
+	// 第一次：summary 失敗
+	generateFail.Store(true)
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("ingest with failed summary: %v", err)
+	}
+
+	// 第二次：summary 正常，應該重跑（manifest 未記錄 → hash 不符 → 重新 embed）
+	generateFail.Store(false)
+	embedCalls.Store(0)
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("retry ingest: %v", err)
+	}
+	if embedCalls.Load() == 0 {
+		t.Error("expected embed calls on retry after summary failure, got 0 — manifest should not have been recorded")
+	}
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -1754,3 +1754,157 @@ func TestFocusStreamWithChapterContent(t *testing.T) {
 		t.Errorf("expected prompt to contain chapter content, got: %s", capturedPrompt)
 	}
 }
+
+// ── IngestIncremental ─────────────────────────────────────────────────────────
+
+func TestIngestIncrementalSkipsUnchangedChapters(t *testing.T) {
+	t.Parallel()
+
+	var embedCalls atomic.Int64
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			embedCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			_, _ = w.Write([]byte(`{"response":"summary","done":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第01章.md"), "## Scene 1\nFirst content.")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+
+	// 第一次：全量
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("first incremental ingest: %v", err)
+	}
+	firstCallCount := embedCalls.Load()
+	if firstCallCount == 0 {
+		t.Fatal("expected at least one embed call on first ingest")
+	}
+
+	// 第二次：內容未改，應該跳過 chapter 的 embed
+	embedCalls.Store(0)
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("second incremental ingest: %v", err)
+	}
+	if embedCalls.Load() != 0 {
+		t.Errorf("expected 0 embed calls for unchanged chapter, got %d", embedCalls.Load())
+	}
+}
+
+func TestIngestIncrementalReindexesChangedChapter(t *testing.T) {
+	t.Parallel()
+
+	var embedCalls atomic.Int64
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			embedCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			_, _ = w.Write([]byte(`{"response":"summary","done":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	chapterPath := filepath.Join(dir, "chapters", "第01章.md")
+	mustWriteFile(t, chapterPath, "## Scene 1\nOriginal content.")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+
+	// 修改章節後再跑增量索引，應該重新 embed
+	embedCalls.Store(0)
+	mustWriteFile(t, chapterPath, "## Scene 1\nModified content.")
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("second ingest: %v", err)
+	}
+	if embedCalls.Load() == 0 {
+		t.Error("expected embed calls after chapter modification, got 0")
+	}
+}
+
+func TestIngestIncrementalManifestPersistedAcrossRestart(t *testing.T) {
+	t.Parallel()
+
+	var embedCalls atomic.Int64
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			embedCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			_, _ = w.Write([]byte(`{"response":"summary","done":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "chapters", "第01章.md"), "## Scene 1\nStable content.")
+
+	// 第一個 server 執行增量索引
+	s1 := newE2ETestServer(t, dir, ollama.URL)
+	if err := s1.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("first server ingest: %v", err)
+	}
+
+	// 模擬重啟：建立新的 server，共用同一個 dataDir
+	embedCalls.Store(0)
+	s2 := newE2ETestServer(t, dir, ollama.URL)
+	if err := s2.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("second server ingest: %v", err)
+	}
+	if embedCalls.Load() != 0 {
+		t.Errorf("expected 0 embed calls after restart with unchanged content, got %d", embedCalls.Load())
+	}
+}
+
+func TestIngestIncrementalClearsByChapterOnChange(t *testing.T) {
+	t.Parallel()
+
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/embeddings":
+			_ = json.NewEncoder(w).Encode(map[string]any{"embedding": []float64{0.1, 0.2, 0.3}})
+		case "/api/generate":
+			_, _ = w.Write([]byte(`{"response":"summary","done":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ollama.Close()
+
+	dir := t.TempDir()
+	chapterPath := filepath.Join(dir, "chapters", "第01章.md")
+	mustWriteFile(t, chapterPath, "## Scene 1\nOld.\n\n## Scene 2\nAlso old.")
+
+	s := newE2ETestServer(t, dir, ollama.URL)
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("first ingest: %v", err)
+	}
+	countAfterFirst := s.store.Len()
+
+	// 改成單場景章節，store 中 chapter 數量應該下降（舊 chunk 被清掉）
+	mustWriteFile(t, chapterPath, "## Scene 1\nNew single scene.")
+	if err := s.IngestIncremental(context.Background()); err != nil {
+		t.Fatalf("second ingest: %v", err)
+	}
+	countAfterSecond := s.store.Len()
+
+	if countAfterSecond >= countAfterFirst {
+		t.Errorf("expected fewer docs after reducing chapter scenes (%d → %d)", countAfterFirst, countAfterSecond)
+	}
+}

--- a/internal/server/ingest_manifest.go
+++ b/internal/server/ingest_manifest.go
@@ -1,0 +1,53 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+)
+
+// IndexManifest tracks per-file SHA-256 hashes to detect changes for incremental indexing.
+type IndexManifest struct {
+	Files map[string]string `json:"files"` // key -> SHA-256 hex
+}
+
+func newManifest() *IndexManifest {
+	return &IndexManifest{Files: make(map[string]string)}
+}
+
+func loadManifest(path string) (*IndexManifest, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return newManifest(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	m := newManifest()
+	if err := json.Unmarshal(data, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *IndexManifest) save(path string) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func (m *IndexManifest) unchanged(key, content string) bool {
+	return m.Files[key] == sha256Hex([]byte(content))
+}
+
+func (m *IndexManifest) record(key, content string) {
+	m.Files[key] = sha256Hex([]byte(content))
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -676,44 +676,56 @@ func (s *Server) IngestIncremental(ctx context.Context) error {
 			continue
 		}
 
-		// Remove stale chunks for this chapter before re-indexing.
-		st.store.ClearByChapter(file.Name())
-
 		chapterIdx := extractChapterIndex(file.Name())
 		chunks := chunkChapter(file.Name(), chapterText)
+
+		// Pre-embed all chunks before touching the store so that any embed
+		// failure leaves the existing data intact (no destructive mid-state).
+		newChunks := make([]vectorstore.Document, 0, len(chunks))
 		for _, chunk := range chunks {
 			vec, err := s.embedder.Embed(ctx, chunk.Content)
 			if err != nil {
 				return fmt.Errorf("embed chapter chunk %s: %w", chunk.ID, err)
 			}
 			chunk.Embedding = vec
+			newChunks = append(newChunks, chunk)
+		}
+
+		// All chunks are ready — atomically replace old with new.
+		st.store.ClearByChapter(file.Name())
+		for _, chunk := range newChunks {
 			st.store.Upsert(chunk)
 			log.Printf("indexed chapter chunk: %s", chunk.ID)
 		}
-		if len(chunks) == 0 {
+
+		if len(newChunks) == 0 {
 			manifest.record("chapter_"+file.Name(), chapterText)
 			continue
 		}
+
+		// Summary is attempted after chunks are in place.
+		// If summary or its embed fails, skip manifest.record so the next
+		// incremental run retries the whole chapter (including summary).
 		summary, err := s.checker.SummarizeChapter(ctx, chapterText)
 		if err != nil {
-			log.Printf("summarize chapter %s: %v (skipped)", file.Name(), err)
-		} else {
-			summaryVec, err := s.embedder.Embed(ctx, summary)
-			if err != nil {
-				log.Printf("embed summary %s: %v (skipped)", file.Name(), err)
-			} else {
-				st.store.Upsert(vectorstore.Document{
-					ID:           "summary_" + file.Name(),
-					Type:         "chapter_summary",
-					Content:      summary,
-					Summary:      summary,
-					Embedding:    summaryVec,
-					ChapterFile:  file.Name(),
-					ChapterIndex: chapterIdx,
-				})
-				log.Printf("indexed chapter summary: %s", file.Name())
-			}
+			log.Printf("summarize chapter %s: %v (skipped, will retry next run)", file.Name(), err)
+			continue
 		}
+		summaryVec, err := s.embedder.Embed(ctx, summary)
+		if err != nil {
+			log.Printf("embed summary %s: %v (skipped, will retry next run)", file.Name(), err)
+			continue
+		}
+		st.store.Upsert(vectorstore.Document{
+			ID:           "summary_" + file.Name(),
+			Type:         "chapter_summary",
+			Content:      summary,
+			Summary:      summary,
+			Embedding:    summaryVec,
+			ChapterFile:  file.Name(),
+			ChapterIndex: chapterIdx,
+		})
+		log.Printf("indexed chapter summary: %s", file.Name())
 		manifest.record("chapter_"+file.Name(), chapterText)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -580,6 +580,149 @@ func (s *Server) Ingest(ctx context.Context) error {
 	return st.store.Save()
 }
 
+// IngestIncremental re-indexes only items whose content has changed since the last run.
+// Chapters and profiles are compared by SHA-256; unchanged items are skipped.
+// Deleted items are NOT removed — use Ingest() for a full rebuild when that matters.
+func (s *Server) IngestIncremental(ctx context.Context) error {
+	st := s.currentState()
+	if err := st.profiles.Load(); err != nil {
+		return fmt.Errorf("load profiles: %w", err)
+	}
+
+	manifestPath := filepath.Join(st.dataDir, "index_hashes.json")
+	manifest, err := loadManifest(manifestPath)
+	if err != nil {
+		log.Printf("load manifest: %v (starting fresh)", err)
+		manifest = newManifest()
+	}
+
+	// Characters
+	for _, char := range st.profiles.Characters {
+		if manifest.unchanged("char_"+char.Name, char.RawContent) {
+			log.Printf("skipped character (unchanged): %s", char.Name)
+			continue
+		}
+		vec, err := s.embedder.Embed(ctx, char.RawContent)
+		if err != nil {
+			return fmt.Errorf("embed %s: %w", char.Name, err)
+		}
+		st.store.Upsert(vectorstore.Document{
+			ID:        "char_" + char.Name,
+			Type:      "character",
+			Content:   char.RawContent,
+			Embedding: vec,
+		})
+		manifest.record("char_"+char.Name, char.RawContent)
+		log.Printf("indexed character: %s", char.Name)
+	}
+
+	// Worlds
+	for _, world := range st.profiles.Worlds {
+		if manifest.unchanged("world_"+world.Name, world.RawContent) {
+			log.Printf("skipped world (unchanged): %s", world.Name)
+			continue
+		}
+		vec, err := s.embedder.Embed(ctx, world.RawContent)
+		if err != nil {
+			return fmt.Errorf("embed world %s: %w", world.Name, err)
+		}
+		st.store.Upsert(vectorstore.Document{
+			ID:        "world_" + world.Name,
+			Type:      "world",
+			Content:   world.RawContent,
+			Embedding: vec,
+		})
+		manifest.record("world_"+world.Name, world.RawContent)
+		log.Printf("indexed world: %s", world.Name)
+	}
+
+	// Styles
+	for _, style := range st.profiles.Styles {
+		if manifest.unchanged("style_"+style.Name, style.RawContent) {
+			log.Printf("skipped style (unchanged): %s", style.Name)
+			continue
+		}
+		vec, err := s.embedder.Embed(ctx, style.RawContent)
+		if err != nil {
+			return fmt.Errorf("embed style %s: %w", style.Name, err)
+		}
+		st.store.Upsert(vectorstore.Document{
+			ID:        "style_" + style.Name,
+			Type:      "style",
+			Content:   style.RawContent,
+			Embedding: vec,
+		})
+		manifest.record("style_"+style.Name, style.RawContent)
+		log.Printf("indexed style: %s", style.Name)
+	}
+
+	// Chapters
+	files, err := os.ReadDir(chapterDirFor(st.dataDir))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("list chapters: %w", err)
+	}
+	for _, file := range files {
+		if file.IsDir() || !strings.HasSuffix(strings.ToLower(file.Name()), ".md") {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(chapterDirFor(st.dataDir), file.Name()))
+		if err != nil {
+			return fmt.Errorf("read chapter %s: %w", file.Name(), err)
+		}
+		chapterText := string(content)
+
+		if manifest.unchanged("chapter_"+file.Name(), chapterText) {
+			log.Printf("skipped chapter (unchanged): %s", file.Name())
+			continue
+		}
+
+		// Remove stale chunks for this chapter before re-indexing.
+		st.store.ClearByChapter(file.Name())
+
+		chapterIdx := extractChapterIndex(file.Name())
+		chunks := chunkChapter(file.Name(), chapterText)
+		for _, chunk := range chunks {
+			vec, err := s.embedder.Embed(ctx, chunk.Content)
+			if err != nil {
+				return fmt.Errorf("embed chapter chunk %s: %w", chunk.ID, err)
+			}
+			chunk.Embedding = vec
+			st.store.Upsert(chunk)
+			log.Printf("indexed chapter chunk: %s", chunk.ID)
+		}
+		if len(chunks) == 0 {
+			manifest.record("chapter_"+file.Name(), chapterText)
+			continue
+		}
+		summary, err := s.checker.SummarizeChapter(ctx, chapterText)
+		if err != nil {
+			log.Printf("summarize chapter %s: %v (skipped)", file.Name(), err)
+		} else {
+			summaryVec, err := s.embedder.Embed(ctx, summary)
+			if err != nil {
+				log.Printf("embed summary %s: %v (skipped)", file.Name(), err)
+			} else {
+				st.store.Upsert(vectorstore.Document{
+					ID:           "summary_" + file.Name(),
+					Type:         "chapter_summary",
+					Content:      summary,
+					Summary:      summary,
+					Embedding:    summaryVec,
+					ChapterFile:  file.Name(),
+					ChapterIndex: chapterIdx,
+				})
+				log.Printf("indexed chapter summary: %s", file.Name())
+			}
+		}
+		manifest.record("chapter_"+file.Name(), chapterText)
+	}
+
+	if err := manifest.save(manifestPath); err != nil {
+		log.Printf("save manifest: %v", err)
+	}
+	return st.store.Save()
+}
+
 func (s *Server) Run() error {
 	return s.router.Run(":" + s.cfg.Port)
 }

--- a/internal/vectorstore/store.go
+++ b/internal/vectorstore/store.go
@@ -87,6 +87,34 @@ func (s *Store) Clear() {
 	s.bm25 = nil
 }
 
+// ClearByChapter removes all documents whose ChapterFile matches chapterFile.
+func (s *Store) ClearByChapter(chapterFile string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := s.docs[:0]
+	for _, d := range s.docs {
+		if d.ChapterFile != chapterFile {
+			kept = append(kept, d)
+		}
+	}
+	s.docs = kept
+	s.bm25 = buildBM25Index(s.docs)
+}
+
+// ClearByType removes all documents of the given type.
+func (s *Store) ClearByType(docType string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	kept := s.docs[:0]
+	for _, d := range s.docs {
+		if d.Type != docType {
+			kept = append(kept, d)
+		}
+	}
+	s.docs = kept
+	s.bm25 = buildBM25Index(s.docs)
+}
+
 func (s *Store) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/vectorstore/store_test.go
+++ b/internal/vectorstore/store_test.go
@@ -90,6 +90,45 @@ func TestDocumentMetadataSurvivesSaveLoad(t *testing.T) {
 	}
 }
 
+func TestClearByChapter(t *testing.T) {
+	t.Parallel()
+
+	store := New("")
+	store.Upsert(Document{ID: "ch1_s1", Type: "chapter", ChapterFile: "第01章.md", Embedding: []float64{1, 0}})
+	store.Upsert(Document{ID: "ch1_s2", Type: "chapter", ChapterFile: "第01章.md", Embedding: []float64{1, 0}})
+	store.Upsert(Document{ID: "ch2_s1", Type: "chapter", ChapterFile: "第02章.md", Embedding: []float64{0, 1}})
+	store.Upsert(Document{ID: "summary_ch1", Type: "chapter_summary", ChapterFile: "第01章.md", Embedding: []float64{1, 0}})
+
+	store.ClearByChapter("第01章.md")
+
+	if store.Len() != 1 {
+		t.Fatalf("expected 1 doc after clearing chapter 1, got %d", store.Len())
+	}
+	all := store.QueryFilteredScored([]float64{1, 0}, 10, nil, 0)
+	if len(all) != 1 || all[0].ID != "ch2_s1" {
+		t.Errorf("expected only ch2_s1 to remain, got %v", all)
+	}
+}
+
+func TestClearByType(t *testing.T) {
+	t.Parallel()
+
+	store := New("")
+	store.Upsert(Document{ID: "char_1", Type: "character", Embedding: []float64{1, 0}})
+	store.Upsert(Document{ID: "char_2", Type: "character", Embedding: []float64{0.9, 0.1}})
+	store.Upsert(Document{ID: "world_1", Type: "world", Embedding: []float64{0, 1}})
+
+	store.ClearByType("character")
+
+	if store.Len() != 1 {
+		t.Fatalf("expected 1 doc after clearing character type, got %d", store.Len())
+	}
+	all := store.QueryFilteredScored([]float64{1, 0}, 10, nil, 0)
+	if len(all) != 1 || all[0].ID != "world_1" {
+		t.Errorf("expected only world_1 to remain, got %v", all)
+	}
+}
+
 func TestQueryFilteredBeforeChapter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- `vectorstore`: 新增 `ClearByChapter(chapterFile)` 和 `ClearByType(docType)`，可局部清除 store 而不需全量清空
- `IndexManifest`：SHA-256 hash 追蹤，持久化至 `data/index_hashes.json`；server 重啟後 hash 狀態保留
- `IngestIncremental`：比對 hash 後只重新 embed 有改動的 character / world / style / chapter；修改的章節先 `ClearByChapter` 清除舊 chunk 再重建，避免舊資料殘留
- 全量 `Ingest()` 不受影響，仍可用於診斷或強制全量重建
- 本票明確不做：不修改 `/ingest` HTTP endpoint 預設行為、不加 watcher 自動觸發

## Test plan

- [x] `go test ./internal/vectorstore/...` — ClearByChapter、ClearByType 單元測試通過
- [x] `go test ./internal/server/...` — 4 個增量索引整合測試通過（skip unchanged、reindex on change、manifest 跨重啟保留、store 縮小）
- [x] `go build ./...` — 零錯誤

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)