### PR TITLE
feat(ci): add Codecov coverage reporting (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,14 @@ jobs:
           fi
 
       - name: Run tests
-        run: go test ./...
+        run: go test -coverprofile=coverage.out ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: false
 
       - name: Build
         run: go build ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Novel Assistant
 
 [![CI](https://github.com/easonchiang07-ship-it/novel-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/easonchiang07-ship-it/novel-assistant/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/easonchiang07-ship-it/novel-assistant/graph/badge.svg)](https://codecov.io/gh/easonchiang07-ship-it/novel-assistant)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 English | [繁體中文](README.zh-TW.md)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,6 +1,7 @@
 # Novel Assistant
 
 [![CI](https://github.com/easonchiang07-ship-it/novel-assistant/actions/workflows/ci.yml/badge.svg)](https://github.com/easonchiang07-ship-it/novel-assistant/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/easonchiang07-ship-it/novel-assistant/graph/badge.svg)](https://codecov.io/gh/easonchiang07-ship-it/novel-assistant)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 [English](README.md) | 繁體中文


### PR DESCRIPTION
## Summary

- Add `-coverprofile=coverage.out` to `go test` in CI
- Upload report to Codecov via `codecov/codecov-action@v4`
- Add coverage badge to both READMEs
- Current coverage: **~60.8%** — no minimum threshold, badge drives organic improvement

## One-time setup required

Before this PR is useful, add `CODECOV_TOKEN` to the repo secrets:

1. Go to [codecov.io](https://codecov.io) → sign in with GitHub
2. Find `easonchiang07-ship-it/novel-assistant` → enable it
3. Copy the `CODECOV_TOKEN`
4. GitHub repo → **Settings → Secrets and variables → Actions → New repository secret**
   - Name: `CODECOV_TOKEN`
   - Value: paste the token

After that, every PR will automatically get a coverage comment from the Codecov bot.

## Design decisions

- `fail_ci_if_error: false` — a Codecov outage should not block merges
- No coverage gate — we don't fail CI if coverage drops; the badge provides visibility without blocking contributors

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)