### PR TITLE
chore(deps): add Dependabot for automated dependency updates (#161)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Taipei
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` to automate dependency version scanning.

## Configuration

| Setting | Value |
|---|---|
| Go modules | Weekly, Monday 09:00 Asia/Taipei |
| GitHub Actions | Weekly, Monday 09:00 Asia/Taipei |
| Max open PRs | 5 (avoids noise) |
| Label | `dependencies` |

## What this does

Every Monday morning, Dependabot scans:
- `go.mod` — opens PRs when new versions of dependencies are available
- `.github/workflows/*.yml` — opens PRs when Action versions are outdated

Combined with `govulncheck` (PR #181), CVE-patched versions will surface automatically as Dependabot PRs within days of a vulnerability fix being released.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)